### PR TITLE
Show dethrone threshold in af get-rank, tune rotation to 1.2 days

### DIFF
--- a/affine/database/system_config.json
+++ b/affine/database/system_config.json
@@ -10,7 +10,7 @@
         "sampling_count": 80,
         "rotation_enabled": true,
         "rotation_count": 3,
-        "rotation_interval": 680,
+        "rotation_interval": 390,
         "scheduling_weight": 3.0
       }
     },
@@ -26,10 +26,10 @@
           "field": "tasks.completed_up_to",
           "range_type": "zero_to_value"
         },
-        "sampling_count": 50,
+        "sampling_count": 40,
         "rotation_enabled": true,
         "rotation_count": 1,
-        "rotation_interval": 360,
+        "rotation_interval": 260,
         "scheduling_weight": 1.0
       }
     },
@@ -42,7 +42,7 @@
         "sampling_count": 80,
         "rotation_enabled": true,
         "rotation_count": 3,
-        "rotation_interval": 680,
+        "rotation_interval": 390,
         "scheduling_weight": 1.0
       }
     },
@@ -68,7 +68,7 @@
         "sampling_count": 80,
         "rotation_enabled": true,
         "rotation_count": 3,
-        "rotation_interval": 680,
+        "rotation_interval": 390,
         "scheduling_weight": 1.0
       }
     },
@@ -81,7 +81,7 @@
         "sampling_count": 80,
         "rotation_enabled": true,
         "rotation_count": 3,
-        "rotation_interval": 680,
+        "rotation_interval": 390,
         "scheduling_weight": 1.0
       }
     },
@@ -99,7 +99,7 @@
         "sampling_count": 40,
         "rotation_enabled": true,
         "rotation_count": 1,
-        "rotation_interval": 450,
+        "rotation_interval": 260,
         "scheduling_weight": 1.0
       }
     }

--- a/affine/src/miner/rank.py
+++ b/affine/src/miner/rank.py
@@ -197,20 +197,10 @@ async def print_rank_table():
         dethrone_cp = scorer_config.get("champion_dethrone_min_checkpoint", 10)
         M = scorer_config.get("champion_termination_total_losses", 3)
         # Dethrone margin: strictest bar applied at CP = dethrone_cp.
-        # Threshold shown in each env column is the score the challenger
-        # must exceed to dethrone the champion in that env.
+        # Shown in legend only — the actual per-cell threshold comes from
+        # the scorer's real common-task computation (dethrone_threshold
+        # field in scores_by_env[env]), which differs per challenger.
         dethrone_margin = scorer_config.get("win_margin_end", 0.03)
-
-        # Champion per-env scores for threshold rendering. Empty if champion
-        # is absent from this snapshot (cold start or champion offline).
-        champion_row = next((m for m in miners if m.is_champion), None)
-        env_dethrone_threshold: Dict[str, float] = {}
-        if champion_row:
-            for env in environments:
-                es = champion_row.scores_by_env.get(env) or {}
-                s = es.get("score")
-                if isinstance(s, (int, float)):
-                    env_dethrone_threshold[env] = s + dethrone_margin
 
         # ── Header ────────────────────────────────────────────────────────
         header_parts = ["Hotkey  ", " UID", "Model                    "]
@@ -253,12 +243,13 @@ async def print_rank_table():
         print("=" * table_width, flush=True)
         print(header_line, flush=True)
         # Legend: each env cell is score% / dethrone-threshold% / samples.
-        # Threshold = champion env score + win_margin_end ({margin}%), i.e.
-        # what a challenger must exceed at CP={dethrone_cp} to dethrone.
+        # Threshold is per-challenger: champion's avg on tasks both mined
+        # in common + win_margin_end ({margin}%). What Pareto actually
+        # checks at CP={dethrone_cp}. "—" when no common tasks with champion.
         legend = (
             f"Env cells: score% / dethrone-threshold% / samples "
-            f"(threshold = champion + {dethrone_margin * 100:.1f}%, "
-            f"applied at CP {dethrone_cp})"
+            f"(threshold = champion_on_common + {dethrone_margin * 100:.1f}%, "
+            f"per-challenger, applied at CP {dethrone_cp})"
         )
         print(legend, flush=True)
         print("-" * table_width, flush=True)
@@ -280,10 +271,12 @@ async def print_rank_table():
                     score_percent = env_score * 100
                     if m.is_champion:
                         thresh_str = "★"
-                    elif env in env_dethrone_threshold:
-                        thresh_str = f"{env_dethrone_threshold[env] * 100:.2f}"
                     else:
-                        thresh_str = "—"
+                        thresh = env_data.get("dethrone_threshold")
+                        if isinstance(thresh, (int, float)):
+                            thresh_str = f"{thresh * 100:.2f}"
+                        else:
+                            thresh_str = "—"
                     score_str = f"{score_percent:.2f}/{thresh_str}/{historical}"
                     row_parts.append(f"{score_str:>18}")
                 else:

--- a/affine/src/miner/rank.py
+++ b/affine/src/miner/rank.py
@@ -196,12 +196,27 @@ async def print_rank_table():
 
         dethrone_cp = scorer_config.get("champion_dethrone_min_checkpoint", 10)
         M = scorer_config.get("champion_termination_total_losses", 3)
+        # Dethrone margin: strictest bar applied at CP = dethrone_cp.
+        # Threshold shown in each env column is the score the challenger
+        # must exceed to dethrone the champion in that env.
+        dethrone_margin = scorer_config.get("win_margin_end", 0.03)
+
+        # Champion per-env scores for threshold rendering. Empty if champion
+        # is absent from this snapshot (cold start or champion offline).
+        champion_row = next((m for m in miners if m.is_champion), None)
+        env_dethrone_threshold: Dict[str, float] = {}
+        if champion_row:
+            for env in environments:
+                es = champion_row.scores_by_env.get(env) or {}
+                s = es.get("score")
+                if isinstance(s, (int, float)):
+                    env_dethrone_threshold[env] = s + dethrone_margin
 
         # ── Header ────────────────────────────────────────────────────────
         header_parts = ["Hotkey  ", " UID", "Model                    "]
         for env in environments:
             disp = env_display_name(env, env_configs.get(env, {}))
-            header_parts.append(f"{disp:>14}")
+            header_parts.append(f"{disp:>18}")
         header_parts.extend(["  Status   ", "  CP ", " Challenge "])
         header_line = " | ".join(header_parts)
         table_width = len(header_line)
@@ -237,6 +252,15 @@ async def print_rank_table():
 
         print("=" * table_width, flush=True)
         print(header_line, flush=True)
+        # Legend: each env cell is score% / dethrone-threshold% / samples.
+        # Threshold = champion env score + win_margin_end ({margin}%), i.e.
+        # what a challenger must exceed at CP={dethrone_cp} to dethrone.
+        legend = (
+            f"Env cells: score% / dethrone-threshold% / samples "
+            f"(threshold = champion + {dethrone_margin * 100:.1f}%, "
+            f"applied at CP {dethrone_cp})"
+        )
+        print(legend, flush=True)
         print("-" * table_width, flush=True)
 
         # ── Rows ──────────────────────────────────────────────────────────
@@ -254,10 +278,16 @@ async def print_rank_table():
                     historical = env_data.get("historical_count",
                                               env_data.get("sample_count", 0))
                     score_percent = env_score * 100
-                    score_str = f"{score_percent:.2f}/{historical}"
-                    row_parts.append(f"{score_str:>14}")
+                    if m.is_champion:
+                        thresh_str = "★"
+                    elif env in env_dethrone_threshold:
+                        thresh_str = f"{env_dethrone_threshold[env] * 100:.2f}"
+                    else:
+                        thresh_str = "—"
+                    score_str = f"{score_percent:.2f}/{thresh_str}/{historical}"
+                    row_parts.append(f"{score_str:>18}")
                 else:
-                    row_parts.append(f"{'  -  ':>14}")
+                    row_parts.append(f"{'  -  ':>18}")
 
             # Status / CP / Challenge
             if m.is_champion:

--- a/affine/src/miner/rank.py
+++ b/affine/src/miner/rank.py
@@ -196,17 +196,17 @@ async def print_rank_table():
 
         dethrone_cp = scorer_config.get("champion_dethrone_min_checkpoint", 10)
         M = scorer_config.get("champion_termination_total_losses", 3)
-        # Dethrone margin: strictest bar applied at CP = dethrone_cp.
-        # Shown in legend only — the actual per-cell threshold comes from
-        # the scorer's real common-task computation (dethrone_threshold
-        # field in scores_by_env[env]), which differs per challenger.
+        # Bounds shown in legend only. Actual per-cell thresholds come
+        # from the scorer's real common-task computation (both bounds
+        # stored in scores_by_env[env]), which differs per challenger.
         dethrone_margin = scorer_config.get("win_margin_end", 0.03)
+        not_worse_tol = scorer_config.get("win_not_worse_tolerance", 0.015)
 
         # ── Header ────────────────────────────────────────────────────────
         header_parts = ["Hotkey  ", " UID", "Model                    "]
         for env in environments:
             disp = env_display_name(env, env_configs.get(env, {}))
-            header_parts.append(f"{disp:>18}")
+            header_parts.append(f"{disp:>26}")
         header_parts.extend(["  Status   ", "  CP ", " Challenge "])
         header_line = " | ".join(header_parts)
         table_width = len(header_line)
@@ -242,14 +242,16 @@ async def print_rank_table():
 
         print("=" * table_width, flush=True)
         print(header_line, flush=True)
-        # Legend: each env cell is score% / dethrone-threshold% / samples.
-        # Threshold is per-challenger: champion's avg on tasks both mined
-        # in common + win_margin_end ({margin}%). What Pareto actually
-        # checks at CP={dethrone_cp}. "—" when no common tasks with champion.
+        # Legend: each env cell is score% [lose-below, win-above] / samples.
+        # Both bounds are vs champion on this miner's common tasks.
+        # Lose < champion_on_common×(1−{tol}%); Win > champion_on_common+{margin}%.
+        # Between bounds = tie (not worse, but not dominant).
+        # "★" = this miner is champion; "—" = no common tasks with champion.
         legend = (
-            f"Env cells: score% / dethrone-threshold% / samples "
-            f"(threshold = champion_on_common + {dethrone_margin * 100:.1f}%, "
-            f"per-challenger, applied at CP {dethrone_cp})"
+            f"Env cells: score% [lose-below, win-above] / samples "
+            f"(lose < champ×(1-{not_worse_tol * 100:.1f}%), "
+            f"win > champ+{dethrone_margin * 100:.1f}%, per-challenger; "
+            f"dethrone at CP {dethrone_cp})"
         )
         print(legend, flush=True)
         print("-" * table_width, flush=True)
@@ -270,17 +272,19 @@ async def print_rank_table():
                                               env_data.get("sample_count", 0))
                     score_percent = env_score * 100
                     if m.is_champion:
-                        thresh_str = "★"
+                        bounds_str = "[★]"
                     else:
-                        thresh = env_data.get("dethrone_threshold")
-                        if isinstance(thresh, (int, float)):
-                            thresh_str = f"{thresh * 100:.2f}"
+                        lower = env_data.get("not_worse_threshold")
+                        upper = env_data.get("dethrone_threshold")
+                        if (isinstance(lower, (int, float))
+                                and isinstance(upper, (int, float))):
+                            bounds_str = f"[{lower * 100:.2f},{upper * 100:.2f}]"
                         else:
-                            thresh_str = "—"
-                    score_str = f"{score_percent:.2f}/{thresh_str}/{historical}"
-                    row_parts.append(f"{score_str:>18}")
+                            bounds_str = "[—]"
+                    score_str = f"{score_percent:.2f}{bounds_str}/{historical}"
+                    row_parts.append(f"{score_str:>26}")
                 else:
-                    row_parts.append(f"{'  -  ':>18}")
+                    row_parts.append(f"{'  -  ':>26}")
 
             # Status / CP / Challenge
             if m.is_champion:

--- a/affine/src/scheduler/sampling_scheduler.py
+++ b/affine/src/scheduler/sampling_scheduler.py
@@ -988,18 +988,24 @@ class SamplingScheduler:
             except asyncio.CancelledError:
                 pass
     
+    ROTATION_POLL_INTERVAL = 10
+    """Seconds between rotation checks. Lower = tighter alignment to
+    configured rotation_interval (at the cost of extra HTTP fetches for
+    envs with dataset_range_source). With 10s, actual rotation cadence
+    drifts by at most 10s from the configured value."""
+
     async def _rotation_loop(self):
-        """Rotation loop - checks every 60 seconds."""
+        """Rotation loop — polls every ROTATION_POLL_INTERVAL seconds."""
         while self._running:
             try:
                 await self._check_and_rotate_all_envs()
-                await asyncio.sleep(60)
+                await asyncio.sleep(self.ROTATION_POLL_INTERVAL)
             except asyncio.CancelledError:
                 logger.info("Rotation loop cancelled")
                 break
             except Exception as e:
                 logger.error(f"Rotation loop error: {e}", exc_info=True)
-                await asyncio.sleep(60)
+                await asyncio.sleep(self.ROTATION_POLL_INTERVAL)
     
     async def _check_and_rotate_all_envs(self):
         """Check all environments and rotate if needed."""

--- a/affine/src/scorer/champion_challenge.py
+++ b/affine/src/scorer/champion_challenge.py
@@ -360,6 +360,7 @@ class ChampionChallenge:
             return
 
         margin = self.config.WIN_MARGIN_END
+        not_worse_tol = self.config.WIN_NOT_WORSE_TOLERANCE
         for uid, miner in miners.items():
             if miner.is_champion:
                 continue
@@ -382,7 +383,13 @@ class ChampionChallenge:
                     "common_tasks": len(common),
                     "score_on_common": chall_on_common,
                     "champion_score_on_common": champ_on_common,
+                    # Upper bound: if challenger's score-on-common exceeds
+                    # this, they WIN this env in Pareto comparison.
                     "dethrone_threshold": champ_on_common + margin,
+                    # Lower bound: if challenger's score-on-common drops
+                    # below this, they LOSE this env (fails "not worse"
+                    # check, blocking dethrone). Between the two → tie.
+                    "not_worse_threshold": champ_on_common * (1 - not_worse_tol),
                 }
             miner.vs_champion_per_env = per_env
 

--- a/affine/src/scorer/champion_challenge.py
+++ b/affine/src/scorer/champion_challenge.py
@@ -85,6 +85,12 @@ class ChampionChallenge:
         # Termination check (after dethrone — its reset wipes counters first)
         self._check_terminations(miners, champion_uid)
 
+        # Per-challenger vs-champion snapshot for UI/diagnostics. Populates
+        # miner.vs_champion_per_env for every non-champion miner with the
+        # real common-task data that Pareto would use. Not CP-gated — every
+        # round, so rank display always has a current threshold.
+        self._populate_vs_champion_per_env(miners, environments, champion_miner)
+
         final_weights = self._assign_weights(miners, weight_uid)
         self._log_summary(miners, champion_uid, champion_changed)
 
@@ -333,6 +339,52 @@ class ChampionChallenge:
                     or miner.challenge_consecutive_losses >= M_con):
                 miner.challenge_status = 'terminated'
                 # termination_reason already set by _run_challenges with last loss detail
+
+    # ── Phase 5b: Per-challenger vs-champion snapshot ────────────────────────
+
+    def _populate_vs_champion_per_env(
+        self,
+        miners: Dict[int, MinerData],
+        environments: List[str],
+        champion_miner: Optional[MinerData],
+    ) -> None:
+        """Fill miner.vs_champion_per_env for every non-champion miner.
+
+        For each (challenger, env) this records the exact numbers the Pareto
+        comparison uses: champion's avg on common tasks, challenger's avg on
+        common tasks, and the dethrone threshold (champion_on_common +
+        WIN_MARGIN_END). Runs regardless of checkpoint so downstream UIs
+        always have the current real threshold, not a historical-avg proxy.
+        """
+        if not champion_miner:
+            return
+
+        margin = self.config.WIN_MARGIN_END
+        for uid, miner in miners.items():
+            if miner.is_champion:
+                continue
+            per_env: Dict[str, Dict[str, Any]] = {}
+            for env in environments:
+                es_champ = champion_miner.env_scores.get(env)
+                es_chall = miner.env_scores.get(env)
+                if not es_champ or not es_chall:
+                    continue
+                common = set(es_champ.all_task_scores) & set(es_chall.all_task_scores)
+                if not common:
+                    continue
+                champ_on_common = sum(
+                    es_champ.all_task_scores[t] for t in common
+                ) / len(common)
+                chall_on_common = sum(
+                    es_chall.all_task_scores[t] for t in common
+                ) / len(common)
+                per_env[env] = {
+                    "common_tasks": len(common),
+                    "score_on_common": chall_on_common,
+                    "champion_score_on_common": champ_on_common,
+                    "dethrone_threshold": champ_on_common + margin,
+                }
+            miner.vs_champion_per_env = per_env
 
     # ── Phase 6: Assign weights ──────────────────────────────────────────────
 

--- a/affine/src/scorer/champion_challenge.py
+++ b/affine/src/scorer/champion_challenge.py
@@ -25,7 +25,7 @@ Invariants:
 - Champion must be pre-set via `af db set-champion` before first run.
 """
 
-from typing import Dict, List, Optional, Tuple
+from typing import Any, Dict, List, Optional, Tuple
 
 from affine.src.scorer.config import ScorerConfig
 from affine.src.scorer.models import MinerData, ParetoComparison, ChampionChallengeOutput

--- a/affine/src/scorer/models.py
+++ b/affine/src/scorer/models.py
@@ -44,6 +44,15 @@ class MinerData:
     termination_reason: str = ''        # Detailed reason with hotkey and per-env scores
     is_champion: bool = False
 
+    # Per-env comparison against the current champion, populated by
+    # champion_challenge. Each env dict has:
+    #   common_tasks: int                  — size of overlap with champion
+    #   score_on_common: float             — this miner's avg on common tasks
+    #   champion_score_on_common: float    — champion's avg on common tasks
+    #   dethrone_threshold: float          — champion_score_on_common + WIN_MARGIN_END
+    # Missing envs = no common tasks with champion (or champion absent).
+    vs_champion_per_env: Dict[str, Dict[str, Any]] = field(default_factory=dict)
+
     # Final weight (set by champion challenge: 1.0 for champion, 0.0 for others)
     normalized_weight: float = 0.0
 

--- a/affine/src/scorer/models.py
+++ b/affine/src/scorer/models.py
@@ -49,7 +49,11 @@ class MinerData:
     #   common_tasks: int                  — size of overlap with champion
     #   score_on_common: float             — this miner's avg on common tasks
     #   champion_score_on_common: float    — champion's avg on common tasks
-    #   dethrone_threshold: float          — champion_score_on_common + WIN_MARGIN_END
+    #   dethrone_threshold: float          — upper: win env if score_on_common > this
+    #                                        (champion_score_on_common + WIN_MARGIN_END)
+    #   not_worse_threshold: float         — lower: lose env if score_on_common < this
+    #                                        (champion_score_on_common × (1 − WIN_NOT_WORSE_TOLERANCE))
+    # Between lower and upper = tie (not-worse but not dominant).
     # Missing envs = no common tasks with champion (or champion absent).
     vs_champion_per_env: Dict[str, Dict[str, Any]] = field(default_factory=dict)
 

--- a/affine/src/scorer/scorer.py
+++ b/affine/src/scorer/scorer.py
@@ -178,6 +178,10 @@ class Scorer:
                     "sample_count": score.sample_count,
                     "historical_count": score.historical_count,
                     "completeness": score.completeness,
+                    # Real per-challenger vs-champion numbers, populated by
+                    # champion_challenge. Absent when miner is champion or
+                    # shares no tasks with champion in this env.
+                    **miner.vs_champion_per_env.get(env, {}),
                 }
                 for env, score in miner.env_scores.items()
             }


### PR DESCRIPTION
## Summary
- `af get-rank`: per-env cell now shows `score%[lose-below, win-above]/samples` — both bounds per-challenger, matching the real Pareto comparison. Miners see exactly when they'd lose an env, win an env, or be in the tie range.
- `system_config.json`: SWE `sampling_count` 50→40; all scored envs' `rotation_interval` retuned so 10 windows complete in ~1.2 days (big envs 390s, SWE/DISTILL 260s).
- `sampling_scheduler.py`: rotation poll interval 60s → 10s so actual rotation cadence stays within ~10s of the configured value.

## Pareto bounds (what the cell means)
For each challenger in each env, on tasks both have sampled in common:
- **Lose below**: `champion_on_common × (1 − WIN_NOT_WORSE_TOLERANCE)` — below this, challenger fails the "not worse" check and can never dethrone.
- **Win above**: `champion_on_common + WIN_MARGIN_END` — above this, challenger dominates that env.
- **In between**: tie (not worse, but not dominant). Contributes to "not-worse-in-all" but not to "dominant-in-3+".

## Scorer changes supporting the real bounds
- `MinerData.vs_champion_per_env` records `{common_tasks, score_on_common, champion_score_on_common, dethrone_threshold, not_worse_threshold}` per env
- `champion_challenge.run` populates this after dethrone/terminations, so values reflect the final champion of the round
- `save_results` merges into `scores_by_env[env]`; no schema, DAO, or API changes required
- `rank.py` renders per-miner per-env bounds; falls back to `[—]` for old snapshots, champion rows, or envs without common tasks