### PR TITLE
feat(miner): add one-command deployment (miner-deploy)

### DIFF
--- a/affine/cli/main.py
+++ b/affine/cli/main.py
@@ -13,6 +13,7 @@ Server Services (af servers):
 - af servers validator : Start validator service
 
 Miner Commands:
+- af miner-deploy: One-command deployment (upload → deploy → commit)
 - af commit      : Commit model to blockchain (miner)
 - af pull        : Pull model from Hugging Face (miner)
 - af chutes_push : Deploy model to Chutes (miner)
@@ -293,6 +294,27 @@ def get_rank(ctx):
     
     sys.argv = ["get-rank"] + ctx.args
     miner_get_rank.main(standalone_mode=False)
+
+
+@cli.command("miner-deploy", context_settings={"ignore_unknown_options": True, "allow_extra_args": True})
+@click.pass_context
+def miner_deploy(ctx):
+    """One-command deployment: Upload -> Deploy -> Commit.
+    
+    Combines the three-step miner deployment process into a single command:
+    1. Upload model to HuggingFace (skip with --skip-upload)
+    2. Deploy to Chutes (skip with --skip-chutes)
+    3. Commit on-chain (skip with --skip-commit)
+    
+    Examples:
+        af miner-deploy -r myuser/model -p ./my_model
+        af miner-deploy -r myuser/model --skip-upload --revision abc123
+        af miner-deploy -r myuser/model -p ./my_model --dry-run
+    """
+    from affine.src.miner.main import deploy as miner_deploy_cmd
+    
+    sys.argv = ["miner-deploy"] + ctx.args
+    miner_deploy_cmd.main(standalone_mode=False)
 
 
 # ============================================================================

--- a/affine/src/miner/main.py
+++ b/affine/src/miner/main.py
@@ -16,6 +16,7 @@ from affine.src.miner.commands import (
     pull_command,
     chutes_push_command,
     commit_command,
+    deploy_command,
     get_sample_command,
     get_miner_command,
     get_weights_command,
@@ -168,6 +169,60 @@ def get_rank():
         af get-rank
     """
     asyncio.run(get_rank_command())
+
+
+@click.command("deploy")
+@click.option("--repo", "-r", required=True, help="HuggingFace repository ID (e.g., username/model-name)")
+@click.option("--model-path", "-p", type=click.Path(exists=True), help="Path to local model directory (required unless --skip-upload)")
+@click.option("--revision", help="HuggingFace revision SHA (required if --skip-upload)")
+@click.option("--chute-id", help="Chutes deployment ID (required if --skip-chutes)")
+@click.option("--message", "-m", default="Model update", help="Commit message for HuggingFace upload")
+@click.option("--dry-run", is_flag=True, help="Show what would be done without executing")
+@click.option("--skip-upload", is_flag=True, help="Skip HuggingFace upload (requires --revision)")
+@click.option("--skip-chutes", is_flag=True, help="Skip Chutes deployment (requires --chute-id)")
+@click.option("--skip-commit", is_flag=True, help="Skip on-chain commit")
+@click.option("--chutes-api-key", help="Chutes API key (optional, from env if not provided)")
+@click.option("--chute-user", help="Chutes username (optional, from env if not provided)")
+@click.option("--coldkey", help="Wallet coldkey name (optional, from env if not provided)")
+@click.option("--hotkey", help="Wallet hotkey name (optional, from env if not provided)")
+@click.option("--hf-token", help="HuggingFace token (optional, from env if not provided)")
+def deploy(repo, model_path, revision, chute_id, message, dry_run, skip_upload, skip_chutes, skip_commit, chutes_api_key, chute_user, coldkey, hotkey, hf_token):
+    """One-command deployment: Upload -> Deploy -> Commit.
+    
+    Combines the three-step deployment process into a single command:
+    1. Upload model to HuggingFace (skip with --skip-upload)
+    2. Deploy to Chutes (skip with --skip-chutes)
+    3. Commit on-chain (skip with --skip-commit)
+    
+    Examples:
+        # Full deployment
+        af miner-deploy -r myuser/model -p ./my_model
+        
+        # Skip upload (model already on HuggingFace)
+        af miner-deploy -r myuser/model --skip-upload --revision abc123
+        
+        # Skip Chutes (already deployed)
+        af miner-deploy -r myuser/model --skip-upload --revision abc123 --skip-chutes --chute-id xyz
+        
+        # Dry run
+        af miner-deploy -r myuser/model -p ./my_model --dry-run
+    """
+    asyncio.run(deploy_command(
+        repo=repo,
+        model_path=model_path,
+        revision=revision,
+        chute_id=chute_id,
+        message=message,
+        dry_run=dry_run,
+        skip_upload=skip_upload,
+        skip_chutes=skip_chutes,
+        skip_commit=skip_commit,
+        chutes_api_key=chutes_api_key,
+        chute_user=chute_user,
+        coldkey=coldkey,
+        hotkey=hotkey,
+        hf_token=hf_token,
+    ))
 
 
 


### PR DESCRIPTION
# feat(miner): Add One-Command Deployment (`miner-deploy`)

## Summary

This PR adds a new CLI command `af miner-deploy` that combines the three-step miner deployment process into a single command:

1. **Upload** model to HuggingFace
2. **Deploy** to Chutes
3. **Commit** on-chain

## Motivation

Previously, miners had to run three separate commands to deploy a model update:
```bash
# Step 1: Upload to HuggingFace (manual)
# Step 2: Deploy to Chutes
af chutes-push --repo user/model --revision abc123
# Step 3: Commit on-chain
af commit --repo user/model --revision abc123 --chute-id xyz
```

This was error-prone and required manually tracking revision SHAs and chute IDs between steps.

## Solution

The new `miner-deploy` command handles all three steps automatically:

```bash
# Full deployment in one command
af miner-deploy -r myuser/model -p ./my_model

# With custom commit message
af miner-deploy -r myuser/model -p ./my_model -m "v2.0 release"

# Dry run (preview without executing)
af miner-deploy -r myuser/model -p ./my_model --dry-run
```

### Flexible Skip Flags

For partial deployments (e.g., model already on HuggingFace):

```bash
# Skip upload (model already on HuggingFace)
af miner-deploy -r myuser/model --skip-upload --revision abc123

# Skip upload + Chutes (already deployed, just commit)
af miner-deploy -r myuser/model --skip-upload --revision abc123 --skip-chutes --chute-id xyz

# Skip commit (test deployment without on-chain commit)
af miner-deploy -r myuser/model -p ./my_model --skip-commit
```

## Changes

| File | Description |
|------|-------------|
| `affine/src/miner/commands.py` | Added `deploy_command` function (~320 lines) |
| `affine/src/miner/main.py` | Added Click CLI wrapper for `deploy` |
| `affine/cli/main.py` | Registered `miner-deploy` command |
| `affine/src/miner/test_deploy.py` | Added 14 unit tests |

## CLI Options

```
Options:
  -r, --repo TEXT        HuggingFace repository ID (required)
  -p, --model-path PATH  Path to local model directory
  --revision TEXT        HuggingFace revision SHA (required if --skip-upload)
  --chute-id TEXT        Chutes deployment ID (required if --skip-chutes)
  -m, --message TEXT     Commit message for HuggingFace upload
  --dry-run              Show what would be done without executing
  --skip-upload          Skip HuggingFace upload
  --skip-chutes          Skip Chutes deployment
  --skip-commit          Skip on-chain commit
  --chutes-api-key TEXT  Chutes API key (or use CHUTES_API_KEY env)
  --chute-user TEXT      Chutes username (or use CHUTE_USER env)
  --coldkey TEXT         Wallet coldkey name (or use BT_WALLET_COLD env)
  --hotkey TEXT          Wallet hotkey name (or use BT_WALLET_HOT env)
  --hf-token TEXT        HuggingFace token (or use HF_TOKEN env)
```

## Testing

```bash
# Run tests
python -m pytest affine/src/miner/test_deploy.py -v

# All 14 tests pass
```

### Test Coverage
- Argument validation (missing required args)
- Skip flag validation (--skip-upload requires --revision, etc.)
- Dry-run modes (full, partial, all skips)
- Credential validation (HF_TOKEN, CHUTES_API_KEY, CHUTE_USER)
- Integration test with mocked HuggingFace API

## Checklist

- [x] Code follows existing patterns in the codebase
- [x] Uses `logger.info` for status messages (matches existing style)
- [x] Reuses Chute config from `chutes_push_command`
- [x] Supports all credentials via CLI args or env vars
- [x] Lint passes (`ruff check`)
- [x] Unit tests pass (14/14)
- [x] Dry-run mode for safe preview

Contribution by Gittensor, learn more at https://gittensor.io/