### PR TITLE
Disable weight burn mechanism

### DIFF
--- a/affine/cli.py
+++ b/affine/cli.py
@@ -499,7 +499,7 @@ def validate():
                     await subtensor.wait_for_block()
                     continue
 
-                force_uid0 = 0.9
+                force_uid0 = 0.0
                 uids, weights = await get_weights(scale=0.5, burn=force_uid0)
                 logger.info("Setting weights ...")
                 await retry_set_weights(wallet, uids=uids, weights=weights, retry=3)


### PR DESCRIPTION
This PR disables the weight burn mechanism by setting force_uid0 from 0.9 to 0.0, allowing weights to be distributed purely based on miner performance without forced allocation to uid 0.