### PR TITLE
Remove chute hot status check from miner validation

### DIFF
--- a/affine/miners.py
+++ b/affine/miners.py
@@ -297,7 +297,7 @@ async def miners(
             async with meta_sem:
                 chute = await get_chute(chute_id)
 
-            if not chute or not chute.get("hot", False):
+            if not chute:
                 return None
 
             chute_name = chute.get("name")


### PR DESCRIPTION
## Summary
- Removed the requirement for chutes to have hot=true status in miner validation
- This allows all chutes (regardless of hot status) to pass the validation check

## Changes
- Modified affine/miners.py line 300: Changed from `if not chute or not chute.get("hot", False):` to `if not chute:`

## Impact
- Miners with non-hot chutes will no longer be filtered out during validation