### PR TITLE
Shrink MEMORY window

### DIFF
--- a/affine/database/system_config.json
+++ b/affine/database/system_config.json
@@ -78,10 +78,10 @@
       "min_completeness": 0.8,
       "sampling_config": {
         "dataset_range": [[0, 1000000000]],
-        "sampling_count": 50,
+        "sampling_count": 40,
         "rotation_enabled": true,
         "rotation_count": 3,
-        "rotation_interval": 620,
+        "rotation_interval": 780,
         "scheduling_weight": 1.0
       }
     },


### PR DESCRIPTION
## Summary
- MEMORY `sampling_count`: 50 → 40
- MEMORY `rotation_interval`: 620s → 780s (so 10 windows still complete in ~1.2 days with the existing 10s scheduler poll)

## Math
- 10 windows target = 400 tasks
- `rotation_interval = 103680s × rotation_count / target = 103680 × 3 / 400 = 777.6s` → rounded up to **780s** (aligned to the 10s poll)
- Verify: `(40 / 3) rotations × 780s per rotation × 10 windows ≈ 104000s ≈ 1.204 days` ✓