### PR TITLE
default to public reads via r2.dev

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -47,11 +47,14 @@ SUBTENSOR_FALLBACK="wss://lite.sub.latent.to:443"
 
 ## VALIDATOR ONLY 
 R2_FOLDER="affine"
-R2_BUCKET_ID="80f15715bb0b882c9e967c13e677ed7d"
-R2_ACCOUNT_ID="80f15715bb0b882c9e967c13e677ed7d"
+R2_BUCKET_ID="00523074f51300584834607253cae0fa"
+R2_ACCOUNT_ID="00523074f51300584834607253cae0fa"
 
-# Required: Validators required write keys (these are only read.)
-R2_WRITE_ACCESS_KEY_ID=ff3f4f078019b064bfb6347c270bee4d
-R2_WRITE_SECRET_ACCESS_KEY=a94b20516013519b2959cbbb441b9d1ec8511dce3c248223d947be8e85ec754d
+# Required: Validators required write keys 
+R2_WRITE_ACCESS_KEY_ID=
+R2_WRITE_SECRET_ACCESS_KEY=
 
-AFFINE_ENV_LIST="agentgym:webshop, agentgym:alfworld, affine:sat, affine:abd, affine:ded"
+# To force S3 (validators only): set AFFINE_R2_PUBLIC="0" (default is public r2.dev)
+AFFINE_R2_PUBLIC="1"
+
+AFFINE_ENV_LIST="agentgym:webshop,agentgym:alfworld,agentgym:babyai,agentgym:sciworld,agentgym:textcraft, affine:sat, affine:ded, affine:abd"


### PR DESCRIPTION
Default public read mode for results and datasets via Cloudflare r2.dev; S3 writes unchanged. 
Users no longer need keys to run af weights; validators still use write keys. 

Added env toggle to fallback to S3 reads and updated dataset reader accordingly:
- Introduced an env flag `AFFINE_R2_PUBLIC` to choose the read path.
  - When `"1"` (default), reads use unauthenticated r2.dev URLs.
  - When `"0"`, reads fall back to the previous authenticated S3 (R2) client.
- Where it’s applied
  - In `__init__.py`, both `_index()` and shard downloads branch on `PUBLIC_READ` (derived from `AFFINE_R2_PUBLIC`).
  - In `utils/dataset.py`, `R2BufferedDataset` fetches `index.json` and chunk files via r2.dev when `PUBLIC_READ` is on, otherwise uses the S3 client.
- What didn’t change
  - Writes (validator sink + index updates) still use authenticated S3 with write keys.