### PR TITLE
fix: check chutes name instead of model commitment

### DIFF
--- a/affine/__init__.py
+++ b/affine/__init__.py
@@ -537,8 +537,8 @@ async def miners(
             data = json.loads(data)
             model, miner_revision, chute_id = data.get("model"), data.get("revision"), data.get("chute_id")
             chute = await get_chute(chute_id)
-            slug, chutes_revision = chute.get("slug"), chute.get("revision")
-            if model.split('/')[1].lower()[:6] != 'affine': return None 
+            chutes_name, slug, chutes_revision = chute.get('name'), chute.get("slug"), chute.get("revision")
+            if model != chutes_name or chutes_name.split('/')[1].lower()[:6] != 'affine': return None 
             if chutes_revision == None or miner_revision == chutes_revision:
                 miner = Miner(
                     uid=uid, hotkey=hotkey, model=model, block=int(block),


### PR DESCRIPTION
A miner can commit a repo name different than the one used for chutes deployment, which might result in unexpected exploits.

The PR includes the fix that checks affine repo name convention against the chutes model name instead of model name included in commitments, which prevents commitment manipulation.