### PR TITLE
Change af weights -r to not upload to S3 by default

### DIFF
--- a/affine/weights.py
+++ b/affine/weights.py
@@ -87,7 +87,7 @@ async def _display_weights_summary(block: int = None):
     "-r", "--recompute",
     is_flag=True,
     default=False,
-    help="Recompute weights from scratch instead of reading cached summary"
+    help="Recompute weights from scratch without uploading to S3"
 )
 @click.option(
     "-b", "--block",
@@ -95,25 +95,17 @@ async def _display_weights_summary(block: int = None):
     default=None,
     help="Load summary from specific block (only works without -r)"
 )
-@click.option(
-    "--no-save",
-    is_flag=True,
-    default=False,
-    help="Don't save computed weights to S3 (only works with -r)"
-)
-def weights(recompute: bool, block: int, no_save: bool):
+def weights(recompute: bool, block: int):
     """Display validator weights summary.
 
     By default, reads the latest computed summary from S3.
-    Use -r to recompute weights from scratch.
+    Use -r to recompute weights from scratch (without saving to S3).
     Use -b BLOCK to load summary from a specific block.
     """
     async def run():
         if recompute:
-            logger.info("Recomputing weights from scratch...")
-            await get_weights(save_to_s3=not no_save)
-            if no_save:
-                logger.info("Weights computed but not saved to S3 (--no-save flag used)")
+            logger.info("Recomputing weights from scratch (not saving to S3)...")
+            await get_weights(save_to_s3=False)
         else:
             try:
                 await _display_weights_summary(block)


### PR DESCRIPTION
## Summary
Remove the `--no-save` flag and make `af weights -r` not upload to S3 by default to prevent accidental uploads during local testing.

## Motivation
The current `--no-save` flag requires users to explicitly opt-out of uploading. This can lead to unintended S3 uploads during development and testing. By making no-upload the default behavior, we make the command safer for local use.

## Changes
- Remove `--no-save` CLI option
- Set `save_to_s3=False` by default when using `-r` flag  
- Update help text to clarify that `-r` does not upload to S3

## Usage
```bash
# Recompute weights locally without uploading (new default)
af weights -r

# View cached weights from S3 (unchanged)
af weights

# View specific block (unchanged)
af weights -b 12345
```

## Test Plan
- [x] Test `af weights -r` - should compute weights without S3 upload
- [x] Test `af weights` - should display cached summary from S3
- [x] Verify log message shows "not saving to S3"