### PR TITLE
Fix missing min_samples parameter and eligibility calculation in sampling module

### DIFF
--- a/affine/sampling.py
+++ b/affine/sampling.py
@@ -239,7 +239,7 @@ class MinerSampler:
         
         for e in envs:
             # Minimum samples = dataset size for that environment
-            required[e] = SamplingConfig.SMALL_DATASET_THRESHOLD
+            required[e] = self.env_dataset_sizes.get(e, 0)
         
         eligible = {
             hk for hk in active_hks
@@ -293,7 +293,8 @@ class MinerSampler:
                 {'hotkey': a, **stats_a},
                 {'hotkey': b, **stats_b},
                 confidence_interval_a=ci_a,
-                confidence_interval_b=ci_b
+                confidence_interval_b=ci_b,
+                min_samples=min_samples
             )
 
             if winner == 'b':


### PR DESCRIPTION
## Summary
This PR fixes two critical issues in the sampling module that were causing incorrect dominance calculations and eligibility determinations.

## Changes

### 1. Fixed Missing `min_samples` Parameter in `challenge_winner` Call
**File:** `affine/sampling.py:292-297`

- Added `min_samples=min_samples` parameter to `challenge_winner` call in `dominates_on` method
- Ensures miners with insufficient samples are properly filtered out during dominance checks
- Prevents incorrect dominance calculations when miners haven't completed enough samples for an environment

**Impact:** The `challenge_winner` method already had logic to handle insufficient samples (lines 142-147), but it wasn't being invoked because the `min_samples` parameter wasn't being passed. This could lead to incorrect Pareto dominance results.

### 2. Fixed Eligibility Calculation to Use Actual Dataset Sizes
**File:** `affine/sampling.py:240-242`

- Changed from hardcoded `SamplingConfig.SMALL_DATASET_THRESHOLD` (400) to `self.env_dataset_sizes.get(e, 0)`
- Now correctly uses the actual dataset size for each environment when determining eligibility

**Impact:** Previously, all environments were using a hardcoded threshold of 400 samples for eligibility, regardless of their actual dataset size. This could incorrectly exclude miners who had completed all samples for smaller datasets, or incorrectly include miners who hadn't completed enough samples for larger datasets.

## Testing
- [x] Verified no linting errors introduced
- [x] Confirmed `min_samples` is correctly calculated from `env_dataset_sizes`
- [x] Verified `challenge_winner` receives the `min_samples` parameter

## Related Issues
Fixes incorrect dominance calculations and eligibility determinations in the sampling algorithm.


Contribution by Gittensor, learn more at https://gittensor.io/