### PR TITLE
fix: use log-space computation in geometric_mean to prevent float underflow

### DIFF
--- a/affine/src/scorer/utils.py
+++ b/affine/src/scorer/utils.py
@@ -150,11 +150,12 @@ def geometric_mean(values: List[float], epsilon: float = 0.0) -> float:
     if any(v <= 0 for v in values):
         return 0.0
 
-    product = 1.0
-    for v in values:
-        product *= v
-
-    return product ** (1.0 / n)
+    # Use log-space computation to avoid float underflow with many small values
+    try:
+        log_mean = sum(math.log(v) for v in values) / n
+        return math.exp(log_mean)
+    except (ValueError, OverflowError):
+        return 0.0
 
 
 def calculate_required_score(


### PR DESCRIPTION
## Summary

- Fixes #346 — `geometric_mean` returned `0.0` incorrectly when iterative multiplication of many small positive values underflowed in IEEE 754
- Replaces the product loop with a numerically stable log-space computation: `exp((1/n) * Σ log(vᵢ))`
- Preserves all existing behavior: zero/negative inputs still return `0.0`, empty list returns `0.0`, the smoothed-epsilon path is unchanged

## Root Cause

```python
# Before — underflows to 0.0 for e.g. [1e-200] * 1000
product = 1.0
for v in values:
    product *= v
return product ** (1.0 / n)
```

IEEE 754 doubles underflow to `0.0` when the running product drops below ~5e-324. With 1000 values of `1e-200`, the true product is `1e-200000`, which is far below that floor.

## Fix

```python
# After — numerically stable across full positive float range
try:
    log_mean = sum(math.log(v) for v in values) / n
    return math.exp(log_mean)
except (ValueError, OverflowError):
    return 0.0
```

## Test plan

- [ ] `geometric_mean([2.0, 8.0])` still returns `4.0`
- [ ] `geometric_mean([1e-200] * 1000)` returns `~1e-200` instead of `0.0`
- [ ] `geometric_mean([0.5, 0.0, 0.5])` still returns `0.0`
- [ ] `geometric_mean([])` still returns `0.0`
- [ ] Existing test suite passes (pre-existing import errors in `tests/` are unrelated to this module)

🤖 Generated with [Claude Code](https://claude.com/claude-code)