### PR TITLE
Pin bittensor version to <=10.0.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ description = "Anima Machina"
 authors = [{ name = "affine", email = "affine@affine.io" }]
 dependencies = [
     "python-dotenv>=0.21.0",
-    "bittensor",
+    "bittensor<=10.0.0",
     "bittensor-cli",
     "aiohttp>=3.10.11",
     "ipykernel>=6.30.1",

--- a/uv.lock
+++ b/uv.lock
@@ -54,7 +54,7 @@ requires-dist = [
     { name = "aiofiles" },
     { name = "aiohttp", specifier = ">=3.10.11" },
     { name = "alive-progress", specifier = ">=3.0.0" },
-    { name = "bittensor" },
+    { name = "bittensor", specifier = "<=10.0.0" },
     { name = "bittensor-cli" },
     { name = "boto3", specifier = ">=1.34" },
     { name = "botocore", specifier = ">=1.38.27" },


### PR DESCRIPTION
## Summary
- Add version constraint to bittensor dependency (`<=10.0.0`)
- Update lock file to reflect the constraint

## Motivation
Ensures compatibility by pinning bittensor to version 10.0.0 or earlier.

## Test Plan
- Verify dependency resolution works correctly
- Check that the application builds and runs with the pinned version