### PR TITLE
Set evaluator temperature to 0 for deterministic outputs

### DIFF
--- a/affine/tasks.py
+++ b/affine/tasks.py
@@ -42,7 +42,7 @@ class SandboxConfig:
 class EvaluatorConfig:
     """Evaluator configuration"""
 
-    temperature: float = 0.7
+    temperature: float = 0
     timeout: int = 600
     max_round: int = 10
 


### PR DESCRIPTION
Changed the default temperature from 0.7 to 0 in EvaluatorConfig to ensure more consistent and deterministic model outputs during evaluation.