### PR TITLE
Add weights summary storage to R2

### DIFF
--- a/affine/cli.py
+++ b/affine/cli.py
@@ -18,7 +18,7 @@ from bittensor.core.errors import MetadataError
 from huggingface_hub import snapshot_download
 from typing import Any, Dict, List, Tuple
 from affine.utils.subtensor import get_subtensor
-from affine.storage import sink_enqueue, CACHE_DIR
+from affine.storage import sink_enqueue, CACHE_DIR, load_summary
 from affine.query import query_miner
 from affine import tasks as affine_tasks
 from affine.miners import get_latest_chute_id, miners, get_chute
@@ -538,9 +538,112 @@ def validate():
     asyncio.run(main())
 
 
+def _print_summary_header(block: int, schema_version: str, timestamp: int):
+    """Print formatted summary header.
+
+    Args:
+        block: Block number
+        schema_version: Schema version string
+        timestamp: Unix timestamp
+    """
+    separator = "=" * 80
+    time_str = time.strftime('%Y-%m-%d %H:%M:%S', time.localtime(timestamp))
+    print(f"\n{separator}")
+    print(f"Validator Summary (Block: {block}, Schema: v{schema_version})")
+    print(f"Timestamp: {time_str}")
+    print(f"{separator}\n")
+
+
+def _print_summary_stats(stats: dict):
+    """Print summary statistics.
+
+    Args:
+        stats: Dictionary containing statistics
+    """
+    print("Statistics:")
+    print(f"  Eligible miners: {stats.get('eligible_count', 0)}")
+    print(f"  Active miners: {stats.get('active_count', 0)}")
+    print(f"  Queryable miners: {stats.get('queryable_count', 0)}")
+    print(f"  Total miners: {stats.get('total_miners', 0)}")
+
+
+def _print_summary_table(header: list, rows: list):
+    """Print summary table.
+
+    Args:
+        header: List of column names
+        rows: List of row data
+    """
+    from tabulate import tabulate
+
+    if header and rows:
+        print(f"\n{tabulate(rows, header, tablefmt='plain')}")
+    else:
+        print("\nNo summary data available.")
+
+
+async def _display_weights_summary(block: int = None):
+    """Load and display weights summary from S3.
+
+    Args:
+        block: Optional block number to load. If None, loads latest.
+
+    Raises:
+        FileNotFoundError: If summary not found
+        Exception: For other errors during loading
+    """
+    logger.info("Loading weights summary from S3...")
+    summary = await load_summary(block)
+
+    # Extract summary components
+    schema_version = summary.get("schema_version", "unknown")
+    timestamp = summary.get("timestamp", 0)
+    block_num = summary.get("block", 0)
+    data = summary.get("data", {})
+
+    # Display formatted summary
+    _print_summary_header(block_num, schema_version, timestamp)
+    _print_summary_stats(data.get("stats", {}))
+
+    if note := data.get("note"):
+        print(f"\nNote: {note}")
+
+    _print_summary_table(data.get("header", []), data.get("rows", []))
+
+
 @cli.command("weights")
-def weights():
-    asyncio.run(get_weights())
+@click.option(
+    "-r", "--recompute",
+    is_flag=True,
+    default=False,
+    help="Recompute weights from scratch instead of reading cached summary"
+)
+@click.option(
+    "-b", "--block",
+    type=int,
+    default=None,
+    help="Load summary from specific block (only works without -r)"
+)
+def weights(recompute: bool, block: int):
+    """Display validator weights summary.
+
+    By default, reads the latest computed summary from S3.
+    Use -r to recompute weights from scratch.
+    Use -b BLOCK to load summary from a specific block.
+    """
+    async def run():
+        if recompute:
+            logger.info("Recomputing weights from scratch...")
+            await get_weights()
+        else:
+            try:
+                await _display_weights_summary(block)
+            except (FileNotFoundError, Exception) as e:
+                error_type = "No cached summary found" if isinstance(e, FileNotFoundError) else "Failed to load summary"
+                logger.error(f"{error_type}: {e}")
+                logger.info("Run with -r flag to compute weights")
+
+    asyncio.run(run())
 
 
 @cli.command("pull")


### PR DESCRIPTION
## Summary

Implement persistent storage of validator weights summaries to R2 for better observability and historical tracking.

## Key Features

- **R2 Storage Integration**: Automatic upload of weights summaries to R2 after each calculation
- **Dual Storage Strategy**: 
  - Block-specific keys: `affine/weights/summary-{block}.json`
  - Latest key: `affine/weights/latest.json` for O(1) fast access
- **Enhanced CLI**: New `--recompute` and `--block` options for weights command
- **Schema Versioning**: Future-proof data structure with version tracking

## Technical Improvements

- Introduced `SummaryContext` dataclass to reduce function parameter complexity (13 → 1)
- Extracted `_create_miner_row` helper to eliminate code duplication
- Improved variable naming for better readability
- Added proper exception logging instead of silent failures
- Optimized S3 uploads with `asyncio.gather` for parallel execution
- Enhanced numpy type conversion with NaN/Inf handling

## Files Changed

- `affine/storage.py`: Add `save_summary()` and `load_summary()` functions
- `affine/validator.py`: Integrate R2 storage with validator workflow
- `affine/cli.py`: Add CLI options for viewing cached weights

## Testing

```bash
# View latest weights from R2
affine weights

# View weights from specific block
affine weights --block 12345

# Recompute weights from scratch
affine weights --recompute
```