### PR TITLE
Enforce MIN_SLOTS and faster slot growth

### DIFF
--- a/affine/database/dao/miner_stats.py
+++ b/affine/database/dao/miner_stats.py
@@ -98,7 +98,7 @@ class MinerStatsDAO(BaseDAO):
                 'is_currently_online': is_online,
                 'sampling_stats': {},
                 'env_stats': {},
-                'sampling_slots': 6,  # Default slots
+                'sampling_slots': 15,  # Default slots (1.5x MIN_SLOTS)
                 'slots_last_adjusted_at': 0  # Never adjusted
             }
         
@@ -197,7 +197,7 @@ class MinerStatsDAO(BaseDAO):
                 'is_currently_online': True,
                 'sampling_stats': global_stats,
                 'env_stats': env_stats,
-                'sampling_slots': 6,  # Default slots
+                'sampling_slots': 15,  # Default slots (1.5x MIN_SLOTS)
                 'slots_last_adjusted_at': 0  # Never adjusted
             }
             await self.put(updated_item)

--- a/affine/src/scheduler/slots_adjuster.py
+++ b/affine/src/scheduler/slots_adjuster.py
@@ -180,12 +180,16 @@ class MinerSlotsAdjuster:
         if success_rate is None:
             success_rate = successful_samples / total_samples if total_samples > 0 else 0
         
+        # Enforce MIN_SLOTS for miners with stale low values
+        if current_slots < self.MIN_SLOTS:
+            current_slots = self.MIN_SLOTS
+
         # Determine adjustment
         new_slots = current_slots
         action = "unchanged"
-        
+
         if success_rate >= self.HIGH_SUCCESS_THRESHOLD:
-            new_slots = min(current_slots + 1, self.MAX_SLOTS)
+            new_slots = min(current_slots + 3, self.MAX_SLOTS)
             if new_slots > current_slots:
                 action = "increased"
         elif success_rate < self.LOW_SUCCESS_THRESHOLD:


### PR DESCRIPTION
Enforce MIN_SLOTS=10 floor on each adjustment, increase growth step from +1 to +3, set initial slots to 15 for new miners.