### PR TITLE
Add template safety check to detect malicious chat_template

### DIFF
--- a/affine/database/dao/miners.py
+++ b/affine/database/dao/miners.py
@@ -45,11 +45,12 @@ class MinersDAO(BaseDAO):
         invalid_reason: Optional[str],
         block_number: int,
         first_block: int,
+        template_check_result: Optional[str] = None,
     ) -> Dict[str, Any]:
         """Save or update miner validation state.
-        
+
         Directly updates the record for this UID (no history tracking).
-        
+
         Args:
             uid: Miner UID (0-255)
             hotkey: Miner's SS58 hotkey
@@ -63,7 +64,8 @@ class MinersDAO(BaseDAO):
             invalid_reason: Reason if invalid (null if valid)
             block_number: Current block when this record was updated
             first_block: Block when miner first committed
-            
+            template_check_result: Template check result ("safe", "unsafe:reason", or null)
+
         Returns:
             Saved miner record
         """
@@ -81,8 +83,9 @@ class MinersDAO(BaseDAO):
             'invalid_reason': invalid_reason,
             'block_number': block_number,
             'first_block': first_block,
+            'template_check_result': template_check_result,
         }
-        
+
         return await self.put(item)
     
     async def get_miner_by_uid(

--- a/affine/utils/template_checker.py
+++ b/affine/utils/template_checker.py
@@ -1,0 +1,323 @@
+"""
+Template Safety Checker
+
+Detects malicious chat_template in HuggingFace models that may contain
+benchmark cheating code (e.g., built-in solvers for sudoku, game of 24, etc.)
+"""
+
+import os
+import json
+import asyncio
+import logging
+from typing import Dict, Any, Optional
+from dataclasses import dataclass
+
+import aiohttp
+
+
+logger = logging.getLogger("affine")
+
+
+# Threshold for template length - only reject if exceeds LLM context limit
+# DeepSeek-V3 supports 128K tokens (~400K chars), set conservative limit
+TEMPLATE_LENGTH_REJECT = 100000  # Above this: auto reject (LLM can't process)
+
+
+@dataclass
+class TemplateCheckResult:
+    """Result of template safety check"""
+    safe: bool
+    reason: str
+    template_length: int = 0
+    audit_details: Optional[Dict[str, Any]] = None
+
+
+# LLM audit prompt for chat_template
+TEMPLATE_AUDIT_PROMPT = """You are a security auditor for HuggingFace models. Analyze the following chat_template to detect benchmark cheating code.
+
+## Background
+A chat_template is a Jinja2 template that formats conversation messages into model input. Normal templates only do simple string concatenation and formatting.
+
+## Normal Template Characteristics
+- Only contains message formatting logic (adding role markers, separators)
+- Simple conditionals (e.g., checking for system prompt)
+- Iterates over messages array and concatenates
+- Typically < 2KB in length
+
+## Cheating Characteristics (any of these = malicious)
+1. **Built-in solvers**: Contains solving algorithms for sudoku, game of 24, cryptarithmetic, dyck language, etc.
+2. **Problem detection**: Detects if input is a specific type of benchmark problem
+3. **Answer injection**: Outputs answers directly based on problem type
+4. **Complex algorithms**: Contains backtracking, permutation, brute-force search code
+5. **Excessive complexity**: Many nested loops, recursive logic, complex math operations
+
+## Your Task
+Analyze the chat_template below and determine if it contains cheating code.
+
+## Output Format (strict JSON only)
+```json
+{
+  "is_malicious": true/false,
+  "confidence": 0.0-1.0,
+  "reason": "brief explanation",
+  "detected_issues": ["issue1", "issue2", ...]
+}
+```
+
+## Chat Template to Audit
+```jinja2
+{template}
+```
+
+Output JSON only, no other text."""
+
+
+
+class TemplateChecker:
+    """Check chat_template safety for HuggingFace models"""
+
+    def __init__(
+        self,
+        api_key: Optional[str] = None,
+        api_url: str = "https://llm.chutes.ai/v1/chat/completions",
+        model: str = "deepseek-ai/DeepSeek-V3-0324",
+        hf_token: Optional[str] = None,
+    ):
+        """Initialize template checker.
+
+        Args:
+            api_key: Chutes API key (defaults to CHUTES_API_KEY env var)
+            api_url: LLM API endpoint
+            model: Model to use for auditing
+            hf_token: HuggingFace token (defaults to HF_TOKEN env var)
+        """
+        self.api_key = api_key or os.getenv("CHUTES_API_KEY")
+        self.api_url = api_url
+        self.model = model
+        self.hf_token = hf_token or os.getenv("HF_TOKEN")
+
+    async def check(self, model_id: str, revision: str) -> TemplateCheckResult:
+        """Check model's chat_template for safety.
+
+        Args:
+            model_id: HuggingFace model repo (e.g., "Qwen/Qwen2.5-7B-Instruct")
+            revision: Git commit hash
+
+        Returns:
+            TemplateCheckResult with safety verdict
+        """
+        try:
+            # Step 1: Get chat_template
+            template_info = await self._get_template(model_id, revision)
+            if template_info.get("error"):
+                return TemplateCheckResult(
+                    safe=False,
+                    reason=f"template_fetch_failed:{template_info['error']}",
+                )
+
+            template = template_info["template"]
+            template_length = template_info["length"]
+
+            # Step 2: Check if chat_template exists - required for valid models
+            if template_length == 0:
+                return TemplateCheckResult(
+                    safe=False,
+                    reason="missing_chat_template",
+                    template_length=0,
+                )
+
+            # Step 3: Check if template exceeds LLM context limit
+            if template_length > TEMPLATE_LENGTH_REJECT:
+                return TemplateCheckResult(
+                    safe=False,
+                    reason=f"template_exceeds_context_limit:{template_length}",
+                    template_length=template_length,
+                )
+
+            # Step 4: LLM audit for all templates
+            audit_result = await self._audit_template_with_llm(template)
+
+            if audit_result.get("is_malicious") is True:
+                return TemplateCheckResult(
+                    safe=False,
+                    reason=f"llm_audit_failed:{audit_result.get('reason', 'malicious_content')}",
+                    template_length=template_length,
+                    audit_details=audit_result,
+                )
+
+            if audit_result.get("is_malicious") is False:
+                return TemplateCheckResult(
+                    safe=True,
+                    reason="llm_audit_passed",
+                    template_length=template_length,
+                    audit_details=audit_result,
+                )
+
+            # LLM audit inconclusive (no API key, error, etc.) - skip for now
+            return TemplateCheckResult(
+                safe=True,
+                reason=f"llm_audit_skipped:{audit_result.get('error', 'unknown')}",
+                template_length=template_length,
+                audit_details=audit_result,
+            )
+
+        except Exception as e:
+            logger.error(f"Template check failed for {model_id}@{revision}: {e}", exc_info=True)
+            return TemplateCheckResult(
+                safe=False,
+                reason=f"check_error:{str(e)[:100]}",
+            )
+
+    async def _get_template(self, model_id: str, revision: str) -> Dict[str, Any]:
+        """Get chat_template by loading the actual tokenizer.
+
+        This is the most accurate method as it reflects the actual template
+        that will be used during inference, including any custom tokenizer code.
+
+        Args:
+            model_id: HuggingFace model repo
+            revision: Git commit hash
+
+        Returns:
+            Dict with 'template', 'length', and optionally 'error'
+        """
+        try:
+            from transformers import AutoTokenizer
+
+            def _load_tokenizer():
+                return AutoTokenizer.from_pretrained(
+                    model_id,
+                    revision=revision,
+                    token=self.hf_token,
+                    trust_remote_code=True,  # Required for custom tokenizer code
+                )
+
+            tokenizer = await asyncio.to_thread(_load_tokenizer)
+            template = getattr(tokenizer, 'chat_template', None) or ""
+
+            # Handle list type (multiple templates)
+            if isinstance(template, list):
+                all_templates = [t.get("template", "") for t in template if isinstance(t, dict)]
+                template_content = "\n---TEMPLATE_SEPARATOR---\n".join(all_templates)
+                template_length = sum(len(t) for t in all_templates)
+            else:
+                template_content = template
+                template_length = len(template)
+
+            return {
+                "template": template_content,
+                "length": template_length,
+            }
+
+        except Exception as e:
+            return {"template": "", "length": 0, "error": str(e)}
+
+    async def _audit_template_with_llm(self, template: str) -> Dict[str, Any]:
+        """Audit chat_template using LLM.
+
+        Args:
+            template: Chat template content
+
+        Returns:
+            Dict with audit result
+        """
+        if not self.api_key:
+            logger.warning("No API key configured for LLM audit")
+            return {"is_malicious": None, "error": "no_api_key"}
+
+        # Truncate if too long
+        if len(template) > 50000:
+            template = template[:25000] + "\n...[TRUNCATED]...\n" + template[-25000:]
+
+        prompt = TEMPLATE_AUDIT_PROMPT.replace("{template}", template)
+
+        return await self._call_llm(prompt)
+
+    async def _call_llm(self, prompt: str) -> Dict[str, Any]:
+        """Call LLM API for audit.
+
+        Args:
+            prompt: Audit prompt
+
+        Returns:
+            Dict with audit result
+        """
+        try:
+            async with aiohttp.ClientSession() as session:
+                async with session.post(
+                    self.api_url,
+                    headers={
+                        "Authorization": f"Bearer {self.api_key}",
+                        "Content-Type": "application/json",
+                    },
+                    json={
+                        "model": self.model,
+                        "messages": [{"role": "user", "content": prompt}],
+                        "max_tokens": 1024,
+                        "temperature": 0,
+                    },
+                    timeout=aiohttp.ClientTimeout(total=120),
+                ) as response:
+                    result = await response.json()
+
+                    if "error" in result:
+                        return {"is_malicious": None, "error": result["error"]}
+
+                    content = result["choices"][0]["message"]["content"]
+
+                    # Parse JSON from response
+                    return self._parse_llm_response(content)
+
+        except Exception as e:
+            logger.error(f"LLM API call failed: {e}")
+            return {"is_malicious": None, "error": str(e)}
+
+    def _parse_llm_response(self, content: str) -> Dict[str, Any]:
+        """Parse LLM response to extract JSON.
+
+        Args:
+            content: LLM response content
+
+        Returns:
+            Parsed JSON dict
+        """
+        try:
+            # Try to extract JSON from markdown code block
+            if "```json" in content:
+                content = content.split("```json")[1].split("```")[0]
+            elif "```" in content:
+                content = content.split("```")[1].split("```")[0]
+
+            return json.loads(content.strip())
+        except Exception as e:
+            logger.warning(f"Failed to parse LLM response: {e}")
+            return {
+                "is_malicious": None,
+                "error": "parse_failed",
+                "raw_response": content[:500],
+            }
+
+
+# Convenience function for external use
+async def check_template_safety(model_id: str, revision: str) -> Dict[str, Any]:
+    """Check if a model's chat_template is safe.
+
+    This is the main entry point for template safety checking.
+
+    Args:
+        model_id: HuggingFace model repo (e.g., "Qwen/Qwen2.5-7B-Instruct")
+        revision: Git commit hash
+
+    Returns:
+        Dict with 'safe' boolean and 'reason' string
+    """
+    checker = TemplateChecker()
+    result = await checker.check(model_id, revision)
+
+    return {
+        "safe": result.safe,
+        "reason": result.reason,
+        "template_length": result.template_length,
+        "has_custom_tokenizer": result.has_custom_tokenizer,
+        "audit_details": result.audit_details,
+    }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ dependencies = [
     "orjson",
     "aiofiles",
     "huggingface_hub",
+    "transformers",
     "datasets",
     "aiobotocore>=2.23.0",
     "botocore>=1.38.27",

--- a/uv.lock
+++ b/uv.lock
@@ -57,7 +57,7 @@ requires-dist = [
     { name = "aiofiles" },
     { name = "aiohttp", specifier = ">=3.10.11" },
     { name = "alive-progress", specifier = ">=3.0.0" },
-    { name = "basilica-sdk", specifier = ">=0.10.0" },
+    { name = "basilica-sdk", specifier = ">=0.11.0" },
     { name = "bittensor" },
     { name = "bittensor-cli" },
     { name = "boto3", specifier = ">=1.34" },
@@ -386,13 +386,13 @@ wheels = [
 
 [[package]]
 name = "basilica-sdk"
-version = "0.10.0"
+version = "0.11.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/c5/25/279d34ba963efd5a1bb5214300441beee8ec7071beae60f12bbf2a735af6/basilica_sdk-0.10.0.tar.gz", hash = "sha256:a46d3cf8cef505b610b7a6198695d0520afd9e58b6cef9fdc839c5ae5a6ed07b", size = 1496331, upload-time = "2025-12-19T17:30:56.048Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/3a/50/41e17245d93a0c1f4635cd5ddbde4a20b93e3d40de7b5b24bd95d7ec4015/basilica_sdk-0.11.0.tar.gz", hash = "sha256:bb31f93257a6f2cf756bb1eb2090bb72f888892cfd09e3cf52e664ccbc8bdc7e", size = 1607516, upload-time = "2025-12-31T11:01:33.35Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/96/5e/326f03523a3e128e3b613fcb31cec2a7f6bcc4be9dcb332987c70f3880fc/basilica_sdk-0.10.0-cp310-abi3-macosx_10_12_x86_64.whl", hash = "sha256:6da37c686b948ec282afae43a46fed45ab7441743c947da617c66407b1eb1973", size = 2881111, upload-time = "2025-12-19T17:30:51.324Z" },
-    { url = "https://files.pythonhosted.org/packages/2a/78/1683032472b2b41e3240da851b317e3482ac3d9470a556ff01337ff466e8/basilica_sdk-0.10.0-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:0ecf486d777114410ecaa761971b94bf3e443f674eade3cbce97b400247fe4e5", size = 2796934, upload-time = "2025-12-19T17:30:52.84Z" },
-    { url = "https://files.pythonhosted.org/packages/31/fb/eaed968d0dac8c288ee70d1f3c6464c6fa9367d03d37e54dedb8e48db632/basilica_sdk-0.10.0-cp310-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9dd80c7edb34b8e862facc24a73e717dbf874510c5127dec3bc95209290070e0", size = 3892800, upload-time = "2025-12-19T17:30:54.252Z" },
+    { url = "https://files.pythonhosted.org/packages/66/07/3204788eaf98cd8916215209a27ec5e182445f92c48adffb3b87402e8a3d/basilica_sdk-0.11.0-cp310-abi3-macosx_10_12_x86_64.whl", hash = "sha256:ca7c9525299d6adbaea732963dd74d90a4a01f40991799c1b5e933d3fab3749f", size = 3308474, upload-time = "2025-12-31T11:01:26.947Z" },
+    { url = "https://files.pythonhosted.org/packages/89/24/6ae74f5372616155f609a4bd2fcb72f80f87692c14fc2c0e78c9a3ae80e7/basilica_sdk-0.11.0-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:c278eedca6f71df869a8414382894e1dbe14fc0221c0cefcdcd453644c8954cf", size = 3121257, upload-time = "2025-12-31T11:01:28.989Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/ac/1a67cd149e77487d0adf4662ecbab2dfd159635d98eb3785e47495c2bc94/basilica_sdk-0.11.0-cp310-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f51bb404ced4f9bb7268777084c31fafed04b874de7fe490051e9c63c5b13fab", size = 3878391, upload-time = "2025-12-31T11:01:31.301Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Add template safety checker to detect benchmark cheating code in chat_template
- Use LLM (DeepSeek-V3) to audit templates for malicious patterns (sudoku solver, game of 24, etc.)
- Load actual template via `AutoTokenizer` for accuracy (supports both tokenizer_config.json and chat_template.jinja)
- Cache `template_check_result` in database to avoid repeated LLM calls
- Skip template check for uid 0

## Test plan
- [x] Run `af servers monitor` and verify template checks execute
- [ ] Verify malicious templates are detected and cached as `unsafe:reason`
- [x] Verify safe templates are cached as `safe` and skipped on subsequent runs
- [x] Verify uid 0 is exempted from template checks