### PR TITLE
Fix alfworld score validation and save_to_s3 flag handling

### DIFF
--- a/affine/cal_weights.py
+++ b/affine/cal_weights.py
@@ -351,7 +351,10 @@ async def get_weights(tail: int = SamplingConfig.TAIL, burn: float = 0.0, save_t
             note="No eligible miners, defaulting to uid 0"
         )
         summary_data = _build_summary_data(ctx, ENVS)
-        await save_summary(blk, summary_data)
+        if save_to_s3:
+            await save_summary(blk, summary_data)
+        else:
+            logger.info("Skipping save to S3 (save_to_s3=False)")
 
         return [0], [1.0]
 

--- a/affine/sampling.py
+++ b/affine/sampling.py
@@ -643,7 +643,14 @@ class SamplingOrchestrator:
             prev[hk] = result
 
             # Add sample to queue (automatically keeps only latest MAX_SAMPLES_CAP)
-            normalized_score = SamplingConfig.normalize_score(float(result.evaluation.score), env)
+            raw_score = float(result.evaluation.score)
+
+            # Filter out invalid alfworld scores (should be 0 or 1, not other values)
+            if "alfworld" in env and raw_score not in [0.0, 1.0]:
+                # Skip this invalid alfworld sample
+                continue
+
+            normalized_score = SamplingConfig.normalize_score(raw_score, env)
             try:
                 block_num = int(result.miner.block)
             except Exception:


### PR DESCRIPTION
## Summary
- Filter out invalid alfworld scores that are not 0 or 1 (skip scores like -100, 35, 70, 82, 100, etc.)
- Fix `save_to_s3=False` flag not being respected when no eligible miners are found

## Test plan
- [ ] Run `af weights -r` without S3 credentials configured
- [ ] Verify alfworld samples with invalid scores are filtered out