### PR TITLE
Improve .env.example documentation and organization

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -18,8 +18,28 @@ BT_WALLET_COLD=default
 # This key is safe to use online and used for mining, validation, or inference.
 BT_WALLET_HOT=default
 
+# HF_USER: Your Hugging Face username
+# ➤ Required for both miners (to upload models) and validators (to download models)
+# ➤ Go to https://huggingface.co/settings/profile
+# ➤ Copy your "Username" (not your full name or email)
+#    e.g., if your profile is https://huggingface.co/myaccount, then:
+HF_USER=myaccount
 
-## MINER ONLY 
+# HF_TOKEN: Your Hugging Face personal access token
+# ➤ Required for both miners and validators
+# ➤ Go to https://huggingface.co/settings/tokens
+# ➤ Click "New token"
+# ➤ For miners: select `Write` scope (to upload models)
+# ➤ For validators: `Read` scope is sufficient (to download models)
+# ➤ Copy the token shown — starts with `hf_...`
+HF_TOKEN=hf_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
+
+# Set this to change the subtensor endpoint.
+SUBTENSOR_ENDPOINT="finney"
+SUBTENSOR_FALLBACK="wss://lite.sub.latent.to:443"
+
+
+## MINER ONLY
 
 # CHUTE_USER:
 # ➤ Your Chutes username.
@@ -27,34 +47,32 @@ BT_WALLET_HOT=default
 # ➤ Used to identify your account on the Chutes platform.
 CHUTE_USER=myusername
 
-# 1. HF_USER: Your Hugging Face username
-# ➤ Go to https://huggingface.co/settings/profile
-# ➤ Copy your "Username" (not your full name or email)
-#    e.g., if your profile is https://huggingface.co/myaccount, then:
-HF_USER=myaccount
+## VALIDATOR ONLY - Cloudflare R2 Storage Configuration
 
-# 2. HF_TOKEN: Your personal access token
-# ➤ Go to https://huggingface.co/settings/tokens
-# ➤ Click "New token"
-# ➤ Name it (e.g., "affine-miner") and select `Write` scope
-# ➤ Copy the token shown — starts with `hf_...`
-#    e.g.:
-HF_TOKEN=hf_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
-
-# Set this to change the subtensor endpoint.
-SUBTENSOR_ENDPOINT="finney"
-SUBTENSOR_FALLBACK="wss://lite.sub.latent.to:443"
-
-## VALIDATOR ONLY 
+# R2_FOLDER: The R2 bucket name (e.g., "affine")
+# ➤ This is the actual bucket name in Cloudflare R2
+# ➤ Used in S3 API calls as the Bucket parameter
 R2_FOLDER="affine"
+
+# R2_BUCKET_ID: Your Cloudflare account ID (32-character hex string)
+# ➤ Find this in your Cloudflare dashboard URL: https://dash.cloudflare.com/<account_id>/
+# ➤ Used to construct the R2 endpoint: https://<account_id>.r2.cloudflarestorage.com
+# ➤ Despite the name "BUCKET_ID", this is actually your Account ID
 R2_BUCKET_ID="00523074f51300584834607253cae0fa"
+
+# R2_ACCOUNT_ID: Same as R2_BUCKET_ID (for compatibility)
+# ➤ This should match R2_BUCKET_ID above
 R2_ACCOUNT_ID="00523074f51300584834607253cae0fa"
 
-# Required: Validators required write keys 
+# Required: R2 API credentials for validators
+# ➤ Create these in Cloudflare dashboard: R2 > Manage R2 API Tokens
+# ➤ Grant "Object Read & Write" permissions
 R2_WRITE_ACCESS_KEY_ID=
 R2_WRITE_SECRET_ACCESS_KEY=
 
-# To force S3 (validators only): set AFFINE_R2_PUBLIC="0" (default is public r2.dev)
+# AFFINE_R2_PUBLIC: Use public R2.dev URL for reading (faster, no auth)
+# ➤ Set to "1" to use public URLs (default, recommended)
+# ➤ Set to "0" to force authenticated S3 API calls
 AFFINE_R2_PUBLIC="1"
 
 # Miner blacklist: comma-separated list of hotkeys to exclude from mining


### PR DESCRIPTION
## Summary

This PR improves the `.env.example` file with better documentation and organization to help users configure their environment more easily.

## Changes

### Reorganization
- **Moved HF_USER and HF_TOKEN to common section**: Both miners and validators need these credentials, so they should not be under "MINER ONLY"
- **Better section structure**: Common configs → Miner-specific → Validator-specific

### Documentation Improvements
- **R2 Storage Configuration**: Added detailed comments explaining what each variable actually represents:
  - `R2_FOLDER`: Clarified this is the actual R2 bucket name (used in S3 API calls)
  - `R2_BUCKET_ID`: Clarified this is actually the Cloudflare account ID (despite the name)
  - `R2_ACCOUNT_ID`: Noted it should match R2_BUCKET_ID
- **HF_TOKEN scope requirements**: Clearly stated miners need `Write` scope, validators only need `Read`
- **Cloudflare dashboard examples**: Added URL patterns to help users find their account ID

### Formatting
- Used `➤` bullet points for better readability
- Consistent comment style across all variables
- More descriptive section headers

## Testing

No code changes - documentation only. Configuration still works with existing deployments.

## Motivation

Users were confused about:
1. The misleading variable names (R2_BUCKET_ID is actually account ID, R2_FOLDER is actually bucket name)
2. Whether validators need HF credentials (they do)
3. What permissions are needed for HF_TOKEN
4. Where to find their Cloudflare account ID

This PR addresses all these issues with clear documentation.