### PR TITLE
fix: deliver SCORER_INTERVAL_MINUTES to scorer and align default to 60

### DIFF
--- a/affine/src/scorer/stage3_subset.py
+++ b/affine/src/scorer/stage3_subset.py
@@ -173,7 +173,7 @@ class Stage3SubsetScorer:
             return rating
 
         import os
-        interval_minutes = int(os.getenv("SCORER_INTERVAL_MINUTES", "30"))
+        interval_minutes = int(os.getenv("SCORER_INTERVAL_MINUTES", "60"))
         interval = interval_minutes * 60
         missed_rounds = elapsed / interval
 

--- a/compose/docker-compose.backend.yml
+++ b/compose/docker-compose.backend.yml
@@ -119,6 +119,8 @@ services:
       - API_URL=http://api:8000/api/v1
       - SCORER_SAVE_TO_DB=true
       - SERVICE_MODE=true
+    env_file:
+      - .env
     depends_on:
       api:
         condition: service_healthy

--- a/docs/AgentSkill.md
+++ b/docs/AgentSkill.md
@@ -918,7 +918,7 @@ Liveweb-arena uses a **plugin architecture** — each plugin provides templates,
 | `NETUID` | Validator | Subnet ID (default: 120) |
 | `WEIGHT_SET_INTERVAL_BLOCKS` | Validator | Blocks between weight submissions (default: 180) |
 | `SERVICE_MODE` | Validator/Scorer | Continuous operation (`true`) |
-| `SCORER_INTERVAL_MINUTES` | Scorer | Minutes between scoring runs in service mode (default: 30) |
+| `SCORER_INTERVAL_MINUTES` | Scorer | Minutes between scoring runs in service mode (default: 60) |
 | `SCORER_SAVE_TO_DB` | Scorer | Enable database saving (default: false) |
 
 ---

--- a/skill/SKILL.md
+++ b/skill/SKILL.md
@@ -877,7 +877,7 @@ Liveweb-arena uses a **plugin architecture** — each plugin provides templates,
 | `NETUID` | Validator | Subnet ID (default: 120) |
 | `WEIGHT_SET_INTERVAL_BLOCKS` | Validator | Blocks between weight submissions (default: 180) |
 | `SERVICE_MODE` | Validator/Scorer | Continuous operation (`true`) |
-| `SCORER_INTERVAL_MINUTES` | Scorer | Minutes between scoring runs in service mode (default: 30) |
+| `SCORER_INTERVAL_MINUTES` | Scorer | Minutes between scoring runs in service mode (default: 60) |
 | `SCORER_SAVE_TO_DB` | Scorer | Enable database saving (default: false) |
 
 ---


### PR DESCRIPTION
## Summary

Fixes ELO absence-decay misfiring on consecutive-round participation, which was resetting miners' ratings back to `BASE_RATING` every round.

- `compose/docker-compose.backend.yml`: add `env_file: .env` to the scorer service so `SCORER_INTERVAL_MINUTES` from `.env` actually reaches the container.
- `affine/src/scorer/stage3_subset.py`: align the env-var default from `"30"` to `"60"` to match `main.py`'s service loop. Docs updated accordingly.