### PR TITLE
Fix cold chute filtering 

### DIFF
--- a/affine/validator.py
+++ b/affine/validator.py
@@ -128,7 +128,7 @@ async def get_weights(tail: int = SamplingConfig.TAIL, burn: float = 0.0):
     BASE_HK = meta.hotkeys[0]
     N_envs = len(ENVS)
     
-    queryable_miners = await miners(meta=meta, netuid=NETUID, check_validity=False)
+    queryable_miners = await miners(meta=meta, netuid=NETUID, check_validity=True)
     queryable_hks = {m.hotkey for m in queryable_miners.values()}
     logger.info(f"Found {len(queryable_hks)} queryable miners (hot, valid chute, not gated)")
 


### PR DESCRIPTION
## Changes

- Enable `check_validity=True` in validator to properly filter out cold chutes

## Problem

Previously, `check_validity=False` was being used, which caused the validator to skip the hot/cold status check in miners.py:300. This resulted in cold chutes still being assigned weights.

## Solution

Changed `check_validity=True` to ensure the hot status check is executed, preventing cold chutes from being included in queryable miners.
