### PR TITLE
Refine anti-copy suspicious handling

### DIFF
--- a/affine/database/dao/anti_copy.py
+++ b/affine/database/dao/anti_copy.py
@@ -23,12 +23,21 @@ class AntiCopyDAO(BaseDAO):
     def _make_sk(self, timestamp: int) -> str:
         return f"ROUND#{timestamp}"
 
+    @staticmethod
+    def _normalize_result(result: Optional[Dict]) -> Optional[Dict]:
+        if not result:
+            return result
+        if "status" not in result:
+            result = result.copy()
+            result["status"] = "cheat" if result.get("is_copy") else "clean"
+        return result
+
     async def save_round(self, results: List[Dict], round_timestamp: int = None):
         """Save one round of detection results.
 
         Args:
             results: List of dicts, one per model:
-                {uid, hotkey, model, revision, block, is_copy,
+                {uid, hotkey, model, revision, block, status, is_copy,
                  copy_of: [{uid, hotkey, model, logprobs_cosine, hs_cosine,
                             js_div, n_tasks}]}
             round_timestamp: Unix timestamp for this round (default: now)
@@ -46,6 +55,7 @@ class AntiCopyDAO(BaseDAO):
                 "model": r["model"],
                 "revision": r["revision"],
                 "block": r["block"],
+                "status": r.get("status", "cheat" if r.get("is_copy") else "clean"),
                 "is_copy": r["is_copy"],
                 "copy_of": r.get("copy_of", []),
                 "timestamp": ts,
@@ -67,8 +77,11 @@ class AntiCopyDAO(BaseDAO):
             limit=1,
             reverse=True,
         )
-        return results[0] if results else None
+        return self._normalize_result(results[0]) if results else None
 
     async def get_history(self, model: str, revision: str) -> List[Dict]:
         """Get all detection results for a model."""
-        return await self.query(pk=self._make_pk(model, revision))
+        return [
+            self._normalize_result(result)
+            for result in await self.query(pk=self._make_pk(model, revision))
+        ]

--- a/affine/src/anticopy/detector.py
+++ b/affine/src/anticopy/detector.py
@@ -11,7 +11,10 @@ JS divergence and token agreement are computed for diagnostics but do NOT
 vote, because they are derived from the same logprob/topk data as cosine
 and carry redundant information.
 
-Decision: is_copy when ALL available signals vote copy, with at least 1 signal.
+Decision:
+  - cheat when ALL available signals vote >= cheat threshold, with at least 1 signal
+  - suspicious when not cheat, but ALL available signals vote >= suspicious threshold
+  - clean otherwise
 """
 
 import numpy as np
@@ -36,11 +39,15 @@ class AntiCopyDetector:
         self,
         hs_threshold: float = 0.99,
         cosine_threshold: float = 0.99,
+        hs_cheat_threshold: float = 0.995,
+        cosine_cheat_threshold: float = 0.995,
         min_tasks: int = 30,
         hs_norm_deviation_max: float = 0.05,
     ):
         self.hs_threshold = hs_threshold
         self.cosine_threshold = cosine_threshold
+        self.hs_cheat_threshold = hs_cheat_threshold
+        self.cosine_cheat_threshold = cosine_cheat_threshold
         self.min_tasks = min_tasks
         # Gate: reject hs vote if per-task ||h_a||/||h_b|| deviates too much
         # from 1.0. True copies (even with added perturbation noise) keep
@@ -201,32 +208,44 @@ class AntiCopyDetector:
                     continue
 
                 # ── Voting (2 independent signals) ─────────────────
-                votes = 0
+                suspicious_votes = 0
+                cheat_votes = 0
                 total_votes = 0
 
                 if has_hs:
                     total_votes += 1
-                    hs_vote_copy = med_hs >= self.hs_threshold
+                    hs_vote_suspicious = med_hs >= self.hs_threshold
+                    hs_vote_cheat = med_hs >= self.hs_cheat_threshold
                     # Norm-ratio gate: if per-task ||h_a||/||h_b|| drifts
                     # too much, this is fine-tune divergence, not copy.
                     if (
                         not np.isnan(hs_norm_deviation)
                         and hs_norm_deviation > self.hs_norm_deviation_max
                     ):
-                        hs_vote_copy = False
-                    if hs_vote_copy:
-                        votes += 1
+                        hs_vote_suspicious = False
+                        hs_vote_cheat = False
+                    if hs_vote_suspicious:
+                        suspicious_votes += 1
+                    if hs_vote_cheat:
+                        cheat_votes += 1
 
                 if has_logprobs and not np.isnan(med_cosine):
                     total_votes += 1
                     if med_cosine >= self.cosine_threshold:
-                        votes += 1
+                        suspicious_votes += 1
+                    if med_cosine >= self.cosine_cheat_threshold:
+                        cheat_votes += 1
 
-                # All available signals must agree; need at least 1
-                is_copy = total_votes >= 1 and votes == total_votes
+                is_cheat = total_votes >= 1 and cheat_votes == total_votes
+                is_suspicious = (
+                    not is_cheat
+                    and total_votes >= 1
+                    and suspicious_votes == total_votes
+                )
+                verdict = "cheat" if is_cheat else "suspicious" if is_suspicious else "clean"
 
                 # Confidence: fraction of votes
-                confidence = votes / max(total_votes, 1)
+                confidence = suspicious_votes / max(total_votes, 1)
 
                 results.append(
                     CopyPair(
@@ -239,20 +258,21 @@ class AntiCopyDetector:
                         js_divergence=med_js,
                         token_agreement=med_agree,
                         n_tasks=n_tasks,
-                        is_copy=is_copy,
+                        verdict=verdict,
+                        is_copy=is_cheat,
                         confidence=confidence,
-                        votes=votes,
+                        votes=suspicious_votes,
                         total_votes=total_votes,
                         hs_norm_deviation=hs_norm_deviation,
                         task_cosines=task_cosine_map,
                     )
                 )
 
-        copies = [r for r in results if r.is_copy]
+        copies = [r for r in results if r.verdict != "clean"]
         results.sort(key=lambda r: r.confidence, reverse=True)
 
         logger.info(
-            f"anti_copy: {len(copies)} copy pairs detected "
+            f"anti_copy: {len(copies)} flagged pairs detected "
             f"out of {len(results)} pairs evaluated"
         )
         return results

--- a/affine/src/anticopy/detector.py
+++ b/affine/src/anticopy/detector.py
@@ -18,7 +18,7 @@ Decision:
 """
 
 import numpy as np
-from typing import Dict, List
+from typing import Dict, List, Optional
 
 from affine.core.setup import logger
 from affine.src.anticopy.loader import TOP_K
@@ -30,24 +30,41 @@ class AntiCopyDetector:
     """Detect model copies using two independent signals.
 
     Args:
-        hs_threshold:      hidden_states cosine >= this → vote copy
-        cosine_threshold:   logprob cosine >= this → vote copy
-        min_tasks:          minimum shared tasks required for comparison
+        hs_suspicious_threshold: hidden_states cosine >= this → vote suspicious
+        logprob_suspicious_threshold: logprob cosine >= this → vote suspicious
+        hs_cheat_threshold: hidden_states cosine >= this → vote cheat
+        logprob_cheat_threshold: logprob cosine >= this → vote cheat
+        min_tasks: minimum shared tasks required for comparison
     """
 
     def __init__(
         self,
-        hs_threshold: float = 0.99,
-        cosine_threshold: float = 0.99,
+        hs_suspicious_threshold: float = 0.99,
+        logprob_suspicious_threshold: float = 0.99,
         hs_cheat_threshold: float = 0.995,
-        cosine_cheat_threshold: float = 0.995,
+        logprob_cheat_threshold: float = 0.995,
         min_tasks: int = 30,
         hs_norm_deviation_max: float = 0.05,
+        *,
+        hs_threshold: Optional[float] = None,
+        cosine_threshold: Optional[float] = None,
+        cosine_cheat_threshold: Optional[float] = None,
     ):
-        self.hs_threshold = hs_threshold
-        self.cosine_threshold = cosine_threshold
+        if hs_threshold is not None:
+            hs_suspicious_threshold = hs_threshold
+        if cosine_threshold is not None:
+            logprob_suspicious_threshold = cosine_threshold
+        if cosine_cheat_threshold is not None:
+            logprob_cheat_threshold = cosine_cheat_threshold
+
+        self.hs_suspicious_threshold = hs_suspicious_threshold
+        self.logprob_suspicious_threshold = logprob_suspicious_threshold
         self.hs_cheat_threshold = hs_cheat_threshold
-        self.cosine_cheat_threshold = cosine_cheat_threshold
+        self.logprob_cheat_threshold = logprob_cheat_threshold
+        # Backward-compatible aliases for older tests/callers.
+        self.hs_threshold = self.hs_suspicious_threshold
+        self.cosine_threshold = self.logprob_suspicious_threshold
+        self.cosine_cheat_threshold = self.logprob_cheat_threshold
         self.min_tasks = min_tasks
         # Gate: reject hs vote if per-task ||h_a||/||h_b|| deviates too much
         # from 1.0. True copies (even with added perturbation noise) keep
@@ -214,7 +231,7 @@ class AntiCopyDetector:
 
                 if has_hs:
                     total_votes += 1
-                    hs_vote_suspicious = med_hs >= self.hs_threshold
+                    hs_vote_suspicious = med_hs >= self.hs_suspicious_threshold
                     hs_vote_cheat = med_hs >= self.hs_cheat_threshold
                     # Norm-ratio gate: if per-task ||h_a||/||h_b|| drifts
                     # too much, this is fine-tune divergence, not copy.
@@ -231,9 +248,9 @@ class AntiCopyDetector:
 
                 if has_logprobs and not np.isnan(med_cosine):
                     total_votes += 1
-                    if med_cosine >= self.cosine_threshold:
+                    if med_cosine >= self.logprob_suspicious_threshold:
                         suspicious_votes += 1
-                    if med_cosine >= self.cosine_cheat_threshold:
+                    if med_cosine >= self.logprob_cheat_threshold:
                         cheat_votes += 1
 
                 is_cheat = total_votes >= 1 and cheat_votes == total_votes

--- a/affine/src/anticopy/main.py
+++ b/affine/src/anticopy/main.py
@@ -27,6 +27,8 @@ DEFAULT_INTERVAL = 86400  # 24 hours
 class AntiCopyService:
     """Periodic anti-copy detection service."""
 
+    _SEVERITY_RANK = {"clean": 0, "suspicious": 1, "cheat": 2}
+
     def __init__(self, interval: int = DEFAULT_INTERVAL):
         self.interval = interval
         self._running = False
@@ -63,20 +65,20 @@ class AntiCopyService:
         return miners
 
     def _build_copy_records(
-        self, copy_pairs, miner_info: Dict[int, dict]
+        self, flagged_pairs, miner_info: Dict[int, dict]
     ) -> List[dict]:
-        """Build per-model copy records.
+        """Build per-model anti-copy records.
 
-        For each miner, find the earliest-block miner among all its
-        direct similar pairs. If that miner committed earlier, the
-        current miner is a copier pointing to it as the original.
+        For each miner, find the strongest direct flagged relation that points
+        to an earlier miner. Severity wins over recency; within the same
+        severity, the earliest block wins.
 
         Returns:
-            List of dicts ready for DAO.save_round() (only copiers)
+            List of dicts ready for DAO.save_round() (only suspicious/cheat miners)
         """
         # Build adjacency: uid -> [(other_uid, CopyPair)]
         neighbors: Dict[int, list] = defaultdict(list)
-        for pair in copy_pairs:
+        for pair in flagged_pairs:
             neighbors[pair.uid_a].append((pair.uid_b, pair))
             neighbors[pair.uid_b].append((pair.uid_a, pair))
 
@@ -86,37 +88,60 @@ class AntiCopyService:
             my_block = info["block"]
 
             # Find the peer with the earliest block
-            earliest_uid = None
-            earliest_block = my_block
-            earliest_pair = None
+            chosen_uid = None
+            chosen_block = my_block
+            chosen_pair = None
+            chosen_severity = "clean"
             for peer_uid, pair in peers:
                 peer_block = miner_info[peer_uid]["block"]
-                if peer_block < earliest_block or (
-                    peer_block == earliest_block and peer_uid < uid
+                if not (
+                    peer_block < my_block or (peer_block == my_block and peer_uid < uid)
                 ):
-                    earliest_block = peer_block
-                    earliest_uid = peer_uid
-                    earliest_pair = pair
+                    continue
+
+                if (
+                    self._SEVERITY_RANK.get(pair.verdict, 0)
+                    > self._SEVERITY_RANK.get(chosen_severity, 0)
+                ):
+                    chosen_uid = peer_uid
+                    chosen_block = peer_block
+                    chosen_pair = pair
+                    chosen_severity = pair.verdict
+                    continue
+
+                if (
+                    pair.verdict == chosen_severity
+                    and (
+                        peer_block < chosen_block
+                        or (
+                            peer_block == chosen_block
+                            and (chosen_uid is None or peer_uid < chosen_uid)
+                        )
+                    )
+                ):
+                    chosen_uid = peer_uid
+                    chosen_block = peer_block
+                    chosen_pair = pair
 
             # If no peer is earlier, this miner is an original
-            if earliest_uid is None:
+            if chosen_uid is None:
                 continue
 
-            orig_info = miner_info[earliest_uid]
+            orig_info = miner_info[chosen_uid]
             copy_entry = {
-                "uid": earliest_uid,
+                "uid": chosen_uid,
                 "hotkey": orig_info["hotkey"],
                 "model": orig_info["model"],
             }
-            if earliest_pair:
+            if chosen_pair:
                 for key, val in [
-                    ("logprobs_cosine", earliest_pair.cosine_similarity),
-                    ("hs_cosine", earliest_pair.hs_cosine),
-                    ("js_div", earliest_pair.js_divergence),
+                    ("logprobs_cosine", chosen_pair.cosine_similarity),
+                    ("hs_cosine", chosen_pair.hs_cosine),
+                    ("js_div", chosen_pair.js_divergence),
                 ]:
                     if val is not None and not (isinstance(val, float) and math.isnan(val)):
                         copy_entry[key] = val
-                copy_entry["n_tasks"] = earliest_pair.n_tasks
+                copy_entry["n_tasks"] = chosen_pair.n_tasks
 
             results.append({
                 "uid": uid,
@@ -124,7 +149,8 @@ class AntiCopyService:
                 "model": info["model"],
                 "revision": info["revision"],
                 "block": info["block"],
-                "is_copy": True,
+                "status": chosen_severity,
+                "is_copy": chosen_severity == "cheat",
                 "copy_of": [copy_entry],
             })
 
@@ -151,23 +177,23 @@ class AntiCopyService:
         detector = AntiCopyDetector()
         results = detector.detect(miner_data)
 
-        copy_pairs = [r for r in results if r.is_copy]
+        flagged_pairs = [r for r in results if r.verdict != "clean"]
         logger.info(
-            f"[AntiCopy] Detection complete: {len(copy_pairs)} copy pairs "
+            f"[AntiCopy] Detection complete: {len(flagged_pairs)} flagged pairs "
             f"out of {len(results)} pairs evaluated"
         )
-        for r in copy_pairs:
+        for r in flagged_pairs:
             logger.warning(f"[AntiCopy] {r}")
 
         # Save to DB: write results for ALL evaluated miners
         # so that previously-flagged miners get cleared when no longer copy
-        copy_records = self._build_copy_records(copy_pairs, miner_info) if copy_pairs else []
-        copy_uids = {r["uid"] for r in copy_records}
+        flagged_records = self._build_copy_records(flagged_pairs, miner_info) if flagged_pairs else []
+        flagged_uids = {r["uid"] for r in flagged_records}
 
         # Build clean records for non-copy miners that were evaluated
         clean_records = []
         for uid in miner_data:
-            if uid not in copy_uids:
+            if uid not in flagged_uids:
                 info = miner_info[uid]
                 clean_records.append({
                     "uid": uid,
@@ -175,19 +201,21 @@ class AntiCopyService:
                     "model": info["model"],
                     "revision": info["revision"],
                     "block": info["block"],
+                    "status": "clean",
                     "is_copy": False,
                     "copy_of": [],
                 })
 
-        all_records = copy_records + clean_records
+        all_records = flagged_records + clean_records
         if all_records:
             dao = AntiCopyDAO()
             round_ts = int(time.time())
             await dao.save_round(all_records, round_timestamp=round_ts)
-            copy_count = sum(1 for r in all_records if r["is_copy"])
+            cheat_count = sum(1 for r in all_records if r["status"] == "cheat")
+            suspicious_count = sum(1 for r in all_records if r["status"] == "suspicious")
             logger.info(
                 f"[AntiCopy] Saved {len(all_records)} records "
-                f"({copy_count} copies, {len(clean_records)} clean) to DB"
+                f"({cheat_count} cheats, {suspicious_count} suspicious, {len(clean_records)} clean) to DB"
             )
 
     async def _loop(self):

--- a/affine/src/anticopy/models.py
+++ b/affine/src/anticopy/models.py
@@ -46,6 +46,7 @@ class CopyPair:
     token_agreement: float      # median token agreement across tasks
 
     n_tasks: int                # shared tasks used
+    verdict: str                # "clean" | "suspicious" | "cheat"
     is_copy: bool
     confidence: float           # 0.0 - 1.0
     votes: int = 0              # number of signals that voted "copy"
@@ -59,7 +60,7 @@ class CopyPair:
     task_cosines: Dict[int, float] = field(default_factory=dict)
 
     def __repr__(self) -> str:
-        flag = "COPY" if self.is_copy else "ok"
+        flag = self.verdict.upper()
         hs_str = f"{self.hs_cosine:.5f}" if not np.isnan(self.hs_cosine) else "N/A"
         nd_str = f"{self.hs_norm_deviation:.4f}" if not np.isnan(self.hs_norm_deviation) else "N/A"
         return (

--- a/affine/src/monitor/miners_monitor.py
+++ b/affine/src/monitor/miners_monitor.py
@@ -511,7 +511,10 @@ class MinersMonitor:
         if uid != 0:
             try:
                 ac_result = await self.anticopy_dao.get_latest(model, revision)
-                if ac_result and ac_result.get("is_copy"):
+                ac_status = ""
+                if ac_result:
+                    ac_status = ac_result.get("status") or ("cheat" if ac_result.get("is_copy") else "clean")
+                if ac_result and ac_status in ("cheat", "suspicious"):
                     copy_of = ac_result.get("copy_of", [])
                     orig = copy_of[0] if copy_of else {}
                     orig_model = orig.get("model", "unknown")
@@ -523,16 +526,23 @@ class MinersMonitor:
                     if hs_cos:
                         sim_parts.append(f"hs={hs_cos:.4f}" if isinstance(hs_cos, (int, float)) else f"hs={hs_cos}")
                     sim_str = ",".join(sim_parts)
-                    reason = f"anticopy:high_similarity_with={orig_model}"
+                    reason_prefix = "anticopy:high_similarity_with" if ac_status == "cheat" else "anticopy:suspicious_similarity_with"
+                    reason = f"{reason_prefix}={orig_model}"
                     if sim_str:
                         reason += f"({sim_str})"
-                    info.is_valid = False
+                    if ac_status == "cheat":
+                        info.is_valid = False
+                        info.invalid_reason = reason
+                        logger.info(
+                            f"[MinersMonitor] Anti-copy flagged uid={uid}: "
+                            f"model={model} high similarity with {orig_model} [{sim_str}]"
+                        )
+                        return info
                     info.invalid_reason = reason
                     logger.info(
-                        f"[MinersMonitor] Anti-copy flagged uid={uid}: "
+                        f"[MinersMonitor] Anti-copy suspicious uid={uid}: "
                         f"model={model} high similarity with {orig_model} [{sim_str}]"
                     )
-                    return info
             except Exception as e:
                 logger.debug(f"[MinersMonitor] Anti-copy check failed for uid={uid}: {e}")
 

--- a/affine/src/scorer/champion_challenge.py
+++ b/affine/src/scorer/champion_challenge.py
@@ -49,10 +49,12 @@ class ChampionChallenge:
         env_sampling_counts: Dict[str, int],
         champion_state: Optional[Dict],
         prev_challenge_states: Dict[str, Dict],
+        anticopy_records: Optional[Dict[str, Dict[str, Any]]] = None,
     ) -> ChampionChallengeOutput:
         if not environments or not miners:
             return self._empty_output(miners)
 
+        self._load_anticopy_records(miners, anticopy_records or {})
         self._load_states(miners, prev_challenge_states)
 
         champion_uid, champion_miner, weight_uid, champion_changed = \
@@ -118,6 +120,12 @@ class ChampionChallenge:
             miner.challenge_checkpoints_passed = p.get('challenge_checkpoints_passed', 0)
             miner.challenge_status = p.get('challenge_status', 'sampling')
             miner.termination_reason = p.get('termination_reason', '')
+
+    def _load_anticopy_records(self, miners: Dict[int, MinerData], records: Dict[str, Dict[str, Any]]):
+        for miner in miners.values():
+            record = records.get(f"{miner.model_repo}#{miner.model_revision}", {})
+            miner.anticopy_status = record.get('status', 'clean')
+            miner.anticopy_target_uid = record.get('copy_of_uid')
 
     # ── Phase 2: Resolve champion ────────────────────────────────────────────
 

--- a/affine/src/scorer/config.py
+++ b/affine/src/scorer/config.py
@@ -63,6 +63,14 @@ class ScorerConfig:
     dynamic margin — it's always this fixed value.
     """
 
+    PARETO_SUSPICIOUS_MARGIN_MULTIPLIER: float = 1.5
+    """Anti-copy margin multiplier for suspicious miners.
+
+    When the current miner is suspicious and the comparison target is the
+    model it copied from, the required dominance margin is multiplied by
+    this factor. Example: 0.04 -> 0.06 when multiplier=1.5.
+    """
+
     # ── Geometric Mean ────────────────────────────────────────────────────
 
     GEOMETRIC_MEAN_EPSILON: float = 0.1
@@ -118,6 +126,7 @@ class ScorerConfig:
             'win_min_dominant_envs': cls.WIN_MIN_DOMINANT_ENVS,
             'win_not_worse_tolerance': cls.WIN_NOT_WORSE_TOLERANCE,
             'pareto_margin': cls.PARETO_MARGIN,
+            'pareto_suspicious_margin_multiplier': cls.PARETO_SUSPICIOUS_MARGIN_MULTIPLIER,
             'pareto_min_dominant_envs': cls.PARETO_MIN_DOMINANT_ENVS,
             'pareto_min_windows': cls.PARETO_MIN_WINDOWS,
             'geometric_mean_epsilon': cls.GEOMETRIC_MEAN_EPSILON,
@@ -132,6 +141,7 @@ class ScorerConfig:
         assert 0.0 < cls.WIN_MARGIN_START < 1.0, "WIN_MARGIN_START must be in (0, 1)"
         assert 0.0 < cls.WIN_MARGIN_END < 1.0, "WIN_MARGIN_END must be in (0, 1)"
         assert cls.WIN_MARGIN_END >= cls.WIN_MARGIN_START, "WIN_MARGIN_END must be >= START"
+        assert cls.PARETO_SUSPICIOUS_MARGIN_MULTIPLIER >= 1.0, "PARETO_SUSPICIOUS_MARGIN_MULTIPLIER must be >= 1"
         assert cls.GEOMETRIC_MEAN_EPSILON >= 0.0, "GEOMETRIC_MEAN_EPSILON must be non-negative"
         assert cls.CHAMPION_WARMUP_CHECKPOINTS >= 0, "CHAMPION_WARMUP_CHECKPOINTS must be >= 0"
         assert cls.CHAMPION_DETHRONE_MIN_CHECKPOINT >= 1, "CHAMPION_DETHRONE_MIN_CHECKPOINT must be >= 1"

--- a/affine/src/scorer/main.py
+++ b/affine/src/scorer/main.py
@@ -14,6 +14,7 @@ from affine.core.setup import logger
 from affine.database import init_client, close_client
 from affine.database.dao.score_snapshots import ScoreSnapshotsDAO
 from affine.database.dao.scores import ScoresDAO
+from affine.database.dao.anti_copy import AntiCopyDAO
 from affine.database.dao.miner_stats import MinerStatsDAO
 from affine.database.dao.system_config import SystemConfigDAO
 from affine.src.scorer.scorer import Scorer
@@ -101,6 +102,7 @@ async def run_scoring_once(save_to_db: bool, range_type: str = "scoring"):
 
     config = ScorerConfig()
     scorer = Scorer(config)
+    anticopy_dao = AntiCopyDAO()
 
     async with cli_api_client() as api_client:
         # Fetch data
@@ -155,6 +157,26 @@ async def run_scoring_once(save_to_db: bool, range_type: str = "scoring"):
                 # Default: fresh state for this miner only, others unaffected
         logger.info(f"Loaded challenge states for {len(prev_challenge_states)} miners")
 
+        anticopy_records = {}
+        for _, miner_info in scoring_data.items():
+            model = miner_info.get('model_repo', '')
+            revision = miner_info.get('model_revision', '')
+            if not model or not revision:
+                continue
+            try:
+                ac = await anticopy_dao.get_latest(model, revision)
+                if ac:
+                    copy_of = ac.get("copy_of", [])
+                    orig = copy_of[0] if copy_of else {}
+                    anticopy_records[f"{model}#{revision}"] = {
+                        "status": ac.get("status")
+                        or ("cheat" if ac.get("is_copy") else "clean"),
+                        "copy_of_uid": orig.get("uid"),
+                    }
+            except Exception as e:
+                logger.warning(f"Failed to load anti-copy status for {model}@{revision[:8]}: {e}")
+        logger.info(f"Loaded anti-copy records for {len(anticopy_records)} miners")
+
         # Extract sampling_count per environment for checkpoint calculation
         env_sampling_counts = {}
         for env_name, ec in env_configs.items():
@@ -172,6 +194,7 @@ async def run_scoring_once(save_to_db: bool, range_type: str = "scoring"):
             env_sampling_counts=env_sampling_counts,
             champion_state=champion_state,
             prev_challenge_states=prev_challenge_states,
+            anticopy_records=anticopy_records,
             print_summary=True,
         )
 

--- a/affine/src/scorer/models.py
+++ b/affine/src/scorer/models.py
@@ -34,6 +34,8 @@ class MinerData:
     first_block: int
 
     env_scores: Dict[str, EnvScore] = field(default_factory=dict)
+    anticopy_status: str = 'clean'      # 'clean' | 'suspicious' | 'cheat'
+    anticopy_target_uid: Optional[int] = None
 
     # Champion challenge state
     challenge_consecutive_wins: int = 0

--- a/affine/src/scorer/scorer.py
+++ b/affine/src/scorer/scorer.py
@@ -46,6 +46,7 @@ class Scorer:
         env_sampling_counts: Optional[Dict[str, int]] = None,
         champion_state: Optional[Dict[str, Any]] = None,
         prev_challenge_states: Optional[Dict[str, Dict[str, Any]]] = None,
+        anticopy_records: Optional[Dict[str, Dict[str, Any]]] = None,
         print_summary: bool = True,
     ) -> ScoringResult:
         """Run one scoring round.
@@ -73,6 +74,7 @@ class Scorer:
             env_sampling_counts=env_sampling_counts or {},
             champion_state=champion_state,
             prev_challenge_states=prev_challenge_states or {},
+            anticopy_records=anticopy_records or {},
         )
 
         result = ScoringResult(

--- a/affine/src/scorer/stage2_pareto.py
+++ b/affine/src/scorer/stage2_pareto.py
@@ -55,6 +55,19 @@ class Stage2ParetoFilter:
         else:
             margin = self.config.PARETO_MARGIN
             not_worse_tol = 1e-9  # No tolerance for pairwise
+
+        suspicious_multiplier = self.config.PARETO_SUSPICIOUS_MARGIN_MULTIPLIER
+
+        def _effective_margin(actor: MinerData, target: MinerData) -> float:
+            if (
+                getattr(actor, "anticopy_status", "clean") == "suspicious"
+                and getattr(actor, "anticopy_target_uid", None) == target.uid
+            ):
+                return margin * suspicious_multiplier
+            return margin
+
+        margin_b_over_a = _effective_margin(miner_b, miner_a)
+        margin_a_over_b = _effective_margin(miner_a, miner_b)
         b_dominant = 0   # envs where B beats A by margin
         b_not_worse = 0  # envs where B >= A (no margin required)
         a_dominant = 0
@@ -79,7 +92,7 @@ class Stage2ParetoFilter:
             n_compared += 1
 
             # B exceeds A by margin → B dominant in this env
-            if score_b > score_a + margin + 1e-9:
+            if score_b > score_a + margin_b_over_a + 1e-9:
                 b_dominant += 1
                 b_not_worse += 1
                 winner = "B"
@@ -94,14 +107,15 @@ class Stage2ParetoFilter:
                 winner = "A"
 
             # A exceeds B by margin → A dominant in this env
-            if score_a > score_b + margin + 1e-9:
+            if score_a > score_b + margin_a_over_b + 1e-9:
                 a_dominant += 1
 
             env_details[env] = {
                 "a_score": score_a,
                 "b_score": score_b,
-                "margin": round(margin, 4),
-                "threshold": score_a + margin,
+                "margin_b_over_a": round(margin_b_over_a, 4),
+                "margin_a_over_b": round(margin_a_over_b, 4),
+                "threshold": score_a + margin_b_over_a,
                 "winner": winner,
                 "common_tasks": len(common),
             }

--- a/affine/src/scorer/stage2_pareto.py
+++ b/affine/src/scorer/stage2_pareto.py
@@ -57,9 +57,12 @@ class Stage2ParetoFilter:
             not_worse_tol = 1e-9  # No tolerance for pairwise
 
         suspicious_multiplier = self.config.PARETO_SUSPICIOUS_MARGIN_MULTIPLIER
+        # Anti-copy bias only applies to pairwise elimination, not champion
+        # challenges or champion-dominance checks.
+        apply_anticopy_bias = (label == "pairwise")
 
         def _effective_margin(actor: MinerData, target: MinerData) -> float:
-            if (
+            if apply_anticopy_bias and (
                 getattr(actor, "anticopy_status", "clean") == "suspicious"
                 and getattr(actor, "anticopy_target_uid", None) == target.uid
             ):
@@ -113,8 +116,7 @@ class Stage2ParetoFilter:
             env_details[env] = {
                 "a_score": score_a,
                 "b_score": score_b,
-                "margin_b_over_a": round(margin_b_over_a, 4),
-                "margin_a_over_b": round(margin_a_over_b, 4),
+                "margin": round(margin_b_over_a, 4),
                 "threshold": score_a + margin_b_over_a,
                 "winner": winner,
                 "common_tasks": len(common),

--- a/tests/test_anti_copy.py
+++ b/tests/test_anti_copy.py
@@ -193,8 +193,8 @@ class TestTokenAgreement:
 class TestAntiCopyDetector:
     def setup_method(self):
         self.detector = AntiCopyDetector(
-            cosine_threshold=0.93,
-            cosine_cheat_threshold=1.1,
+            logprob_suspicious_threshold=0.93,
+            logprob_cheat_threshold=1.1,
             min_tasks=3,
         )
 
@@ -209,7 +209,7 @@ class TestAntiCopyDetector:
         assert len(suspicious) == 1
         pair = suspicious[0]
         # Cosine is high but not exactly 1.0 because p2 split varies by uid
-        assert pair.cosine_similarity > self.detector.cosine_threshold
+        assert pair.cosine_similarity > self.detector.logprob_suspicious_threshold
         # Only cos signal (no hs), votes 1/1
         assert pair.votes == 1
         assert pair.total_votes == 1
@@ -299,18 +299,18 @@ class TestAntiCopyDetector:
 class TestHiddenStatesVoting:
     def setup_method(self):
         self.detector = AntiCopyDetector(
-            hs_threshold=0.99,
-            cosine_threshold=0.93,
+            hs_suspicious_threshold=0.99,
+            logprob_suspicious_threshold=0.93,
             min_tasks=3,
         )
 
     def test_both_signals_identical(self):
         """With both cos and hs identical, should get 2/2 votes."""
         detector = AntiCopyDetector(
-            hs_threshold=0.99,
-            cosine_threshold=0.93,
+            hs_suspicious_threshold=0.99,
+            logprob_suspicious_threshold=0.93,
             hs_cheat_threshold=0.99,
-            cosine_cheat_threshold=0.93,
+            logprob_cheat_threshold=0.93,
             min_tasks=3,
         )
         m0 = make_miner_with_hs(0, BASE_LPS, BASE_HS)

--- a/tests/test_anti_copy.py
+++ b/tests/test_anti_copy.py
@@ -9,13 +9,13 @@ import math
 import numpy as np
 import pytest
 
-from affine.src.anti_copy.metrics import (
+from affine.src.anticopy.metrics import (
     js_divergence_topk,
     token_agreement_rate,
 )
-from affine.src.anti_copy.models import MinerLogprobs
-from affine.src.anti_copy.detector import AntiCopyDetector
-from affine.src.anti_copy.loader import _parse_tokens, MIN_TOKENS, TOP_K
+from affine.src.anticopy.models import MinerLogprobs
+from affine.src.anticopy.detector import AntiCopyDetector
+from affine.src.anticopy.loader import _parse_tokens, MIN_TOKENS, TOP_K
 
 
 # ── Helpers ──────────────────────────────────────────────────────────────────
@@ -194,6 +194,7 @@ class TestAntiCopyDetector:
     def setup_method(self):
         self.detector = AntiCopyDetector(
             cosine_threshold=0.93,
+            cosine_cheat_threshold=1.1,
             min_tasks=3,
         )
 
@@ -203,13 +204,16 @@ class TestAntiCopyDetector:
         m1 = make_miner(1, BASE_LPS)
         pairs = self.detector.detect({0: m0, 1: m1})
         copies = [p for p in pairs if p.is_copy]
-        assert len(copies) == 1
-        pair = copies[0]
+        suspicious = [p for p in pairs if p.verdict == "suspicious"]
+        assert len(copies) == 0
+        assert len(suspicious) == 1
+        pair = suspicious[0]
         # Cosine is high but not exactly 1.0 because p2 split varies by uid
         assert pair.cosine_similarity > self.detector.cosine_threshold
         # Only cos signal (no hs), votes 1/1
         assert pair.votes == 1
         assert pair.total_votes == 1
+        assert pair.verdict == "suspicious"
 
     def test_independent_models_not_flagged(self):
         """Models with different logprobs should not be flagged."""
@@ -226,8 +230,8 @@ class TestAntiCopyDetector:
         m0 = make_miner(0, BASE_LPS)
         m1 = make_miner(1, BASE_LPS, noise_std=1e-4)
         pairs = self.detector.detect({0: m0, 1: m1})
-        copies = [p for p in pairs if p.is_copy]
-        assert len(copies) == 1
+        suspicious = [p for p in pairs if p.verdict == "suspicious"]
+        assert len(suspicious) == 1
 
     def test_heavily_noised_not_flagged(self):
         """A model fine-tuned enough to have different logprobs should not be flagged."""
@@ -244,9 +248,9 @@ class TestAntiCopyDetector:
         m1 = make_miner(1, BASE_LPS)
         m2 = make_miner(2, lps_c)
         pairs = self.detector.detect({0: m0, 1: m1, 2: m2})
-        copies = [p for p in pairs if p.is_copy]
-        assert len(copies) == 1
-        assert set([copies[0].uid_a, copies[0].uid_b]) == {0, 1}
+        suspicious = [p for p in pairs if p.verdict == "suspicious"]
+        assert len(suspicious) == 1
+        assert set([suspicious[0].uid_a, suspicious[0].uid_b]) == {0, 1}
 
     def test_insufficient_tasks_skipped(self):
         """Pairs with fewer than min_tasks shared tasks are skipped."""
@@ -278,6 +282,7 @@ class TestAntiCopyDetector:
         pairs = self.detector.detect({0: m0, 1: m1})
         assert len(pairs) == 1
         assert pairs[0].is_copy is False
+        assert pairs[0].verdict == "clean"
 
     def test_confidence_range(self):
         """All confidence values must be in [0, 1]."""
@@ -301,13 +306,21 @@ class TestHiddenStatesVoting:
 
     def test_both_signals_identical(self):
         """With both cos and hs identical, should get 2/2 votes."""
+        detector = AntiCopyDetector(
+            hs_threshold=0.99,
+            cosine_threshold=0.93,
+            hs_cheat_threshold=0.99,
+            cosine_cheat_threshold=0.93,
+            min_tasks=3,
+        )
         m0 = make_miner_with_hs(0, BASE_LPS, BASE_HS)
         m1 = make_miner_with_hs(1, BASE_LPS, BASE_HS)
-        pairs = self.detector.detect({0: m0, 1: m1})
+        pairs = detector.detect({0: m0, 1: m1})
         copies = [p for p in pairs if p.is_copy]
         assert len(copies) == 1
         assert copies[0].votes == 2
         assert copies[0].total_votes == 2
+        assert copies[0].verdict == "cheat"
 
     def test_hs_only_copy(self):
         """With only hidden_states data, 1 signal is enough."""
@@ -319,14 +332,23 @@ class TestHiddenStatesVoting:
         pairs = self.detector.detect({0: m0, 1: m1})
         assert len(pairs) == 1
         assert pairs[0].is_copy is True
+        assert pairs[0].verdict == "cheat"
         assert pairs[0].votes == 1
         assert pairs[0].total_votes == 1
 
     def test_cos_disagree_not_copy(self):
         """hs agrees but cos disagrees → not copy (must be unanimous)."""
-        lps_b = {t: list(np.random.default_rng(t + 500).uniform(-5, 0, 20)) for t in range(20)}
-        m0 = make_miner_with_hs(0, BASE_LPS, BASE_HS)
-        m1 = make_miner_with_hs(1, lps_b, BASE_HS)
+        m0 = MinerLogprobs(uid=0, hotkey="hk0")
+        m1 = MinerLogprobs(uid=1, hotkey="hk1")
+        for t in range(5):
+            m0.task_hidden_states[t] = BASE_HS[t]
+            m1.task_hidden_states[t] = BASE_HS[t]
+            # Same tokens so logprob signal participates, but orthogonal
+            # vectors so cosine stays below threshold.
+            m0.task_tokens[t] = ["x", "y"]
+            m1.task_tokens[t] = ["x", "y"]
+            m0.task_logprobs[t] = np.array([1.0, 0.0, 0.0, 0.0, 1.0, 0.0], dtype=np.float32)
+            m1.task_logprobs[t] = np.array([0.0, 1.0, 0.0, 1.0, 0.0, 0.0], dtype=np.float32)
         pairs = self.detector.detect({0: m0, 1: m1})
         copies = [p for p in pairs if p.is_copy]
         assert len(copies) == 0

--- a/tests/test_champion_challenge.py
+++ b/tests/test_champion_challenge.py
@@ -52,8 +52,15 @@ def prev(hotkey, wins=0, tl=0, cl=0, cp=0, status="sampling", revision="rev1"):
                      "challenge_status": status, "revision": revision}}
 
 
-def run(cc, miners, champion_state=None, prev_states=None):
-    return cc.run(miners, ENVS, ENV_SC, champion_state, prev_states or {})
+def run(cc, miners, champion_state=None, prev_states=None, anticopy_records=None):
+    return cc.run(
+        miners,
+        ENVS,
+        ENV_SC,
+        champion_state,
+        prev_states or {},
+        anticopy_records=anticopy_records or {},
+    )
 
 
 # ── Checkpoint Gate ──────────────────────────────────────────────────────────
@@ -435,6 +442,70 @@ class TestWeights:
         assert miners[2].challenge_checkpoints_passed == 0
 
 
+class TestAntiCopyBias:
+
+    def test_suspicious_miner_needs_higher_margin_against_copied_champion(self):
+        cc = ChampionChallenge(cfg(
+            CHAMPION_DETHRONE_MIN_CHECKPOINT=1,
+            WIN_MARGIN_START=0.02,
+            WIN_MARGIN_END=0.02,
+            PARETO_SUSPICIOUS_MARGIN_MULTIPLIER=1.5,
+        ))
+        miners = {
+            1: miner(1, "hk_champ", revision="champ", scores=[0.50, 0.50]),
+            2: miner(2, "hk_susp", revision="susp", scores=[0.525, 0.525]),
+        }
+        r = run(
+            cc,
+            miners,
+            cs(revision="champ"),
+            anticopy_records={"test/model#susp": {"status": "suspicious", "copy_of_uid": 1}},
+        )
+        assert r.champion_uid == 1
+        assert miners[2].challenge_consecutive_wins == 0
+
+    def test_suspicious_miner_keeps_normal_margin_against_unrelated_target(self):
+        cc = ChampionChallenge(cfg(
+            CHAMPION_DETHRONE_MIN_CHECKPOINT=1,
+            WIN_MARGIN_START=0.02,
+            WIN_MARGIN_END=0.02,
+            PARETO_SUSPICIOUS_MARGIN_MULTIPLIER=1.5,
+        ))
+        miners = {
+            1: miner(1, "hk_champ", revision="champ", scores=[0.50, 0.50]),
+            2: miner(2, "hk_susp", revision="susp", scores=[0.525, 0.525]),
+        }
+        r = run(
+            cc,
+            miners,
+            cs(revision="champ"),
+            anticopy_records={"test/model#susp": {"status": "suspicious", "copy_of_uid": 99}},
+        )
+        assert r.champion_uid == 2
+        assert miners[2].challenge_consecutive_wins == 0
+
+    def test_pairwise_filter_uses_higher_margin_only_against_copied_uid(self):
+        cc = ChampionChallenge(cfg(
+            PARETO_MIN_WINDOWS=3,
+            PARETO_MARGIN=0.04,
+            PARETO_SUSPICIOUS_MARGIN_MULTIPLIER=1.5,
+        ))
+        n = 3 * WINDOW
+        miners = {
+            1: miner(1, "hk_champ", revision="champ", first_block=50, scores=[0.2, 0.2], n_tasks=n),
+            2: miner(2, "hk_old", revision="old", first_block=100, scores=[0.70, 0.70], n_tasks=n),
+            3: miner(3, "hk_new", revision="new", first_block=200, scores=[0.735, 0.735], n_tasks=n),
+        }
+        run(
+            cc,
+            miners,
+            cs(revision="champ"),
+            anticopy_records={"test/model#new": {"status": "suspicious", "copy_of_uid": 2}},
+        )
+        assert miners[2].challenge_status == "sampling"
+        assert miners[3].challenge_status == "terminated"
+
+
 # ── Edge Cases ───────────────────────────────────────────────────────────────
 
 class TestEdgeCases:
@@ -515,4 +586,3 @@ class TestEdgeCases:
             prev("hk_dead", status="terminated", tl=5, cl=5, cp=5))
         assert miners[2].challenge_status == "terminated"
         assert miners[3].challenge_status == "sampling"
-

--- a/tests/test_champion_challenge.py
+++ b/tests/test_champion_challenge.py
@@ -444,7 +444,10 @@ class TestWeights:
 
 class TestAntiCopyBias:
 
-    def test_suspicious_miner_needs_higher_margin_against_copied_champion(self):
+    def test_suspicious_bias_does_not_apply_to_champion_challenge(self):
+        # Gap 0.025 > WIN_MARGIN_END 0.02 but < margin*1.5=0.03.
+        # If anti-copy bias applied to challenges, 2 would be blocked;
+        # since bias is pairwise-only, 2 dethrones 1 normally.
         cc = ChampionChallenge(cfg(
             CHAMPION_DETHRONE_MIN_CHECKPOINT=1,
             WIN_MARGIN_START=0.02,
@@ -461,8 +464,7 @@ class TestAntiCopyBias:
             cs(revision="champ"),
             anticopy_records={"test/model#susp": {"status": "suspicious", "copy_of_uid": 1}},
         )
-        assert r.champion_uid == 1
-        assert miners[2].challenge_consecutive_wins == 0
+        assert r.champion_uid == 2
 
     def test_suspicious_miner_keeps_normal_margin_against_unrelated_target(self):
         cc = ChampionChallenge(cfg(


### PR DESCRIPTION
## Summary
- add `clean`/`suspicious`/`cheat` anti-copy statuses with DAO fallback for legacy `is_copy` records
- keep `suspicious` miners valid in monitor while annotating the anti-copy reason, and only invalidate `cheat`
- raise the Pareto margin only when a suspicious miner tries to outrank the specific miner it copied from
- update anti-copy and champion challenge tests to cover the new thresholds and copied-target behavior

## Testing
- `uv run --with pytest python -m pytest tests/test_anti_copy.py -q`
- `uv run --with pytest python -m pytest tests/test_champion_challenge.py -q`