### PR TITLE
Update confidence level from 0.90 to 0.85

### DIFF
--- a/affine/sampling.py
+++ b/affine/sampling.py
@@ -20,7 +20,7 @@ class SamplingConfig:
     
     # Challenge algorithm parameters
     # Confidence level for Beta distribution interval (can be adjusted easily)
-    CONFIDENCE_LEVEL = 0.90  # confidence level
+    CONFIDENCE_LEVEL = 0.85  # confidence level
 
     # Beta distribution prior parameters (Jeffrey's prior for binomial proportion)
     BETA_PRIOR_ALPHA = 0.5


### PR DESCRIPTION
## Summary
- Lowered Beta distribution confidence level from 0.90 to 0.85 for sampling configuration

## Test plan
- [ ] Verify sampling behavior with new confidence level
- [ ] Monitor miner evaluation results