### PR TITLE
Fix: Prevent geometric mean underflow for small values

### DIFF
--- a/affine/src/scorer/utils.py
+++ b/affine/src/scorer/utils.py
@@ -2,6 +2,7 @@
 Scorer Utility Functions
 """
 
+import math
 from typing import List
 
 
@@ -10,7 +11,7 @@ def geometric_mean(values: List[float], epsilon: float = 0.0) -> float:
 
     When epsilon > 0, applies smoothing to prevent zero scores from
     collapsing the result to 0:
-        GM_smoothed = ((v1+e) * (v2+e) * ... * (vn+e))^(1/n) - e
+        GM_smoothed = exp((log(v1+e) + log(v2+e) + ... + log(vn+e)) / n) - e
 
     Args:
         values: list of numeric values (typically in [0, 1])
@@ -21,17 +22,25 @@ def geometric_mean(values: List[float], epsilon: float = 0.0) -> float:
     """
     if not values:
         return 0.0
+
     n = len(values)
 
     if epsilon > 0:
-        product = 1.0
-        for v in values:
-            product *= (v + epsilon)
-        return max(product ** (1.0 / n) - epsilon, 0.0)
+        adjusted_values = [v + epsilon for v in values]
+        if any(v <= 0 for v in adjusted_values):
+            return 0.0
+
+        try:
+            log_mean = sum(math.log(v) for v in adjusted_values) / n
+            return max(math.exp(log_mean) - epsilon, 0.0)
+        except (ValueError, OverflowError):
+            return 0.0
 
     if any(v <= 0 for v in values):
         return 0.0
-    product = 1.0
-    for v in values:
-        product *= v
-    return product ** (1.0 / n)
+
+    try:
+        log_mean = sum(math.log(v) for v in values) / n
+        return math.exp(log_mean)
+    except (ValueError, OverflowError):
+        return 0.0


### PR DESCRIPTION
Problem

The current implementation of geometric_mean computes the product of all values before taking the nth root. For many small positive values (e.g. [1e-200] * 1000), this causes floating-point underflow to 0.0, producing incorrect results.

Root Cause

Iterative multiplication underflows in IEEE 754 double precision:

product *= v
Solution

Replaced the product-based computation with a numerically stable log-space formulation:

exp(sum(log(v)) / n)

This avoids underflow while preserving mathematical correctness.

Impact
Fixes incorrect outputs for small-value inputs
Improves numerical stability of scoring functions
No breaking changes
Example

Before:

geometric_mean([1e-200] * 1000) → 0.0

After:

→ ~1e-200