### PR TITLE
Docs: add pip/venv install instructions and INSTALL.md to enable more contributors who do not use `uv`

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -1,0 +1,113 @@
+# Installation Guide
+
+This guide covers the different ways to install and run Affine:
+
+- [Using `uv` (Recommended)](#install-using-uv)
+- [Using `pip` and `venv` (Standard)](#install-using-pip-and-venv)
+- [Using Docker](#install-using-docker)
+
+## Install using uv
+
+We rely on `uv` for fast, reliable package management.
+
+```bash
+# Install uv
+curl -LsSf https://astral.sh/uv/install.sh | sh
+
+# Clone and install
+git clone https://github.com/AffineFoundation/affine.git
+cd affine
+uv venv && source .venv/bin/activate && uv pip install -e .
+
+# Verify
+af --help
+```
+
+## Install using pip and venv
+
+If you prefer the standard Python tooling (`pip` and `venv`), follow these steps.
+
+**Prerequisites:** Python 3.11 or higher.
+
+1. **Clone the repository:**
+
+   ```bash
+   git clone https://github.com/AffineFoundation/affine.git
+   cd affine
+   ```
+
+2. **Create a virtual environment:**
+
+   ```bash
+   python3 -m venv .venv
+   ```
+
+3. **Activate the environment:**
+   - On Linux/macOS:
+
+     ```bash
+     source .venv/bin/activate
+     ```
+
+   - On Windows:
+
+     ```powershell
+     .venv\Scripts\activate
+     ```
+
+4. **Install dependencies and the package:**
+   This project uses `pyproject.toml` for dependency management.
+
+   ```bash
+   pip install --upgrade pip build
+   pip install -e .
+   ```
+
+   *Note: The `-e .` flag installs the package in "editable" mode, meaning
+   changes to the code will be reflected immediately without reinstalling.*
+
+5. **Verify installation:**
+
+   ```bash
+   af --help
+   ```
+
+### Troubleshooting
+
+- **Python Version Mismatch**: Ensure you are using Python 3.11+. Check with
+  `python3 --version`.
+- **Permission Errors**: If you see permission errors, ensure you are in the
+  virtual environment. Avoid using `sudo pip install`.
+- **Missing Dependencies**: On some systems, you might need build tools. On
+  Ubuntu/Debian: `sudo apt install build-essential python3-dev`.
+
+## Install using Docker
+
+You can use Docker to run the validator or watchtower services without installing
+Python dependencies locally.
+
+### Using Docker Compose (Recommended)
+
+1. **Configure environment:**
+   Copy `.env.example` to `.env` and fill in your details (wallet info, etc.).
+
+   ```bash
+   cp .env.example .env
+   ```
+
+2. **Run with Compose:**
+
+   ```bash
+   docker-compose up -d
+   ```
+
+   This will start the validator and watchtower services.
+
+### Building Manually
+
+You can build the image directly using the provided `Dockerfile`.
+
+```bash
+docker build -t affine .
+docker run --env-file .env affine
+```

--- a/README.md
+++ b/README.md
@@ -6,17 +6,31 @@ Mine open reasoning.
 
 ## Introduction
 
-Affine is an incentivized RL environment that pays miners who make incremental improvements on a set of tasks (such as program abduction or coding). The mechanism is sybil-proof, decoy-proof, copy-proof, and overfitting-proof.
+Affine is an incentivized RL environment that pays miners who make incremental
+improvements on a set of tasks (such as program abduction or coding). The
+mechanism is sybil-proof, decoy-proof, copy-proof, and overfitting-proof.
 
-**How does Affine work?** 
+**How does Affine work?**
 
-Affine validators incentivize miners to submit models to Subnet 64 on Bittensor (a.k.a Chutes) where they are inference load balanced and publicly available. These models are evaluated on a set of RL environments, with validators looking for models that dominate the Pareto frontier—namely, models that outcompete all other models across all environments. The network uses a winners-take-all mechanism where miners are incentivized to copy, download, and improve the Pareto frontier model.
+Affine validators incentivize miners to submit models to Subnet 64 on Bittensor
+(a.k.a Chutes) where they are inference load balanced and publicly available.
+These models are evaluated on a set of RL environments, with validators looking
+for models that dominate the Pareto frontier—namely, models that outcompete all
+other models across all environments. The network uses a winners-take-all
+mechanism where miners are incentivized to copy, download, and improve the
+Pareto frontier model.
 
-**Why Affine?** 
+**Why Affine?**
 
-Directed incentives for RL have never been achieved. The ability to direct intelligence and aggregate the work effort of a large, non-permissioned group of individuals on RL tasks will unlock rapid advancement in intelligence. We intend to commoditize reasoning (intelligence's highest form) and break the intelligence sound barrier.
+Directed incentives for RL have never been achieved. The ability to direct
+intelligence and aggregate the work effort of a large, non-permissioned group
+of individuals on RL tasks will unlock rapid advancement in intelligence. We
+intend to commoditize reasoning (intelligence's highest form) and break the
+intelligence sound barrier.
 
 ## Installation
+
+### Install with uv (Recommended)
 
 ```bash
 # Install uv package manager
@@ -31,15 +45,36 @@ uv venv && source .venv/bin/activate && uv pip install -e .
 af
 ```
 
+### Install with pip
+
+```bash
+# Clone
+git clone https://github.com/AffineFoundation/affine.git
+cd affine
+
+# Create venv
+python -m venv .venv
+source .venv/bin/activate  # or .venv\Scripts\activate on Windows
+
+# Install
+pip install --upgrade pip build
+pip install -e .
+```
+
+For detailed instructions and Docker usage, see [INSTALL.md](INSTALL.md).
+
 ### Architecture
 
-Affine uses [Affinetes](https://github.com/AffineFoundation/affinetes) for container orchestration, providing:
+Affine uses [Affinetes](https://github.com/AffineFoundation/affinetes) for
+container orchestration, providing:
+
 - Clean, lightweight container management
 - Support for local and remote Docker deployments
 - Environment caching for improved performance
 - Type-safe environment definitions
 
-All evaluation environments are packaged as pre-built Docker images, eliminating the need for complex sandbox management.
+All evaluation environments are packaged as pre-built Docker images, eliminating
+the need for complex sandbox management.
 
 ## Getting Started
 
@@ -48,6 +83,7 @@ All evaluation environments are packaged as pre-built Docker images, eliminating
 📖 **[Complete Miner Guide →](docs/MINER.md)**
 
 Learn how to:
+
 - Set up your environment and configure API keys
 - Pull models from the network
 - Improve models with reinforcement learning
@@ -59,6 +95,7 @@ Learn how to:
 📖 **[Complete Validator Guide →](docs/VALIDATOR.md)**
 
 Learn how to:
+
 - Set up and configure your validator
 - Run with Docker (recommended) or locally
 - Monitor validator performance
@@ -74,10 +111,14 @@ Learn how to:
 Affine can be used as an SDK for evaluating models across different environments.
 
 **Examples:**
-- [`examples/sdk.py`](examples/sdk.py) - Evaluate miners from the network on DED-V2 and ABD-V2 environments
-- [`examples/sdk2.py`](examples/sdk2.py) - Evaluate custom models by specifying model parameters directly
+
+- [`examples/sdk.py`](examples/sdk.py) - Evaluate miners from the network on
+  DED-V2 and ABD-V2 environments
+- [`examples/sdk2.py`](examples/sdk2.py) - Evaluate custom models by specifying
+  model parameters directly
 
 **Key Features:**
+
 - Evaluate registered miners by UID
 - Evaluate custom models with direct parameters (model, base_url, temperature)
 - Support for multiple environments (DED-V2, ABD-V2, etc.)


### PR DESCRIPTION
### Documentation Update: Standard Installation Instructions
This PR addresses the lack of standard `pip` and `venv` installation instructions, which blocked contributors who do not use `uv`.
#### Changes
1. **Updated [README.md](cci:7://file:///c:/Users/user/Desktop/affine-cortex/README.md:0:0-0:0)**:
    * Added a new "Install with pip" section.
    * Preserved existing `uv` instructions as the recommended method.
    * Refatted long lines to satisfy generic markdown linters.
    * Added a reference to the new [INSTALL.md](cci:7://file:///c:/Users/user/Desktop/affine-cortex/INSTALL.md:0:0-0:0).
2. **Created [INSTALL.md](cci:7://file:///c:/Users/user/Desktop/affine-cortex/INSTALL.md:0:0-0:0)**:
    * Provided detailed, step-by-step instructions for:
        * **Standard Python (`pip`/`venv`)**: Clone, create specific virtual environments on Windows/Linux, and install in editable mode (`pip install -e .`).
        * **UV**: Referenced the fast path.
        * **Docker**: Instructions for using `docker-compose` and manual `docker build`.
    * Included a **Troubleshooting** section for common issues (Python version, permissions).
#### Verification
* **Linting**: Ran `markdownlint-cli` on modified files and fixed all reported issues (line length, spacing around lists/code blocks).
* **Correctness**: Instructions verified against standard Python packaging practices (using `pip install -e .` for `pyproject.toml` based projects).