### PR TITLE
Detailed termination reasons and complete config export

### DIFF
--- a/affine/src/miner/commands.py
+++ b/affine/src/miner/commands.py
@@ -513,12 +513,7 @@ async def get_miner_command(uid: int):
                 print(f"  Consecutive losses:  {cs.get('challenge_consecutive_losses', 0)}")
                 if status == 'terminated':
                     reason = cs.get('termination_reason', 'unknown')
-                    if reason == 'challenge_loss':
-                        print(f"  Termination reason:  Challenge loss (accumulated too many losses vs champion)")
-                    elif reason == 'pairwise':
-                        print(f"  Termination reason:  Pairwise filter (dominated by an older miner)")
-                    else:
-                        print(f"  Termination reason:  {reason}")
+                    print(f"  Termination reason:  {reason}")
 
             if stats_data and stats_data.get('sampling_stats'):
                 print("\n" + "="*80)

--- a/affine/src/scorer/champion_challenge.py
+++ b/affine/src/scorer/champion_challenge.py
@@ -178,7 +178,9 @@ class ChampionChallenge:
                     min_dominant_envs=0)  # strict: ALL envs
                 if cmp.b_dominates_a:  # champion actively beats miner in every env
                     m.challenge_status = 'terminated'
-                    m.termination_reason = 'pairwise'
+                    detail = ','.join(f'{e}:{d.get("a_score",0):.3f}<{d.get("b_score",0):.3f}'
+                                     for e, d in cmp.env_comparisons.items() if d.get("winner"))
+                    m.termination_reason = f'dominated_by_champion:{champion_miner.hotkey[:10]}|{detail}'
                     logger.info(f"CHAMPION DOMINANCE: UID {uid} terminated "
                                 f"(champion exceeds by margin in all envs)")
 
@@ -205,11 +207,15 @@ class ChampionChallenge:
                     min_dominant_envs=self.config.PARETO_MIN_DOMINANT_ENVS)
                 if cmp.a_dominates_b:
                     miner_b.challenge_status = 'terminated'
-                    miner_b.termination_reason = 'pairwise'
+                    detail = ','.join(f'{e}:{d.get("b_score",0):.3f}<{d.get("a_score",0):.3f}'
+                                     for e, d in cmp.env_comparisons.items() if d.get("winner"))
+                    miner_b.termination_reason = f'dominated_by:{miner_a.hotkey[:10]}|{detail}'
                     logger.info(f"PAIRWISE: UID {uid_b} terminated by older UID {uid_a}")
                 elif cmp.b_dominates_a:
                     miner_a.challenge_status = 'terminated'
-                    miner_a.termination_reason = 'pairwise'
+                    detail = ','.join(f'{e}:{d.get("a_score",0):.3f}<{d.get("b_score",0):.3f}'
+                                     for e, d in cmp.env_comparisons.items() if d.get("winner"))
+                    miner_a.termination_reason = f'dominated_by:{miner_b.hotkey[:10]}|{detail}'
                     logger.info(f"PAIRWISE: UID {uid_a} terminated by newer UID {uid_b}")
                     break
 
@@ -268,10 +274,14 @@ class ChampionChallenge:
                 miner.challenge_total_losses += 1
                 miner.challenge_consecutive_losses += 1
                 miner.challenge_consecutive_wins = 0
+                # Always record latest loss detail so termination has context
+                detail = ','.join(
+                    f'{e}:{d.get("b_score",0):.3f}vs{d.get("a_score",0):.3f}{"✗" if d.get("winner")=="A" else "✓"}'
+                    for e, d in cmp.env_comparisons.items() if d.get("winner"))
+                miner.termination_reason = f'lost_to_champion:{champion_miner.hotkey[:10]}|{detail}'
                 # At dethrone CP or beyond, losing is decisive — terminate immediately
                 if cp >= dethrone_cp:
                     miner.challenge_status = 'terminated'
-                    miner.termination_reason = 'challenge_loss'
                     logger.info(f"UID {uid} fails at dethrone CP {cp} → terminated")
                 else:
                     logger.info(f"UID {uid} fails at CP {cp} "
@@ -319,7 +329,7 @@ class ChampionChallenge:
             if (miner.challenge_total_losses >= M
                     or miner.challenge_consecutive_losses >= M_con):
                 miner.challenge_status = 'terminated'
-                miner.termination_reason = 'challenge_loss'
+                # termination_reason already set by _run_challenges with last loss detail
 
     # ── Phase 6: Assign weights ──────────────────────────────────────────────
 

--- a/affine/src/scorer/config.py
+++ b/affine/src/scorer/config.py
@@ -116,13 +116,15 @@ class ScorerConfig:
             'win_margin_start': cls.WIN_MARGIN_START,
             'win_margin_end': cls.WIN_MARGIN_END,
             'win_min_dominant_envs': cls.WIN_MIN_DOMINANT_ENVS,
+            'win_not_worse_tolerance': cls.WIN_NOT_WORSE_TOLERANCE,
+            'pareto_margin': cls.PARETO_MARGIN,
             'pareto_min_dominant_envs': cls.PARETO_MIN_DOMINANT_ENVS,
+            'pareto_min_windows': cls.PARETO_MIN_WINDOWS,
             'geometric_mean_epsilon': cls.GEOMETRIC_MEAN_EPSILON,
             'champion_warmup_checkpoints': cls.CHAMPION_WARMUP_CHECKPOINTS,
             'champion_dethrone_min_checkpoint': cls.CHAMPION_DETHRONE_MIN_CHECKPOINT,
             'champion_termination_total_losses': cls.CHAMPION_TERMINATION_TOTAL_LOSSES,
             'champion_termination_consecutive_losses': cls.CHAMPION_TERMINATION_CONSECUTIVE_LOSSES,
-            'pareto_min_windows': cls.PARETO_MIN_WINDOWS,
         }
 
     @classmethod

--- a/affine/src/scorer/models.py
+++ b/affine/src/scorer/models.py
@@ -41,7 +41,7 @@ class MinerData:
     challenge_consecutive_losses: int = 0
     challenge_checkpoints_passed: int = 0
     challenge_status: str = 'sampling'  # 'sampling' | 'terminated'
-    termination_reason: str = ''        # '' | 'challenge_loss' | 'pairwise'
+    termination_reason: str = ''        # Detailed reason with hotkey and per-env scores
     is_champion: bool = False
 
     # Final weight (set by champion challenge: 1.0 for champion, 0.0 for others)

--- a/tests/test_e2e_realistic.py
+++ b/tests/test_e2e_realistic.py
@@ -512,7 +512,8 @@ class TestProductionSimulation:
         # After 6 rounds: hk_weak (0.30) terminated — either by challenge
         # losses or pairwise filter (dominated by stronger miners in all envs)
         assert db.challenge_states['hk_weak']['challenge_status'] == 'terminated'
-        assert db.challenge_states['hk_weak']['termination_reason'] in ('challenge_loss', 'pairwise')
+        reason = db.challenge_states['hk_weak']['termination_reason']
+        assert 'dominated_by' in reason or 'lost_to_champion' in reason
         # Champion unchanged (nobody beats alpha)
         assert db.champion['hotkey'] == 'hk_alpha'
 
@@ -541,7 +542,8 @@ class TestProductionSimulation:
         # Copycat terminated — either by pairwise (identical scores to an older
         # miner) or by challenge losses (can't exceed champion by margin)
         assert db.challenge_states['hk_copycat']['challenge_status'] == 'terminated'
-        assert db.challenge_states['hk_copycat']['termination_reason'] in ('pairwise', 'challenge_loss')
+        reason = db.challenge_states['hk_copycat']['termination_reason']
+        assert 'dominated_by' in reason or 'lost_to_champion' in reason
         # Champion still hk_strong
         assert db.champion['hotkey'] == 'hk_strong'
 


### PR DESCRIPTION
## Summary

- Export pareto_margin and win_not_worse_tolerance in score snapshot config
- Termination reason now includes opponent hotkey and per-env score details
- Remove redundant reason formatting in af get-miner