### PR TITLE
fix: time-based absence decay with accelerated decay for dominated miners

### DIFF
--- a/affine/src/scorer/config.py
+++ b/affine/src/scorer/config.py
@@ -145,36 +145,16 @@ class ScorerConfig:
     """Seniority advantage factor. 0.0 disables seniority bonus."""
 
     ELO_ABSENCE_DECAY_RATE: float = 0.95
-    """Per-round decay rate for miners not participating in scoring.
-
-    Miners that don't participate in a round (incomplete sampling, Pareto-filtered,
-    offline) still retain their weight position based on historical rating, but their
-    rating decays each round. This ensures ranking stability — no sudden weight drops
-    when a miner is temporarily unable to participate.
-
-    Applied as: rating = BASE_RATING + excess * DECAY_RATE^(missed_rounds^POWER)
-
-    Combined with ELO_ABSENCE_DECAY_POWER for accelerating decay:
-    gentle at first, aggressive over time. Guarantees convergence to BASE_RATING.
-
-    With 0.95 rate and 1.4 power at 30-minute intervals:
-    - 1 hour:   retains 87% (gentle)
-    - 3 hours:  retains 53%
-    - 6 hours:  retains 19%
-    - 12 hours: retains  1.3% (nearly gone)
-    - 18 hours: retains  0.05% (gone)
-    """
+    """Per-unit decay rate. Applied as: excess * rate^(units^power)."""
 
     ELO_ABSENCE_DECAY_POWER: float = 1.4
-    """Power exponent for accelerating absence decay.
+    """Power exponent for accelerating decay over time."""
 
-    Makes decay gentle at first but increasingly aggressive over time.
-    The exponent is applied to missed_rounds: decay_rate^(missed_rounds^power).
+    ELO_ABSENCE_DECAY_UNIT: int = 1800
+    """Time unit (seconds) for decay progression. 1800 = 30min → ~12h convergence."""
 
-    power=1.0: constant decay rate (no acceleration, standard exponential)
-    power=1.4: accelerating decay, any rating reaches BASE within ~18 hours
-    power=2.0: very aggressive acceleration
-    """
+    ELO_ABSENCE_DECAY_UNIT_DOMINATED: int = 900
+    """Faster decay unit for Pareto-dominated miners. 900 = 15min → ~6h convergence."""
 
 
     # Database & Storage

--- a/affine/src/scorer/stage3_subset.py
+++ b/affine/src/scorer/stage3_subset.py
@@ -143,25 +143,10 @@ class Stage3SubsetScorer:
             ranks[uid] = prev_rank
         return ranks
 
-    def _apply_absence_decay(self, rating: float, last_scored_at: Optional[int]) -> float:
-        """Apply absence decay based on time since last scored.
-
-        Decays rating toward BASE_RATING proportionally to the number of
-        missed scoring rounds. Miners that haven't been scored recently
-        lose their accumulated rating advantage.
-
-        Args:
-            rating: Current stored rating
-            last_scored_at: Unix timestamp of last scoring, or None if never scored
-
-        Returns:
-            Decayed rating (never below BASE_RATING)
-        """
+    def _apply_absence_decay(
+        self, rating: float, last_scored_at: Optional[int], is_dominated: bool = False,
+    ) -> float:
         if last_scored_at is None:
-            # No timestamp: either a brand new miner or a legacy miner from
-            # before elo_last_scored_at was introduced. Don't decay — the
-            # timestamp will be backfilled in save_results for non-participants,
-            # starting the decay clock from next round.
             return rating
 
         base = self.config.ELO_BASE_RATING
@@ -172,34 +157,27 @@ class Stage3SubsetScorer:
         if elapsed <= 0:
             return rating
 
+        # Grace: 1 scoring interval (no decay for consecutive participation)
         import os
-        interval_minutes = int(os.getenv("SCORER_INTERVAL_MINUTES", "60"))
-        interval = interval_minutes * 60
-        missed_rounds = elapsed / interval
-
-        # Only apply decay after missing 2+ rounds (1 hour+).
-        # This gives buffer for timing jitter and ensures miners that participated
-        # last round (~30min gap) are never decayed.
-        if missed_rounds < 2.0:
+        interval = int(os.getenv("SCORER_INTERVAL_MINUTES", "60")) * 60
+        if elapsed < 2 * interval:
             return rating
 
         excess = rating - base
+
+        # Decay speed: fixed time-unit based, independent of scorer interval.
+        # Normal → 1800s (30min) units → ~12h convergence
+        # Dominated → 900s (15min) units → ~6h convergence
+        decay_unit = (self.config.ELO_ABSENCE_DECAY_UNIT_DOMINATED
+                      if is_dominated else self.config.ELO_ABSENCE_DECAY_UNIT)
+        grace_seconds = 2 * interval
+        decay_elapsed = max(0, elapsed - grace_seconds)
+        effective_units = max(1.0, decay_elapsed / decay_unit + 1.0)
+
         decay_rate = self.config.ELO_ABSENCE_DECAY_RATE
         power = self.config.ELO_ABSENCE_DECAY_POWER
+        decayed = base + excess * (decay_rate ** (effective_units ** power))
 
-        # Offset by grace period so the first effective round = 1.
-        # This ensures the first decay is exactly 5% (one round worth),
-        # then accelerates from there.
-        grace_rounds = 2.0
-        effective_rounds = max(1.0, missed_rounds - grace_rounds + 1.0)
-
-        # Accelerating decay: gentle at first, aggressive over time.
-        # effective_rounds^power makes the exponent grow super-linearly,
-        # guaranteeing convergence to BASE_RATING within ~18 hours.
-        decayed = base + excess * (decay_rate ** (effective_rounds ** power))
-
-        # Snap to BASE_RATING when excess is negligible (< 30 points).
-        # Avoids meaningless tail where rating is near-BASE but not exactly BASE.
         if decayed - base < 30.0:
             decayed = base
 
@@ -230,8 +208,10 @@ class Stage3SubsetScorer:
                 if last_scored_at is not None:
                     last_scored_at = int(last_scored_at)
 
-                # Apply absence decay based on time since last scored
-                current_ratings[uid] = self._apply_absence_decay(stored_rating, last_scored_at)
+                is_dominated = bool(miner.filtered_subsets)
+                current_ratings[uid] = self._apply_absence_decay(
+                    stored_rating, last_scored_at, is_dominated=is_dominated,
+                )
                 current_rounds[uid] = prev.get('elo_rounds_played') or 0
                 submit_block = prev.get('elo_model_submit_block') or current_block
                 model_ages[uid] = max(0, current_block - submit_block)


### PR DESCRIPTION
## Summary

- Decay speed no longer tied to SCORER_INTERVAL_MINUTES. Grace period uses actual interval, decay progression uses fixed time units.
- Normal miners: ~12h convergence to BASE_RATING
- Pareto-dominated miners: ~6h convergence (2x speed)