### PR TITLE
Accelerate sampling pipeline for champion challenge

### DIFF
--- a/affine/database/system_config.json
+++ b/affine/database/system_config.json
@@ -7,10 +7,10 @@
       "min_completeness": 0.85,
       "sampling_config": {
         "dataset_range": [[0, 500000000],[600000000, 800000000]],
-        "sampling_count": 300,
+        "sampling_count": 100,
         "rotation_enabled": true,
-        "rotation_count": 1,
-        "rotation_interval": 1200,
+        "rotation_count": 2,
+        "rotation_interval": 900,
         "scheduling_weight": 3.0
       }
     },
@@ -45,10 +45,10 @@
           "field": "tasks.completed_up_to",
           "range_type": "zero_to_value"
         },
-        "sampling_count": 130,
+        "sampling_count": 50,
         "rotation_enabled": true,
-        "rotation_count": 4,
-        "rotation_interval": 3600,
+        "rotation_count": 1,
+        "rotation_interval": 900,
         "scheduling_weight": 1.0
       }
     },
@@ -58,10 +58,10 @@
       "min_completeness": 0.8,
       "sampling_config": {
         "dataset_range": [[0, 78060000]],
-        "sampling_count": 200,
+        "sampling_count": 100,
         "rotation_enabled": true,
-        "rotation_count": 1,
-        "rotation_interval": 1200,
+        "rotation_count": 2,
+        "rotation_interval": 900,
         "scheduling_weight": 1.0
       }
     },
@@ -84,10 +84,10 @@
       "min_completeness": 0.85,
       "sampling_config": {
         "dataset_range": [[0, 1000000000]],
-        "sampling_count": 200,
+        "sampling_count": 100,
         "rotation_enabled": true,
-        "rotation_count": 1,
-        "rotation_interval": 800,
+        "rotation_count": 2,
+        "rotation_interval": 900,
         "scheduling_weight": 1.0
       }
     },
@@ -97,10 +97,10 @@
       "min_completeness": 0.8,
       "sampling_config": {
         "dataset_range": [[0, 1000000000]],
-        "sampling_count": 200,
+        "sampling_count": 100,
         "rotation_enabled": true,
-        "rotation_count": 1,
-        "rotation_interval": 1200,
+        "rotation_count": 2,
+        "rotation_interval": 900,
         "scheduling_weight": 1.0
       }
     },
@@ -115,10 +115,10 @@
           "field": "completed_up_to",
           "range_type": "zero_to_value"
         },
-        "sampling_count": 80,
+        "sampling_count": 40,
         "rotation_enabled": true,
-        "rotation_count": 3,
-        "rotation_interval": 3600,
+        "rotation_count": 1,
+        "rotation_interval": 900,
         "scheduling_weight": 1.0
       }
     }

--- a/affine/src/monitor/miners_monitor.py
+++ b/affine/src/monitor/miners_monitor.py
@@ -583,6 +583,33 @@ class MinersMonitor:
         
         return miners
     
+    async def _release_terminated_chutes(self, miners: list):
+        """Release chute deployments for miners terminated by champion challenge."""
+        from affine.database.dao.miner_stats import MinerStatsDAO
+        from affine.utils.api_client import delete_chute
+
+        miner_stats_dao = MinerStatsDAO()
+
+        for miner in miners:
+            if not miner.chute_id or miner.chute_status != 'hot':
+                continue
+            if miner.uid == 0 or miner.uid > 1000:
+                continue
+
+            try:
+                state = await miner_stats_dao.get_challenge_state(
+                    miner.hotkey, miner.revision)
+                if state.get('challenge_status') != 'terminated':
+                    continue
+
+                logger.info(
+                    f"[MinersMonitor] Releasing chute for terminated miner "
+                    f"uid={miner.uid} chute_id={miner.chute_id}")
+                await delete_chute(miner.chute_id)
+            except Exception as e:
+                logger.warning(
+                    f"[MinersMonitor] Failed to release chute for uid={miner.uid}: {e}")
+
     async def refresh_miners(self) -> Dict[str, MinerInfo]:
         """Refresh and validate all miners
         
@@ -746,6 +773,9 @@ class MinersMonitor:
                     first_block=miner.block,
                     template_check_result=miner.template_check_result,
                 )
+
+            # Release chutes for terminated miners that still have hot instances
+            await self._release_terminated_chutes(miners)
 
             valid_miners = {m.key(): m for m in miners if m.is_valid}
 

--- a/affine/src/scheduler/sampling_scheduler.py
+++ b/affine/src/scheduler/sampling_scheduler.py
@@ -30,13 +30,12 @@ class PerMinerSamplingScheduler:
     5. Priority-based task selection from sampling list tail
     6. Rate limiting: actual sampling rate is limited to rotation_rate * RATE_MARGIN
        to prevent answer memorization attacks (independent of rotation_enabled)
-    7. Minimum rate guarantee: allowed rate is at least sampling_count/48 per hour
-       to ensure sampling completes within 2 days
+    7. Rate is based on rotation rate only — no minimum guarantee
     """
 
     DEFAULT_SLOTS = 10
     MIN_SLOTS = 10
-    MAX_SLOTS = 16
+    MAX_SLOTS = 50
 
     # Rate limiting: allow actual sampling rate to exceed rotation rate by this margin
     RATE_MARGIN = 1.2
@@ -329,11 +328,7 @@ class PerMinerSamplingScheduler:
         else:
             rotation_rate = 0
 
-        # Minimum rate guarantee: ensure sampling can complete within 48 hours
-        min_rate = sampling_count / 48 if sampling_count > 0 else 0
-
-        # Use the higher of rotation rate and minimum rate
-        allowed_per_hour = max(rotation_rate, min_rate)
+        allowed_per_hour = rotation_rate
 
         # If no valid rate can be calculated, don't limit
         if allowed_per_hour <= 0:

--- a/affine/src/scheduler/sampling_scheduler.py
+++ b/affine/src/scheduler/sampling_scheduler.py
@@ -989,11 +989,11 @@ class SamplingScheduler:
                 pass
     
     async def _rotation_loop(self):
-        """Rotation loop - checks every 5 minutes."""
+        """Rotation loop - checks every 60 seconds."""
         while self._running:
             try:
                 await self._check_and_rotate_all_envs()
-                await asyncio.sleep(300)
+                await asyncio.sleep(60)
             except asyncio.CancelledError:
                 logger.info("Rotation loop cancelled")
                 break

--- a/affine/src/scheduler/slots_adjuster.py
+++ b/affine/src/scheduler/slots_adjuster.py
@@ -32,7 +32,7 @@ class MinerSlotsAdjuster:
     
     DEFAULT_SLOTS = 10
     MIN_SLOTS = 10
-    MAX_SLOTS = 16
+    MAX_SLOTS = 50
     ADJUSTMENT_INTERVAL = 21600  # 6 hours in seconds
     MIN_SAMPLES_FOR_ADJUSTMENT = 50
     HIGH_SUCCESS_THRESHOLD = 0.80

--- a/affine/utils/api_client.py
+++ b/affine/utils/api_client.py
@@ -324,6 +324,36 @@ class APIClient:
             logger.debug(f"Failed to fetch chute {chute_id}: {e}")
             return None
 
+    async def delete_chute(self, chute_id: str) -> bool:
+        """Delete a chute deployment via Chutes API.
+
+        Args:
+            chute_id: Chute deployment ID
+
+        Returns:
+            True if deleted successfully, False otherwise
+        """
+        url = f"https://api.chutes.ai/chutes/{chute_id}"
+        token = os.getenv("CHUTES_API_KEY", "")
+
+        if not token:
+            logger.warning("CHUTES_API_KEY not configured, cannot delete chute")
+            return False
+
+        headers = {"Authorization": token}
+
+        try:
+            async with self._session.delete(url, headers=headers, timeout=aiohttp.ClientTimeout(total=10)) as resp:
+                if resp.status == 200:
+                    logger.info(f"Deleted chute {chute_id}")
+                    return True
+                body = await resp.text()
+                logger.warning(f"Failed to delete chute {chute_id}: HTTP {resp.status} {body[:200]}")
+                return False
+        except Exception as e:
+            logger.error(f"Error deleting chute {chute_id}: {e}")
+            return False
+
 
 def cli_api_client(base_url: Optional[str] = None) -> CLIAPIClient:
     """Create CLI-specific API client context manager.
@@ -349,6 +379,12 @@ async def get_chute_info(chute_id: str) -> Optional[Dict]:
     """
     async with cli_api_client() as client:
         return await client.get_chute_info(chute_id)
+
+
+async def delete_chute(chute_id: str) -> bool:
+    """Delete a chute deployment via Chutes API."""
+    async with cli_api_client() as client:
+        return await client.delete_chute(chute_id)
 
 
 async def create_api_client(base_url: Optional[str] = None) -> APIClient:


### PR DESCRIPTION
## Summary

- Raise sampling slots upper limit from 16 to 50
- Remove 48-hour sampling completion rate guarantee — rate now purely based on rotation rate
- Reduce rotation check interval from 5min to 60s
- Adjust rotation params for ~5-day 10-window completion
- Auto-release chutes for terminated miners via monitor