### PR TITLE
Fix: take last task from the pending tasks

### DIFF
--- a/affine/api/services/task_pool.py
+++ b/affine/api/services/task_pool.py
@@ -514,7 +514,7 @@ class TaskPoolManager:
                 if isinstance(result, Exception):
                     continue
                 if isinstance(result, list) and result:
-                    candidate_tasks.append(result[0])  # Take first task
+                    candidate_tasks.append(result[-1])  # Take last task
             
             # Take first batch_size tasks and assign in parallel
             tasks_to_assign = candidate_tasks[:batch_size]


### PR DESCRIPTION
This PR fixes a scheduling issue that causes executors to spend time running tasks that are no longer needed, which reduces overall evaluation throughput.

### Problem
Tasks are rotated from the front of the queue at every `rotating_interval`.
Executors also fetch tasks from the front.

When an executor cannot finish `rotating_count` tasks within one interval, tasks may be rotated before they are executed.
As a result, executors can spend time running tasks that are already outdated, which leads to unnecessarily low evaluation speed.

### Solution
Executors now fetch tasks from the end of the queue instead of the front.
Rotation continues to operate on the front of the queue.

This prevents in-progress tasks from being removed and improves evaluation throughput.