### PR TITLE
Align weights setting with epoch boundary

### DIFF
--- a/affine/validator.py
+++ b/affine/validator.py
@@ -319,7 +319,7 @@ def validate():
         
                 # ---------------- Set weights. ------------------------
                 af.logger.info("Setting weights ...")
-                # await af.retry_set_weights( wallet, uids=uids, weights=weights, retry = 3)
+                await af.retry_set_weights( wallet, uids=uids, weights=weights, retry = 3)
                 subtensor = await af.get_subtensor()
                 SETBLOCK = await subtensor.get_current_block()
                 af.LASTSET.set_function(lambda: SETBLOCK - LAST)


### PR DESCRIPTION
Change `BLOCK % 100 == 0` to `(TEMPO + 1 + NETUID + 1 + BLOCK) % (TEMPO + 1) % 100 == 0` to make sure weights are always set with enough time before epoch boundary