### PR TITLE
Add R2 weights mode for validators

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -87,3 +87,12 @@ AFFINE_MINER_BLACKLIST=""
 # ➤ If not set or empty, environments will be deployed locally
 # ➤ Requires SSH access and Docker installed on remote hosts
 AFFINETES_HOSTS="localhost"
+
+## VALIDATOR ONLY - R2 Weights Mode
+
+# USE_R2_WEIGHTS: Enable downloading weights from R2 instead of computing locally
+# ➤ Set to "true" to enable R2 weights mode (validator will download pre-computed weights)
+# ➤ Set to "false" or leave empty to use local weight computation (default)
+# ➤ When enabled, the validator will download weights from the official Affine R2 bucket
+# ➤ Weights are always loaded from affine/weights/latest.json
+USE_R2_WEIGHTS="false"

--- a/affine/validate_from_r2.py
+++ b/affine/validate_from_r2.py
@@ -1,0 +1,131 @@
+"""Validate by loading weights from remote R2 storage.
+
+This module provides functionality to run a validator that downloads weights
+from a remote R2 bucket and applies them to the blockchain, instead of
+computing weights locally.
+
+The weights are always downloaded from the official Affine R2 bucket:
+https://pub-bf429ea7a5694b99adaf3d444cbbe64d.r2.dev/affine/weights/latest.json
+"""
+
+import json
+import aiohttp
+from typing import Tuple, List
+
+from affine.setup import logger
+
+# Official Affine R2 public URL
+R2_PUBLIC_URL = "https://pub-bf429ea7a5694b99adaf3d444cbbe64d.r2.dev"
+WEIGHTS_KEY = "affine/weights/latest.json"
+
+
+async def download_weights_summary(timeout: int = 30) -> dict:
+    """Download weights summary from R2 public URL.
+
+    Always downloads from affine/weights/latest.json on the official R2 bucket.
+
+    Args:
+        timeout: Request timeout in seconds
+
+    Returns:
+        Dictionary containing the weights summary data
+
+    Raises:
+        Exception: If download fails or data is invalid
+    """
+    url = f"{R2_PUBLIC_URL}/{WEIGHTS_KEY}"
+    logger.info(f"Downloading latest weights from: {url}")
+
+    # Download the data
+    async with aiohttp.ClientSession() as session:
+        async with session.get(url, timeout=aiohttp.ClientTimeout(total=timeout)) as response:
+            response.raise_for_status()
+            data = await response.json()
+
+    logger.info(f"Successfully downloaded weights summary")
+    logger.debug(f"Summary data keys: {list(data.keys())}")
+
+    return data
+
+
+def extract_uids_weights(summary: dict) -> Tuple[List[int], List[float]]:
+    """Extract UIDs and weights from summary data.
+
+    Args:
+        summary: Dictionary containing the full summary structure
+                 Expected format: {
+                     'schema_version': '1.0.0',
+                     'timestamp': ...,
+                     'block': ...,
+                     'data': {
+                         'miners': {
+                             'hotkey': {
+                                 'uid': uid,
+                                 'weight': weight,
+                                 ...
+                             },
+                             ...
+                         }
+                     }
+                 }
+
+    Returns:
+        Tuple of (uids, weights) lists
+
+    Raises:
+        ValueError: If summary format is invalid
+    """
+    # Extract data section
+    if "data" not in summary:
+        raise ValueError("Summary missing 'data' key")
+
+    data = summary["data"]
+
+    # Extract miners
+    if "miners" not in data:
+        raise ValueError("Summary data missing 'miners' key")
+
+    miners_data = data["miners"]
+
+    if not isinstance(miners_data, dict):
+        raise ValueError(f"Expected 'miners' to be a dict, got {type(miners_data)}")
+
+    # Extract UIDs and weights
+    uids = []
+    weights = []
+
+    for miner_data in miners_data.values():
+        if not isinstance(miner_data, dict):
+            continue
+
+        uid = miner_data.get("uid")
+        weight = miner_data.get("weight")
+
+        if uid is not None and weight is not None:
+            uids.append(int(uid))
+            weights.append(float(weight))
+
+    if not uids:
+        raise ValueError("No valid UIDs/weights found in summary")
+
+    logger.info(f"Extracted {len(uids)} UIDs and weights from summary")
+    logger.debug(f"UIDs: {uids[:10]}..." if len(uids) > 10 else f"UIDs: {uids}")
+    logger.debug(f"Weights sum: {sum(weights):.6f}")
+
+    return uids, weights
+
+
+async def get_weights_from_r2() -> Tuple[List[int], List[float]]:
+    """Download weights from R2 and extract UIDs and weights.
+
+    Always downloads from the official Affine R2 bucket at:
+    https://pub-bf429ea7a5694b99adaf3d444cbbe64d.r2.dev/affine/weights/latest.json
+
+    Returns:
+        Tuple of (uids, weights) lists
+    """
+    # Download and extract
+    summary = await download_weights_summary()
+    uids, weights = extract_uids_weights(summary)
+
+    return uids, weights


### PR DESCRIPTION
## Summary

This PR adds the ability for validators to download pre-computed weights from R2 storage instead of computing them locally. This allows validators to use weights calculated by other validators.

## Changes

- **New module**: `affine/validate_from_r2.py`
  - Downloads weights from R2 public URL
  - Parses summary data structure to extract UIDs and weights
  - Always uses `affine/weights/latest.json` from the official R2 bucket

- **Modified**: `affine/cli.py`
  - Updated `validate` command to support R2 weights mode
  - Checks `USE_R2_WEIGHTS` environment variable to determine mode
  - Displays current mode on startup

- **Modified**: `.env.example`
  - Added `USE_R2_WEIGHTS` configuration option
  - Defaults to `false` (local computation)

## Usage

**Local computation mode (default):**
```bash
affine validate
```

**R2 weights mode:**
```bash
# Set in .env file
USE_R2_WEIGHTS=true

# Then run
affine validate
```

## Technical Details

- Weights are downloaded from: `https://pub-bf429ea7a5694b99adaf3d444cbbe64d.r2.dev/affine/weights/latest.json`
- Data structure: `summary.data.miners[hotkey].{uid, weight}`
- No additional dependencies required (uses existing aiohttp)

## Testing

Tested with live R2 data and confirmed:
- Successful download of weights summary
- Correct parsing of UIDs and weights
- Proper weight setting on-chain