### PR TITLE
Redistribute weights below threshold to uid 0

### DIFF
--- a/affine/src/scorer/config.py
+++ b/affine/src/scorer/config.py
@@ -76,7 +76,7 @@ class ScorerConfig:
     """
     
     # Stage 4: Weight Normalization
-    MIN_WEIGHT_THRESHOLD: float = 0.5
+    MIN_WEIGHT_THRESHOLD: float = 0.01
     """Minimum weight threshold (1%). Miners below this are set to 0."""
     
     # Stage 1: Data Collection

--- a/affine/src/scorer/stage4_weights.py
+++ b/affine/src/scorer/stage4_weights.py
@@ -80,7 +80,14 @@ class Stage4WeightNormalizer:
         
         # Step 3: Final normalization (ensure sum = 1.0)
         final_weights = normalize_weights(weights_after_threshold)
-        
+
+        # Step 4: Apply min threshold after normalization and redistribute to uid 0
+        final_weights = apply_min_threshold(
+            final_weights,
+            threshold=self.min_threshold,
+            redistribute_to_uid_zero=True
+        )
+
         # Update miner objects with normalized weights
         for uid, weight in final_weights.items():
             if uid in miners:


### PR DESCRIPTION
## Summary
- Update MIN_WEIGHT_THRESHOLD from 0.5 to 0.01 (1%)
- Apply threshold check after normalization to catch small weights
- Redistribute sub-threshold weights to uid 0 instead of discarding
- Add redistribute_to_uid_zero parameter to apply_min_threshold function

## Problem
The previous implementation applied the threshold check before normalization, which could result in new small weights (e.g., 0.001933 < 0.01) appearing after normalization. These small weights persisted in the final results but didn't meet the minimum threshold requirement.

## Solution
1. Change threshold from 0.5 to 0.01 (1%)
2. Apply threshold check again after normalization
3. Set all weights below 0.01 to 0 and redistribute their sum to uid 0

## Result
- Ensures all final weights are either 0 or >= 0.01
- Maintains total weight sum of 1.0
- Redistributes filtered weights to uid 0 instead of losing them