### PR TITLE
Update TAIL configuration from 20000 to 40000

### DIFF
--- a/affine/sampling.py
+++ b/affine/sampling.py
@@ -12,7 +12,7 @@ from typing import Dict, List, Tuple, Optional, Any, Set
 class SamplingConfig:
     """Configuration parameters for sampling."""
     
-    TAIL = 20_000  # Ensure all the dataset evaluation result is included in the window
+    TAIL = 40_000  # Ensure all the dataset evaluation result is included in the window
     SCALE = 1.0  # Scaling factor for layer weights
     
     # Task ID deduplication threshold


### PR DESCRIPTION
## Summary
Increase the TAIL parameter from 20000 to 40000 to ensure all dataset evaluation results are included in the sampling window.

## Changes
- Updated `SamplingConfig.TAIL` from 20000 to 40000 in [sampling.py](affine/sampling.py#L15)

## Test plan
- Verify validator can process larger sample windows
- Monitor memory usage and performance