### PR TITLE
Shrink GAME/LIVEWEB/NAVWORLD window 80→50, retune rotation to 1.2-day cycle

### DIFF
--- a/affine/database/system_config.json
+++ b/affine/database/system_config.json
@@ -7,10 +7,10 @@
       "min_completeness": 0.85,
       "sampling_config": {
         "dataset_range": [[0, 500000000],[600000000, 800000000]],
-        "sampling_count": 80,
+        "sampling_count": 50,
         "rotation_enabled": true,
         "rotation_count": 3,
-        "rotation_interval": 390,
+        "rotation_interval": 620,
         "scheduling_weight": 3.0
       }
     },
@@ -39,10 +39,10 @@
       "min_completeness": 0.8,
       "sampling_config": {
         "dataset_range": [[0, 78060000]],
-        "sampling_count": 80,
+        "sampling_count": 50,
         "rotation_enabled": true,
         "rotation_count": 3,
-        "rotation_interval": 390,
+        "rotation_interval": 620,
         "scheduling_weight": 1.0
       }
     },
@@ -65,10 +65,10 @@
       "min_completeness": 0.85,
       "sampling_config": {
         "dataset_range": [[0, 1000000000]],
-        "sampling_count": 80,
+        "sampling_count": 50,
         "rotation_enabled": true,
         "rotation_count": 3,
-        "rotation_interval": 390,
+        "rotation_interval": 620,
         "scheduling_weight": 1.0
       }
     },


### PR DESCRIPTION
## Summary
Drop `sampling_count` from 80 to 50 for the three big-window scored envs (GAME, LIVEWEB, NAVWORLD). Retune `rotation_interval` so 10 windows still complete in ~1.2 days with the existing 10s scheduler poll.

## Math
- 10 windows target = 500 tasks per env
- `rotation_interval = 103680s × rotation_count / target = 103680 × 3 / 500 = 622.08s` → rounded to **620s** (aligned to 10s poll)
- Verify: `(50 / 3) rotations × 620s × 10 windows ≈ 103333s ≈ 1.196 days` ✓

## Envs updated
| Env | sampling_count | rotation_interval |
|---|---|---|
| GAME     | 80 → 50 | 390s → 620s |
| LIVEWEB  | 80 → 50 | 390s → 620s |
| NAVWORLD | 80 → 50 | 390s → 620s |
