### PR TITLE
Add not-worse tolerance for challenge, speed up rotation to 3 days

### DIFF
--- a/affine/database/system_config.json
+++ b/affine/database/system_config.json
@@ -10,7 +10,7 @@
         "sampling_count": 100,
         "rotation_enabled": true,
         "rotation_count": 2,
-        "rotation_interval": 900,
+        "rotation_interval": 540,
         "scheduling_weight": 3.0
       }
     },
@@ -48,7 +48,7 @@
         "sampling_count": 50,
         "rotation_enabled": true,
         "rotation_count": 1,
-        "rotation_interval": 900,
+        "rotation_interval": 540,
         "scheduling_weight": 1.0
       }
     },
@@ -61,7 +61,7 @@
         "sampling_count": 100,
         "rotation_enabled": true,
         "rotation_count": 2,
-        "rotation_interval": 900,
+        "rotation_interval": 540,
         "scheduling_weight": 1.0
       }
     },
@@ -87,7 +87,7 @@
         "sampling_count": 100,
         "rotation_enabled": true,
         "rotation_count": 2,
-        "rotation_interval": 900,
+        "rotation_interval": 540,
         "scheduling_weight": 1.0
       }
     },
@@ -100,7 +100,7 @@
         "sampling_count": 100,
         "rotation_enabled": true,
         "rotation_count": 2,
-        "rotation_interval": 900,
+        "rotation_interval": 540,
         "scheduling_weight": 1.0
       }
     },
@@ -118,7 +118,7 @@
         "sampling_count": 40,
         "rotation_enabled": true,
         "rotation_count": 1,
-        "rotation_interval": 900,
+        "rotation_interval": 540,
         "scheduling_weight": 1.0
       }
     }

--- a/affine/src/scorer/config.py
+++ b/affine/src/scorer/config.py
@@ -30,11 +30,20 @@ class ScorerConfig:
 
     WIN_MIN_DOMINANT_ENVS: int = 3
     """Champion challenge: minimum environments where the challenger must
-    exceed by PARETO_MARGIN. Remaining environments must not be worse
-    (score_b >= score_a).
+    exceed by margin. Remaining environments must not be worse than
+    score_a - WIN_NOT_WORSE_TOLERANCE.
 
     0 = strict: must exceed in ALL environments.
     N > 0 = partial: exceed in at least N, not lose in any other.
+    """
+
+    WIN_NOT_WORSE_TOLERANCE: float = 0.015
+    """Tolerance ratio for "not worse" check in champion challenge.
+
+    Challenger is considered "not worse" in an env if
+    score_b >= score_a * (1 - tolerance). E.g., if champion scores
+    0.45 and tolerance is 0.015, challenger needs >= 0.45 * 0.985 = 0.443.
+    Accounts for random noise in non-dominant environments.
     """
 
     PARETO_MIN_DOMINANT_ENVS: int = 0
@@ -84,10 +93,10 @@ class ScorerConfig:
     take the crown. CP=10 means 10×window_size common tasks
     (e.g., window=100 → 1000 tasks)."""
 
-    CHAMPION_TERMINATION_TOTAL_LOSSES: int = 3
+    CHAMPION_TERMINATION_TOTAL_LOSSES: int = 4
     """Accumulated post-warmup losses → terminate sampling."""
 
-    CHAMPION_TERMINATION_CONSECUTIVE_LOSSES: int = 2
+    CHAMPION_TERMINATION_CONSECUTIVE_LOSSES: int = 3
     """Consecutive post-warmup losses → terminate sampling."""
 
     PARETO_MIN_WINDOWS: int = 3

--- a/affine/src/scorer/main.py
+++ b/affine/src/scorer/main.py
@@ -181,6 +181,13 @@ async def run_scoring_once(save_to_db: bool, range_type: str = "scoring"):
             score_snapshots_dao = ScoreSnapshotsDAO()
             scores_dao = ScoresDAO()
 
+            # Read previous scores BEFORE saving this round, so we can
+            # copy last known scores for terminated miners not in scoring_data.
+            prev_scores = await scores_dao.get_latest_scores(limit=256)
+            prev_by_hk = {}
+            for s in prev_scores.get('scores', []):
+                prev_by_hk[s.get('miner_hotkey', '')] = s
+
             await scorer.save_results(
                 result=result,
                 score_snapshots_dao=score_snapshots_dao,
@@ -190,6 +197,42 @@ async def run_scoring_once(save_to_db: bool, range_type: str = "scoring"):
                 block_number=block_number,
             )
             logger.info("Results saved successfully")
+
+            # Write terminated miners not in scoring_data to scores table
+            # so they remain visible in af get-rank.
+            result_hotkeys = {m.hotkey for m in result.miners.values()}
+
+            all_miners = await miner_stats_dao.get_all_historical_miners()
+            terminated_extra = 0
+            for ms in all_miners:
+                hk = ms.get('hotkey', '')
+                if (ms.get('challenge_status') == 'terminated'
+                        and hk not in result_hotkeys):
+                    prev = prev_by_hk.get(hk, {})
+                    await scores_dao.save_score(
+                        block_number=block_number,
+                        miner_hotkey=hk,
+                        uid=prev.get('uid', ms.get('uid', 0)),
+                        model_revision=ms.get('revision', ''),
+                        model=prev.get('model', ms.get('model_repo', '')),
+                        first_block=prev.get('first_block', 0),
+                        overall_score=0.0,
+                        average_score=prev.get('average_score', 0.0),
+                        scores_by_env=prev.get('scores_by_env', {}),
+                        total_samples=prev.get('total_samples', 0),
+                        challenge_info={
+                            'status': 'terminated',
+                            'termination_reason': ms.get('termination_reason', ''),
+                            'checkpoints_passed': ms.get('challenge_checkpoints_passed', 0),
+                            'total_losses': ms.get('challenge_total_losses', 0),
+                            'consecutive_losses': ms.get('challenge_consecutive_losses', 0),
+                            'consecutive_wins': 0,
+                            'is_champion': False,
+                        },
+                    )
+                    terminated_extra += 1
+            if terminated_extra:
+                logger.info(f"Wrote {terminated_extra} terminated miners to scores (not in scoring_data)")
 
         elapsed = time.time() - start_time
         logger.info(f"Scoring completed in {elapsed:.2f}s")

--- a/affine/src/scorer/stage2_pareto.py
+++ b/affine/src/scorer/stage2_pareto.py
@@ -51,8 +51,10 @@ class Stage2ParetoFilter:
             else:
                 t = 1.0
             margin = m_start + t * (m_end - m_start)
+            not_worse_tol = self.config.WIN_NOT_WORSE_TOLERANCE
         else:
             margin = self.config.PARETO_MARGIN
+            not_worse_tol = 1e-9  # No tolerance for pairwise
         b_dominant = 0   # envs where B beats A by margin
         b_not_worse = 0  # envs where B >= A (no margin required)
         a_dominant = 0
@@ -81,8 +83,8 @@ class Stage2ParetoFilter:
                 b_dominant += 1
                 b_not_worse += 1
                 winner = "B"
-            elif score_b >= score_a - 1e-9:
-                # B is not worse (at least tied)
+            elif score_b >= score_a * (1 - not_worse_tol) - 1e-9:
+                # B is not worse (within tolerance of champion's score)
                 b_not_worse += 1
                 a_not_worse += 1
                 winner = "A"  # incumbent advantage: tie goes to A

--- a/tests/test_e2e_realistic.py
+++ b/tests/test_e2e_realistic.py
@@ -179,6 +179,8 @@ class TestFullLifecycle:
         """Challenge counters survive round-trip through DB mocks."""
         config = ScorerConfig()
         config.CHAMPION_WARMUP_CHECKPOINTS = 0
+        config.CHAMPION_TERMINATION_CONSECUTIVE_LOSSES = 2
+        config.CHAMPION_TERMINATION_TOTAL_LOSSES = 2
         scorer = Scorer(config)
         db = MockedDB()
 
@@ -196,7 +198,7 @@ class TestFullLifecycle:
         assert s1['challenge_total_losses'] == 1
         assert s1['challenge_status'] == 'sampling'
 
-        # Round 2: more data, checkpoint 2 fires, 2 consecutive losses → terminated
+        # Round 2: more data, 2 consecutive losses → terminated
         await run_round(scorer, db, miners, n_tasks=2 * WINDOW, block_number=1100)
         s2 = db.challenge_states['hk_weak']
         assert s2['challenge_checkpoints_passed'] == 2


### PR DESCRIPTION
## Summary

- Challenger is considered "not worse" in non-dominant envs if score >= champion score * 98.5%, tolerating slight random noise
- Rotation interval reduced to 540s for ~3-day 10-window completion