### PR TITLE
Fix: Export storage functions in __init__.py

### DIFF
--- a/affine/__init__.py
+++ b/affine/__init__.py
@@ -39,7 +39,8 @@ from affine.cli import cli
 #                               dataset                                       #
 # --------------------------------------------------------------------------- #
 from affine.storage import (
-    FOLDER, BUCKET, ACCESS, SECRET, ENDPOINT, PUBLIC_READ, R2_PUBLIC_BASE
+    FOLDER, BUCKET, ACCESS, SECRET, ENDPOINT, PUBLIC_READ, R2_PUBLIC_BASE,
+    load_summary, save_summary, dataset, sink, sink_enqueue, prune
 )
 
 


### PR DESCRIPTION
## Problem
The affine package was missing exports for several storage functions, causing ImportError when trying to import functions like `load_summary`, `save_summary`, etc.

## Solution
Added exports for the following functions from `affine.storage`:
- `load_summary` - Load validator summary from S3
- `save_summary` - Save validator summary to S3  
- `dataset` - Load dataset from R2 storage
- `sink` - Upload results to storage
- `sink_enqueue` - Queue results for upload
- `prune` - Prune old cache files

## Testing
- Verify that `from affine.storage import load_summary` works without errors
- Ensure the runner and validator services can start successfully