### PR TITLE
Rewrite scheduler: rotation-rate-weighted dynamic slots, head-first, drop paused

### DIFF
--- a/affine/api/services/task_pool.py
+++ b/affine/api/services/task_pool.py
@@ -662,19 +662,22 @@ class TaskPoolManager:
                 error_code
             )
 
-            # fail_task() returns either 'paused' or 'pending' status
-            if updated_task['status'] == 'paused':
-                # Max retries reached, paused
+            # fail_task returns None on max retries: the task record
+            # has been deleted. The scheduler may recreate it next
+            # cycle if the task_id is still in the sampling list;
+            # otherwise rotation will move on from it.
+            if updated_task is None:
                 async with self._cache_lock:
                     self._uuid_cache.pop(task_uuid, None)
-                
+                retries = task.get('retry_count', 0) + 1
+                max_retries = task.get('max_retries')
                 logger.warning(
-                    f"Task {task_uuid} paused"
-                    f"{updated_task['retry_count']} retries (max={updated_task['max_retries']})"
+                    f"Task {task_uuid} dropped after "
+                    f"{retries} retries (max={max_retries})"
                 )
                 return {
-                    'status': 'paused',
-                    'message': f"Task paused after {updated_task['retry_count']} retries"
+                    'status': 'dropped',
+                    'message': f"Task dropped after {retries} retries"
                 }
             
             # Status is 'pending', will retry (assigned_at is None for pending)

--- a/affine/database/cli.py
+++ b/affine/database/cli.py
@@ -1408,7 +1408,7 @@ async def cmd_get_pool():
                 # Get completed task IDs and pool task IDs concurrently
                 completed_taskids, pool_taskids = await asyncio.gather(
                     sample_dao.get_completed_task_ids(hotkey, revision, env),
-                    task_dao.get_pending_task_ids_for_miner(hotkey, revision, env, include_paused=True)
+                    task_dao.get_pending_task_ids_for_miner(hotkey, revision, env)
                 )
                 
                 # Calculate missing tasks

--- a/affine/database/dao/task_pool.py
+++ b/affine/database/dao/task_pool.py
@@ -403,62 +403,41 @@ class TaskPoolDAO(BaseDAO):
         task: Dict[str, Any],
         error_message: str,
         error_code: str = 'EXECUTION_ERROR'
-    ) -> Dict[str, Any]:
+    ) -> Optional[Dict[str, Any]]:
         """Record task failure and handle retry logic.
-        
-        If retry_count < max_retries, reset status to 'pending'.
-        Otherwise, set status to 'paused'.
-        
-        Strategy: Create new task first, then delete old task to avoid race condition.
-        
+
+        If retry_count < max_retries, reset status to 'pending' (the
+        scheduler will re-assign it). Otherwise DELETE the task and
+        return None — the scheduler will either recreate it next cycle
+        (if the sampling list still contains this task_id) or simply
+        move on (rotation removes it within minutes). This replaces
+        the old 4-hour 'paused' DB state, unnecessary given the small
+        sampling windows and short rotation cycles.
+
         Args:
             task: Task dict
             error_message: Error description
             error_code: Error classification code
-            
+
         Returns:
-            Updated task (or task with status='paused' if max retries reached)
+            Updated task if still retryable; None if deleted on max retries.
         """
         # Save old PK/SK for deletion
         old_pk = task['pk']
         old_sk = task['sk']
-        
+
         retry_count = task.get('retry_count', 0) + 1
         max_retries = task.get('max_retries')
-        
+
         if retry_count >= max_retries:
             logger.info(
-                f"Task paused after {retry_count} retries: "
+                f"Task deleted after {retry_count} retries: "
                 f"miner={task['miner_hotkey'][:12]}... env={task['env']} "
                 f"task_id={task['task_id']} error={error_message[:100]}"
             )
-            
-            new_status = 'paused'
-            new_sk = self._make_sk(task['env'], new_status, task['task_id'])
-            new_gsi1_pk = self._make_gsi1_pk(task['env'], new_status)
-            new_gsi1_sk = self._make_gsi1_sk(
-                task['miner_hotkey'],
-                task['model_revision'],
-                task['task_id']
-            )
-            
-            task['sk'] = new_sk
-            task['status'] = new_status
-            task['retry_count'] = retry_count
-            task['last_error'] = error_message
-            task['last_error_code'] = error_code
-            task['last_failed_at'] = int(time.time())
-            task['assigned_to'] = None
-            task['assigned_at'] = None
-            task['gsi1_pk'] = new_gsi1_pk
-            task['gsi1_sk'] = new_gsi1_sk
-            task['ttl'] = int(time.time()) + 3600 * 4
-            
-            await self.put(task)
             await self.delete(old_pk, old_sk)
-            
-            return task
-        
+            return None
+
         # Still have retries left, reset to pending
         new_status = 'pending'
         new_sk = self._make_sk(task['env'], new_status, task['task_id'])
@@ -491,28 +470,20 @@ class TaskPoolDAO(BaseDAO):
         miner_hotkey: str,
         model_revision: str,
         env: str,
-        include_paused: bool = True
     ) -> Set[int]:
         """Get set of task_ids in queue for a miner's env.
-        
-        Used by task generator to avoid creating duplicate tasks.
-        
-        Args:
-            miner_hotkey: Miner's hotkey
-            model_revision: Model revision
-            env: Environment name
-            include_paused: Whether to include paused tasks (default: True)
-                - True: Include paused tasks (for duplicate detection)
-                - False: Exclude paused tasks (for concurrency control)
-            
-        Returns:
-            Set of task_ids (integers)
+
+        Used by task generator to avoid creating duplicate tasks, and
+        by the scheduler to count active tasks against the miner's slot
+        budget. Only `pending` and `assigned` statuses are ever present
+        since `fail_task` now deletes on max retries instead of marking
+        tasks `paused`.
         """
         from affine.database.client import get_client
         client = get_client()
-        
+
         pk = self._make_pk(miner_hotkey, model_revision)
-        
+
         params = {
             'TableName': self.table_name,
             'KeyConditionExpression': 'pk = :pk AND begins_with(sk, :sk_prefix)',
@@ -523,30 +494,25 @@ class TaskPoolDAO(BaseDAO):
             'ProjectionExpression': 'task_id, #status',
             'ExpressionAttributeNames': {'#status': 'status'}
         }
-        
+
         all_items = []
         last_key = None
-        
+
         while True:
             if last_key:
                 params['ExclusiveStartKey'] = last_key
-            
+
             response = await client.query(**params)
             items = response.get('Items', [])
             all_items.extend([self._deserialize(item) for item in items])
-            
+
             last_key = response.get('LastEvaluatedKey')
             if not last_key:
                 break
-        
-        # Filter by status based on include_paused parameter
-        valid_statuses = ['pending', 'assigned']
-        if include_paused:
-            valid_statuses.append('paused')
-        
+
         return {
             item['task_id'] for item in all_items
-            if item.get('status') in valid_statuses
+            if item.get('status') in ('pending', 'assigned')
         }
     
     async def cleanup_invalid_tasks(
@@ -939,76 +905,3 @@ class TaskPoolDAO(BaseDAO):
         logger.info(f"Deleted {deleted_count} assigned tasks on startup")
         return deleted_count
     
-    async def get_all_paused_tasks(self) -> List[Dict[str, Any]]:
-        """Get all paused tasks across all environments.
-        
-        Uses FilterExpression to scan only paused tasks.
-        Used by cleanup loop to remove expired tasks.
-        
-        Returns:
-            List of paused tasks with full attributes including ttl
-        """
-        from affine.database.client import get_client
-        client = get_client()
-        
-        params = {
-            'TableName': self.table_name,
-            'FilterExpression': '#status = :status',
-            'ExpressionAttributeNames': {'#status': 'status'},
-            'ExpressionAttributeValues': {':status': {'S': 'paused'}}
-        }
-        
-        all_tasks = []
-        last_key = None
-        
-        while True:
-            if last_key:
-                params['ExclusiveStartKey'] = last_key
-            
-            response = await client.scan(**params)
-            items = response.get('Items', [])
-            
-            for item in items:
-                all_tasks.append(self._deserialize(item))
-            
-            last_key = response.get('LastEvaluatedKey')
-            if not last_key:
-                break
-        
-        return all_tasks
-    
-    async def cleanup_expired_paused_tasks(self) -> int:
-        """Clean up paused tasks that have exceeded their TTL.
-        
-        This handles cases where DynamoDB TTL deletion is delayed.
-        
-        Returns:
-            Number of expired tasks deleted
-        """
-        current_time = int(time.time())
-        
-        # Get all paused tasks
-        paused_tasks = await self.get_all_paused_tasks()
-        
-        if not paused_tasks:
-            return 0
-        
-        # Filter tasks that have exceeded TTL
-        expired_tasks = [
-            task for task in paused_tasks
-            if task.get('ttl', 0) > 0 and task['ttl'] <= current_time
-        ]
-        
-        if not expired_tasks:
-            logger.debug(f"Found {len(paused_tasks)} paused tasks, none expired")
-            return 0
-        
-        # Batch delete expired tasks
-        deleted_count = await self._batch_delete_tasks(expired_tasks)
-        
-        logger.info(
-            f"Cleaned up {deleted_count} expired paused tasks "
-            f"(out of {len(paused_tasks)} total paused tasks)"
-        )
-        
-        return deleted_count

--- a/affine/database/system_config.json
+++ b/affine/database/system_config.json
@@ -4,21 +4,18 @@
     "GAME": {
       "enabled_for_sampling": true,
       "enabled_for_scoring": true,
-      "min_completeness": 0.85,
       "sampling_config": {
         "dataset_range": [[0, 500000000],[600000000, 800000000]],
         "sampling_count": 50,
         "rotation_enabled": true,
         "rotation_count": 1,
-        "rotation_interval": 170,
-        "scheduling_weight": 3.0
+        "rotation_interval": 170
       }
     },
     "SWE-INFINITE": {
       "display_name": "SWE",
       "enabled_for_sampling": true,
       "enabled_for_scoring": true,
-      "min_completeness": 0.6,
       "sampling_config": {
         "dataset_range": [[1616, 1716]],
         "dataset_range_source": {
@@ -29,66 +26,56 @@
         "sampling_count": 40,
         "rotation_enabled": true,
         "rotation_count": 1,
-        "rotation_interval": 260,
-        "scheduling_weight": 1.0
+        "rotation_interval": 260
       }
     },
     "LIVEWEB": {
       "enabled_for_sampling": true,
       "enabled_for_scoring": true,
-      "min_completeness": 0.8,
       "sampling_config": {
         "dataset_range": [[0, 78060000]],
         "sampling_count": 50,
         "rotation_enabled": true,
         "rotation_count": 1,
-        "rotation_interval": 170,
-        "scheduling_weight": 1.0
+        "rotation_interval": 170
       }
     },
     "LOGPROBS": {
       "enabled_for_sampling": true,
       "enabled_for_scoring": false,
-      "min_completeness": 0.9,
       "sampling_config": {
         "dataset_range": [[100000000, 400000000]],
         "sampling_count": 50,
         "rotation_enabled": true,
         "rotation_count": 1,
-        "rotation_interval": 21600,
-        "scheduling_weight": 1.0
+        "rotation_interval": 21600
       }
     },
     "NAVWORLD": {
       "enabled_for_sampling": true,
       "enabled_for_scoring": true,
-      "min_completeness": 0.85,
       "sampling_config": {
         "dataset_range": [[0, 1000000000]],
         "sampling_count": 50,
         "rotation_enabled": true,
         "rotation_count": 1,
-        "rotation_interval": 170,
-        "scheduling_weight": 1.0
+        "rotation_interval": 170
       }
     },
     "MEMORY": {
       "enabled_for_sampling": true,
       "enabled_for_scoring": true,
-      "min_completeness": 0.8,
       "sampling_config": {
         "dataset_range": [[0, 1000000000]],
         "sampling_count": 40,
         "rotation_enabled": true,
         "rotation_count": 1,
-        "rotation_interval": 220,
-        "scheduling_weight": 3.0
+        "rotation_interval": 220
       }
     },
     "DISTILL": {
       "enabled_for_sampling": true,
       "enabled_for_scoring": true,
-      "min_completeness": 0.6,
       "sampling_config": {
         "dataset_range": [[30, 110]],
         "dataset_range_source": {
@@ -99,8 +86,7 @@
         "sampling_count": 30,
         "rotation_enabled": true,
         "rotation_count": 1,
-        "rotation_interval": 290,
-        "scheduling_weight": 1.0
+        "rotation_interval": 290
       }
     }
   }

--- a/affine/src/scheduler/main.py
+++ b/affine/src/scheduler/main.py
@@ -5,7 +5,6 @@ Runs the TaskScheduler as an independent background service.
 This service generates sampling tasks for all miners periodically.
 """
 
-import os
 import asyncio
 import signal
 import click
@@ -16,7 +15,7 @@ from .sampling_scheduler import SamplingScheduler, PerMinerSamplingScheduler
 from .slots_adjuster import MinerSlotsAdjuster
 
 
-async def run_service(cleanup_interval: int):
+async def run_service():
     """Run the task scheduler service."""
     logger.info("Starting Task Scheduler Service")
     
@@ -125,12 +124,8 @@ def main(verbosity):
     # Setup logging if verbosity specified
     if verbosity is not None:
         setup_logging(int(verbosity))
-    
-    # Cleanup interval for expired paused tasks
-    cleanup_interval = int(os.getenv("SCHEDULER_CLEANUP_INTERVAL", "300"))
 
-    # Run service
-    asyncio.run(run_service(cleanup_interval=cleanup_interval))
+    asyncio.run(run_service())
 
 
 if __name__ == "__main__":

--- a/affine/src/scheduler/sampling_scheduler.py
+++ b/affine/src/scheduler/sampling_scheduler.py
@@ -23,14 +23,19 @@ class PerMinerSamplingScheduler:
     """Per-miner sampling pool scheduler with weighted allocation.
 
     Architecture:
-    1. Each miner has dynamic slots (3-12, default 6), stored in MinerStats
-    2. Weighted allocation across environments based on scheduling_weight config
-    3. Minimum guarantee: each env gets at least 1 slot
-    4. Incremental scheduling every 10s
-    5. Priority-based task selection from sampling list tail
-    6. Rate limiting: actual sampling rate is limited to rotation_rate * RATE_MARGIN
-       to prevent answer memorization attacks (independent of rotation_enabled)
-    7. Rate is based on rotation rate only — no minimum guarantee
+    1. Each miner has dynamic slots (MIN_SLOTS-MAX_SLOTS), stored in MinerStats
+    2. Per-miner dynamic env weights derived from each env's window
+       completeness (laggard envs get more slots; saturated envs trickle)
+    3. Anti-starvation: envs with no active but missing tasks are reserved
+       one slot before weighted fairness allocation
+    4. Head-first task selection within each env (Earliest Deadline First —
+       oldest tasks are closest to rotating out of the sampling list)
+    5. Rate limiting: actual sampling rate is limited to rotation_rate *
+       RATE_MARGIN to prevent answer memorization attacks
+    6. Failed tasks: max retries → deleted. Sampling-list rotation
+       (minutes to hours, depending on env) naturally retires the task
+       ID so a persistently-failing task self-limits; no paused state or
+       cooldown needed.
     """
 
     DEFAULT_SLOTS = 10
@@ -39,7 +44,7 @@ class PerMinerSamplingScheduler:
 
     # Rate limiting: allow actual sampling rate to exceed rotation rate by this margin
     RATE_MARGIN = 1.2
-    
+
     def __init__(
         self,
         system_config_dao: Optional[SystemConfigDAO] = None,
@@ -204,22 +209,81 @@ class PerMinerSamplingScheduler:
             logger.debug(f"Error getting miner slots, using default: {e}")
             return self.DEFAULT_SLOTS
     
-    def _get_env_weights(self, environments: Dict[str, Any]) -> Dict[str, float]:
-        """Extract scheduling weights from environment configurations.
+    # Floor weight for envs at 100 % completeness. Keeps a trickle of
+    # slots flowing into saturated envs so newly rotated-in tasks still
+    # get sampled promptly; too low and the tail-end rotation would
+    # starve, too high and laggard envs lose their priority advantage.
+    ENV_WEIGHT_FLOOR = 0.1
 
-        Args:
-            environments: Full environment configurations
+    def _compute_env_completeness(
+        self,
+        sampling_envs: List[str],
+        environments: Dict[str, Any],
+        env_missing_tasks: Dict[str, List[int]],
+        env_active_counts: Dict[str, int],
+    ) -> Dict[str, float]:
+        """How much of each env's current sampling window this miner has
+        already covered, in [0.0, 1.0].
 
-        Returns:
-            Dict mapping env name to weight (default 1.0 if not configured)
+        completed ≈ window_size - |missing| - active
+        completeness = completed / window_size, clamped to [0, 1].
         """
-        weights = {}
-        for env_name, env_config in environments.items():
-            if not env_config.get('enabled_for_sampling', False):
-                continue
-            sampling_config = env_config.get('sampling_config', {})
-            # Default weight is 1.0 if not specified
-            weights[env_name] = float(sampling_config.get('scheduling_weight', 1.0))
+        out: Dict[str, float] = {}
+        for env in sampling_envs:
+            cfg = environments.get(env, {}).get('sampling_config', {}) or {}
+            window = max(1, int(cfg.get('sampling_count', 0) or 1))
+            missing = len(env_missing_tasks.get(env, []))
+            active = int(env_active_counts.get(env, 0))
+            completed = window - missing - active
+            if completed < 0:
+                completed = 0
+            out[env] = min(1.0, completed / window)
+        return out
+
+    def _get_env_weights_for_miner(
+        self,
+        sampling_envs: List[str],
+        environments: Dict[str, Any],
+        completeness_map: Dict[str, float],
+    ) -> Dict[str, float]:
+        """Per-miner dynamic env weights.
+
+        weight[env] = rotation_rate[env] × deficit_factor[env]
+
+          rotation_rate  = rotation_count / rotation_interval (tasks/sec)
+          deficit_factor = max(ENV_WEIGHT_FLOOR, 1 - completeness[env])
+
+        Rationale. Each env needs a miner to sample at its own rotation
+        rate to keep the window populated. Slot share should therefore
+        track rotation_rate, not be uniform.
+
+        - Fully keeping up: every env saturates, deficit_factor collapses
+          to FLOOR for all, so slot shares still sit in rotation_rate
+          proportions — just at trickle level, enough to accept newly
+          rotated-in tasks.
+        - Falling behind uniformly: all envs unsaturated, deficit_factor
+          ≈ 1 for all, so shares ∝ rotation_rate. Each env lags its
+          rotation at the same fraction — nothing is singled out.
+        - Mixed: saturated envs drop to FLOOR trickle; the freed slots
+          go to laggard envs still in rotation_rate proportion.
+
+        rotation_count == 0 (rotation disabled) falls back to base 1.0
+        so the env still gets a share.
+        """
+        weights: Dict[str, float] = {}
+        for env in sampling_envs:
+            cfg = environments.get(env, {}).get('sampling_config', {}) or {}
+            rot_interval = float(cfg.get('rotation_interval', 0) or 0)
+            rot_count = float(cfg.get('rotation_count', 0) or 0)
+            if rot_count > 0 and rot_interval > 0:
+                base = rot_count / rot_interval
+            else:
+                base = 1.0
+            deficit_factor = max(
+                self.ENV_WEIGHT_FLOOR,
+                1.0 - completeness_map.get(env, 0.0),
+            )
+            weights[env] = base * deficit_factor
         return weights
 
     def _get_allocation_count(
@@ -385,7 +449,7 @@ class PerMinerSamplingScheduler:
         # Get miner's total slots from MinerStats
         total_slots = await self._get_miner_slots(miner)
 
-        # Get current active task count per env (exclude paused tasks)
+        # Get current active task count per env (pending + assigned)
         env_active_counts: Dict[str, int] = {}
         total_pool_count = 0
 
@@ -394,7 +458,6 @@ class PerMinerSamplingScheduler:
                 miner_hotkey=hotkey,
                 model_revision=revision,
                 env=env,
-                include_paused=False
             )
             env_active_counts[env] = len(active_task_ids)
             total_pool_count += len(active_task_ids)
@@ -453,10 +516,18 @@ class PerMinerSamplingScheduler:
             return
         
         slots_available = allowed_total - total_pool_count
-        
-        # Get env weights for weighted allocation
-        env_weights = self._get_env_weights(environments)
-        
+
+        # Per-miner dynamic env weights: laggard envs (low window
+        # completeness) get the bulk of this miner's slots; near-
+        # saturated envs drop to a floor so they still accept a trickle
+        # for newly rotated-in tasks.
+        env_completeness = self._compute_env_completeness(
+            sampling_envs, environments, env_missing_tasks, env_active_counts
+        )
+        env_weights = self._get_env_weights_for_miner(
+            sampling_envs, environments, env_completeness
+        )
+
         # Select tasks to create with weighted allocation strategy
         tasks_to_create = self._select_tasks_to_create(
             env_missing_tasks=env_missing_tasks,
@@ -480,7 +551,8 @@ class PerMinerSamplingScheduler:
     ) -> List[int]:
         """Get missing task IDs for a miner in an environment.
         
-        Prioritizes tasks from the tail of sampling list.
+        Prioritizes tasks from the head of the sampling list (Earliest
+        Deadline First — head tasks are closest to being rotated out).
         
         Returns:
             List of missing task IDs, ordered by priority (tail first)
@@ -522,13 +594,17 @@ class PerMinerSamplingScheduler:
         if not missing_ids:
             return []
         
-        # Prioritize tasks from tail (reverse order)
-        # Tasks at the tail are less likely to be rotated out
+        # Head-first (Earliest Deadline First): tasks at the head are
+        # closest to being rotated out. If a miner doesn't sample them
+        # before rotation, that (miner, task) data point is lost forever.
+        # With small windows (40-50 tasks) and per-miner rate limits barely
+        # matching rotation rate, every task is on a tight deadline.
+        # Prioritising by rotation proximity minimises lost coverage.
         priority_order = []
-        for task_id in reversed(sampling_list):
+        for task_id in sampling_list:
             if task_id in missing_ids:
                 priority_order.append(task_id)
-        
+
         return priority_order
     
     async def _handle_sampling_list_change(
@@ -809,23 +885,18 @@ class PerMinerSamplingScheduler:
             logger.info(f"Total cleanup: removed {total_deleted} tasks for {len(removed_miners)} miners")
     
     async def _cleanup_loop(self):
-        """Cleanup loop - runs every 5 minutes for all cleanup tasks.
-        
-        Handles:
-        1. Invalid sampling tasks (env disabled or task_id not in sampling_list)
-        2. Expired paused tasks (TTL exceeded)
+        """Cleanup loop — runs every 5 minutes.
+
+        Removes tasks whose env got disabled or whose task_id dropped
+        out of the sampling_list. Failed tasks are already deleted
+        inline by fail_task, so no separate cleanup is needed.
         """
         # Wait 60s before first cleanup (let scheduler stabilize)
         await asyncio.sleep(60)
-        
+
         while self._running:
             try:
-                # Cleanup invalid sampling tasks
                 await self._cleanup_invalid_sampling_tasks()
-                
-                # Cleanup expired paused tasks
-                await self.task_pool_dao.cleanup_expired_paused_tasks()
-                
                 await asyncio.sleep(300)  # Run every 5 minutes
             except asyncio.CancelledError:
                 logger.info("Cleanup loop cancelled")

--- a/affine/src/scorer/main.py
+++ b/affine/src/scorer/main.py
@@ -53,7 +53,7 @@ async def fetch_system_config(api_client, range_type: str = "scoring") -> dict:
     Returns:
         System config dict with:
         - 'environments': list of enabled environment names
-        - 'env_configs': dict mapping env_name -> env_config (including min_completeness)
+        - 'env_configs': dict mapping env_name -> env_config
     """
     try:
         config = await api_client.get("/config/environments")


### PR DESCRIPTION
Systemic scheduler refactor replacing static config with feedback-driven allocation.

## 1. Dynamic per-miner env weights

  weight[env] = rotation_rate[env] × max(FLOOR, 1 − completeness[env])

Base weight is each env's rotation rate (`rotation_count / rotation_interval`), so slot share tracks how fast the env's window turns over. Deficit factor demotes saturated envs to a small trickle and redirects free slots to laggards — always in rotation-rate proportion.

Three regimes fall out naturally:
- Miner keeps up everywhere → every env saturates at `FLOOR × rate` trickle, proportions preserved.
- Miner can't keep up anywhere → shares are exactly rotation-rate proportions; every env lags its rotation by the same fraction.
- Partial → saturated envs drop to trickle, free slots flow to laggards still weighted by rotation rate.

Completeness is derived from `env_missing_tasks` and `env_active_counts` already computed in the scheduling pass — no extra DB queries.

## 2. Head-first task selection (Earliest Deadline First)

Inside each env, the scheduler now picks tasks from the head of `sampling_list` (closest to rotating out) instead of the tail. With windows of 30-50 and per-miner rate limits barely matching rotation, old tasks were being lost before the miner could reach them.

## 3. Drop `paused` task state

`fail_task` deletes the task on max retries instead of flipping to `paused` with a 4-hour TTL. Sampling-list rotation (minutes to a couple of hours) is the natural garbage collector. Removed `get_all_paused_tasks`, `cleanup_expired_paused_tasks`, the cleanup-loop hookup, and the `include_paused` DAO kwarg.

## 4. Config cleanup

- `scheduling_weight` removed from every env in `system_config.json` (now computed dynamically).
- `min_completeness` removed — dead config, never read from Python.
- `cleanup_interval` parameter on `scheduler/main.py` removed — only ever pointed at paused-task cleanup, which is gone.

## Starvation protection

`_select_tasks_to_create` stage 1 (anti-starvation reservation) is unchanged and covers the LOGPROBS-like edge case where an env's rotation_rate is ~1/127 of others: any env with `missing > 0 AND active == 0` gets 1 slot reserved via uniform random sampling before weighted allocation. Verified in 4 stress scenarios.

## Unchanged

- Per-env timeout auto-release (`reset_timeout_tasks` every 5 min) — assigned tasks that never complete still flip back to pending.
- Rate limiting (`rotation_rate × RATE_MARGIN` per miner per env).
- Task completion / retry flow (retry_count <= max still becomes pending).