### PR TITLE
Set evaluator temperature to 0 for deterministic outputs

### DIFF
--- a/affine/tasks.py
+++ b/affine/tasks.py
@@ -42,7 +42,7 @@ class SandboxConfig:
 class EvaluatorConfig:
     """Evaluator configuration"""
 
-    temperature: float = 0.7
+    temperature: float = 0
     timeout: int = 600
     max_round: int = 10
 


### PR DESCRIPTION
## Summary
- Changed the default temperature from 0.7 to 0 in EvaluatorConfig

## Rationale
Setting temperature to 0 ensures more consistent and deterministic model outputs during evaluation, which is important for reproducible results and fair comparison across different evaluation runs.

## Changes
- Updated `EvaluatorConfig.temperature` from 0.7 to 0 in tasks.py

## Test Plan
- [ ] Verify evaluations run successfully with temperature=0
- [ ] Check that outputs are more consistent across multiple runs
- [ ] Ensure no unexpected behavior changes in evaluation logic