### PR TITLE
Keep cold miners in Pareto, preserve challenge state across redeploys, bump slot floor

### DIFF
--- a/affine/api/services/scoring_cache.py
+++ b/affine/api/services/scoring_cache.py
@@ -183,28 +183,23 @@ class ScoringCacheManager:
         previous_miner_keys = getattr(self, '_previous_miner_keys', set())
         removed_miners = previous_miner_keys - current_miner_keys
 
-        # 3. Remove invalid miner cache, but keep terminated miners
-        # so their last known scores are preserved in scoring_data
+        # 3. Handle invalid miners (cold or terminated):
+        # - Drop them from SAMPLING cache so the sampler stops scheduling
+        #   new tasks for miners that can't respond.
+        # - Keep them in SCORING cache so the champion-challenge Pareto
+        #   can still evaluate them on their historical common-task data.
+        #   Otherwise a miner could go cold to freeze its loss counter
+        #   and escape termination.
         if removed_miners:
-            from affine.database.dao.miner_stats import MinerStatsDAO
-            miner_stats_dao = MinerStatsDAO()
             for hotkey, revision in removed_miners:
                 key = f"{hotkey}#{revision}"
-
-                # Check if this miner is terminated — if so, keep cache
-                try:
-                    state = await miner_stats_dao.get_challenge_state(hotkey, revision)
-                    if state.get('challenge_status') == 'terminated':
-                        logger.debug(f"Keeping cache for terminated miner {hotkey[:8]}...")
-                        continue
-                except Exception:
-                    pass
-
-                # Remove from both caches
-                self._scoring_data.pop(key, None)
+                # Stop scheduling new samples for cold/terminated miners.
                 self._sampling_data.pop(key, None)
-
-                logger.info(f"Removed cache for invalid miner {hotkey[:8]}...#{revision[:8]}...")
+                # Scoring cache stays; section 5b below refreshes it
+                # with the latest DB row so env data/UID are current.
+                logger.debug(
+                    f"Miner {hotkey[:8]}...#{revision[:8]}... no longer valid; "
+                    f"keeping in scoring cache, dropped from sampling cache")
         
         # 4. Get environment configurations
         environments = await system_config_dao.get_param_value('environments', {})
@@ -255,12 +250,15 @@ class ScoringCacheManager:
                 # Update UID if it changed
                 self._sampling_data[key]['uid'] = uid
         
-        # 5b. Also include terminated miners not in valid_miners,
-        # so their last known scores remain visible in af get-rank.
-        from affine.database.dao.miner_stats import MinerStatsDAO
-        miner_stats_dao = MinerStatsDAO()
+        # 5b. Also include every DB miner not already in valid_miners
+        # (cold, terminated, or otherwise invalid) in the SCORING cache
+        # only. These miners don't sample new tasks, but the scorer
+        # still Pareto-evaluates them against the champion using their
+        # historical common-task data — so going cold no longer freezes
+        # the loss counter and doesn't let a terminated miner evade
+        # termination by dropping out.
         all_db_miners = await miners_dao.get_all_miners()
-        terminated_added = 0
+        extra_added = 0
         for miner in all_db_miners:
             hotkey = miner.get('hotkey', '')
             revision = miner.get('revision', '')
@@ -269,12 +267,9 @@ class ScoringCacheManager:
             if (hotkey, revision) in current_miner_keys:
                 continue  # Already in valid_miners
             key = f"{hotkey}#{revision}"
-            try:
-                state = await miner_stats_dao.get_challenge_state(hotkey, revision)
-                if state.get('challenge_status') != 'terminated':
-                    continue
-            except Exception:
-                continue
+            # Only add to scoring (not sampling). Samples won't be
+            # requested; the env data below reflects whatever is still
+            # in sample_results (within its 30-day TTL).
             if key not in self._scoring_data:
                 self._scoring_data[key] = {
                     'uid': miner.get('uid', 0),
@@ -284,11 +279,23 @@ class ScoringCacheManager:
                     'first_block': miner.get('first_block', 0),
                     'env': {}
                 }
-                # Add to valid_miners list so step 6 queries their samples
-                valid_miners.append(miner)
-                terminated_added += 1
-        if terminated_added:
-            logger.info(f"Added {terminated_added} terminated miners to scoring cache")
+            else:
+                # Keep the entry but refresh top-level fields in case
+                # model/UID/first_block moved.
+                self._scoring_data[key].update({
+                    'uid': miner.get('uid', 0),
+                    'model_repo': miner.get('model',
+                                            self._scoring_data[key].get('model_repo', '')),
+                    'first_block': miner.get('first_block',
+                                             self._scoring_data[key].get('first_block', 0)),
+                })
+            # Add to valid_miners list so step 6 re-queries their samples.
+            valid_miners.append(miner)
+            extra_added += 1
+        if extra_added:
+            logger.info(
+                f"Added {extra_added} non-valid miners (cold/terminated) to scoring cache "
+                f"for continued Pareto evaluation")
 
         # 6. Build concurrent query tasks for ALL miner×env combinations
         async def query_and_populate(miner: dict, env_name: str, env_config: dict):

--- a/affine/database/dao/miner_stats.py
+++ b/affine/database/dao/miner_stats.py
@@ -435,6 +435,49 @@ class MinerStatsDAO(BaseDAO):
             logger.error(f"Failed to update sampling slots for {hotkey[:8]}...: {e}")
             return False
 
+    # Fields that make up a miner's challenge state (loss/win counters etc.)
+    _CHALLENGE_FIELDS = (
+        'challenge_consecutive_wins',
+        'challenge_total_losses',
+        'challenge_consecutive_losses',
+        'challenge_checkpoints_passed',
+        'challenge_status',
+        'termination_reason',
+    )
+
+    @staticmethod
+    def _challenge_defaults() -> Dict[str, Any]:
+        return {
+            'challenge_consecutive_wins': 0,
+            'challenge_total_losses': 0,
+            'challenge_consecutive_losses': 0,
+            'challenge_checkpoints_passed': 0,
+            'challenge_status': 'sampling',
+            'termination_reason': '',
+        }
+
+    @classmethod
+    def _extract_challenge_state(cls, stats: Dict[str, Any]) -> Dict[str, Any]:
+        """Pick only the challenge_* fields out of a stats row."""
+        defaults = cls._challenge_defaults()
+        return {k: stats.get(k, defaults[k]) for k in cls._CHALLENGE_FIELDS}
+
+    @staticmethod
+    def _has_challenge_state(stats: Dict[str, Any]) -> bool:
+        """True if the stats row actually has any challenge_* counter set
+        (not just defaults from a freshly-initialised sampling record).
+        We ignore the default 'sampling' status + zero counters case, since
+        that means the scorer has never written to this row yet."""
+        if not stats:
+            return False
+        for k in ('challenge_total_losses', 'challenge_consecutive_losses',
+                  'challenge_consecutive_wins', 'challenge_checkpoints_passed'):
+            if stats.get(k, 0):
+                return True
+        if stats.get('challenge_status') == 'terminated':
+            return True
+        return False
+
     async def get_challenge_state(
         self,
         hotkey: str,
@@ -442,26 +485,47 @@ class MinerStatsDAO(BaseDAO):
     ) -> Dict[str, Any]:
         """Get challenge state for a miner.
 
-        Returns challenge fields with defaults if not present (backward compatible).
+        Identity is hotkey: a miner that redeploys (revision change) or
+        bounces cold/hot should not lose accumulated losses, wins, CP, or
+        terminated status. Priority order:
+
+        1. Direct row at (hotkey, revision) with real challenge state → use it.
+        2. Fallback: most recently-updated row for this hotkey that carries
+           real challenge state → inherit it (losses persist across
+           revisions, terminated stays terminated forever).
+        3. Nothing found → fresh defaults (brand-new hotkey).
         """
-        stats = await self.get_miner_stats(hotkey, revision)
-        if not stats:
-            return {
-                'challenge_consecutive_wins': 0,
-                'challenge_total_losses': 0,
-                'challenge_consecutive_losses': 0,
-                'challenge_checkpoints_passed': 0,
-                'challenge_status': 'sampling',
-                'termination_reason': '',
-            }
-        return {
-            'challenge_consecutive_wins': stats.get('challenge_consecutive_wins', 0),
-            'challenge_total_losses': stats.get('challenge_total_losses', 0),
-            'challenge_consecutive_losses': stats.get('challenge_consecutive_losses', 0),
-            'challenge_checkpoints_passed': stats.get('challenge_checkpoints_passed', 0),
-            'challenge_status': stats.get('challenge_status', 'sampling'),
-            'termination_reason': stats.get('termination_reason', ''),
-        }
+        direct = await self.get_miner_stats(hotkey, revision)
+        if self._has_challenge_state(direct):
+            return self._extract_challenge_state(direct)
+
+        # Fallback: scan all revisions for this hotkey and pick the freshest
+        # row that actually carries challenge state. DynamoDB PK query, not
+        # a table scan, so this is an O(revisions-per-hotkey) operation.
+        try:
+            all_rows = await self.query(pk=self._make_pk(hotkey))
+        except Exception as e:
+            logger.warning(
+                f"get_challenge_state fallback query failed for {hotkey[:8]}...: {e}"
+            )
+            all_rows = []
+
+        candidates = [r for r in all_rows if self._has_challenge_state(r)]
+        if candidates:
+            latest = max(candidates, key=lambda r: r.get('last_updated_at', 0))
+            logger.debug(
+                f"get_challenge_state inherited state for {hotkey[:8]}... "
+                f"(target rev={revision[:8]}..., source rev={latest.get('revision','?')[:8]}..., "
+                f"losses={latest.get('challenge_total_losses', 0)}, "
+                f"status={latest.get('challenge_status', 'sampling')})"
+            )
+            return self._extract_challenge_state(latest)
+
+        # Direct row exists but has no challenge state (e.g., freshly created
+        # by update_sampling_stats). Return its fields (all zeros/sampling).
+        if direct:
+            return self._extract_challenge_state(direct)
+        return self._challenge_defaults()
 
     async def update_challenge_state(
         self,

--- a/affine/database/dao/miner_stats.py
+++ b/affine/database/dao/miner_stats.py
@@ -98,7 +98,7 @@ class MinerStatsDAO(BaseDAO):
                 'is_currently_online': is_online,
                 'sampling_stats': {},
                 'env_stats': {},
-                'sampling_slots': 15,  # Default slots (1.5x MIN_SLOTS)
+                'sampling_slots': 20,  # Default = MIN_SLOTS (slots_adjuster)
                 'slots_last_adjusted_at': 0  # Never adjusted
             }
         
@@ -197,7 +197,7 @@ class MinerStatsDAO(BaseDAO):
                 'is_currently_online': True,
                 'sampling_stats': global_stats,
                 'env_stats': env_stats,
-                'sampling_slots': 15,  # Default slots (1.5x MIN_SLOTS)
+                'sampling_slots': 20,  # Default = MIN_SLOTS (slots_adjuster)
                 'slots_last_adjusted_at': 0  # Never adjusted
             }
             await self.put(updated_item)

--- a/affine/src/scheduler/slots_adjuster.py
+++ b/affine/src/scheduler/slots_adjuster.py
@@ -19,19 +19,20 @@ class MinerSlotsAdjuster:
     Uses sampling_stats from MinerStats table (last_1hour window) to determine
     success rate. No need to query sample_results table.
     
-    Adjustment rules:
-    - Only adjust miners with >10 samples in last 1 hour
-    - Success rate >= 90%: slots + 1 (max 16)
-    - Success rate < 50%: slots - 1 (min 10)
-    - Adjustment runs every 2 hours
-    
+    Adjustment rules (see constants below for current values):
+    - Only adjust miners with >= MIN_SAMPLES_FOR_ADJUSTMENT samples
+      in the last 6 hours.
+    - Success rate >= HIGH_SUCCESS_THRESHOLD: slots += 6 (cap MAX_SLOTS).
+    - Success rate <  LOW_SUCCESS_THRESHOLD:  slots -= 1 (floor MIN_SLOTS).
+    - Adjustment loop runs every ADJUSTMENT_INTERVAL seconds.
+
     Persistence:
     - sampling_slots stored in MinerStats table
     - slots_last_adjusted_at tracks last adjustment time
     """
-    
-    DEFAULT_SLOTS = 10
-    MIN_SLOTS = 10
+
+    DEFAULT_SLOTS = 20
+    MIN_SLOTS = 20
     MAX_SLOTS = 50
     ADJUSTMENT_INTERVAL = 21600  # 6 hours in seconds
     MIN_SAMPLES_FOR_ADJUSTMENT = 50
@@ -189,7 +190,7 @@ class MinerSlotsAdjuster:
         action = "unchanged"
 
         if success_rate >= self.HIGH_SUCCESS_THRESHOLD:
-            new_slots = min(current_slots + 3, self.MAX_SLOTS)
+            new_slots = min(current_slots + 6, self.MAX_SLOTS)
             if new_slots > current_slots:
                 action = "increased"
         elif success_rate < self.LOW_SUCCESS_THRESHOLD:

--- a/affine/src/scorer/scorer.py
+++ b/affine/src/scorer/scorer.py
@@ -20,7 +20,7 @@ from affine.core.setup import logger
 # later because CP monotonicity blocks re-triggering within the reign).
 FIRST_CHALLENGE_SLOTS_BONUS = 10
 FIRST_CHALLENGE_SLOTS_CAP = 30
-FIRST_CHALLENGE_DEFAULT_SLOTS = 15  # Matches MinerStatsDAO's init default
+FIRST_CHALLENGE_DEFAULT_SLOTS = 20  # Matches MinerStatsDAO init default / slots_adjuster MIN_SLOTS
 
 
 class Scorer:


### PR DESCRIPTION
## Summary

- **Preserve challenge state across revision changes / cold-hot cycles**: `get_challenge_state` now treats hotkey as the identity. If the direct `(hotkey, revision)` row carries no state (freshly created by `update_sampling_stats` after a redeploy, cleanup, or first sample), it falls back to the most-recently-updated row for the same hotkey and inherits losses / wins / CP / terminated status. Terminated stays terminated, so a redeploy can't bypass termination.

- **Keep cold miners in Pareto evaluation**: invalid miners are now only dropped from the sampling cache. The scoring cache keeps them so champion-challenge Pareto keeps firing on their historical common-task data — going cold no longer freezes the loss counter.

- **Bump slot floor**: `MIN_SLOTS` / `DEFAULT_SLOTS` 10 → 20, high-success step 3 → 6. `MinerStatsDAO` init default and `FIRST_CHALLENGE_DEFAULT_SLOTS` both raised to 20 so the three spots agree.