### PR TITLE
Surface cold miner status in af get-rank

### DIFF
--- a/affine/src/miner/rank.py
+++ b/affine/src/miner/rank.py
@@ -101,6 +101,18 @@ class RankedMiner:
     total_losses: int
     consecutive_losses: int
     checkpoints_passed: int
+    total_samples: int             # Samples produced in current scoring cycle
+
+    @property
+    def is_cold(self) -> bool:
+        # Challenge state preserved across cold/hot cycles, so a miner can sit
+        # in 'sampling' indefinitely without producing samples. Flag that as
+        # cold so operators can tell it apart from actively-sampled miners.
+        return (
+            not self.is_champion
+            and self.status == "sampling"
+            and self.total_samples == 0
+        )
 
 
 def parse_ranked_miners(scores_list: List[Dict[str, Any]]) -> List[RankedMiner]:
@@ -119,16 +131,19 @@ def parse_ranked_miners(scores_list: List[Dict[str, Any]]) -> List[RankedMiner]:
             total_losses=int(ci.get("total_losses", 0) or 0),
             consecutive_losses=int(ci.get("consecutive_losses", 0) or 0),
             checkpoints_passed=int(ci.get("checkpoints_passed", 0) or 0),
+            total_samples=int(s.get("total_samples", 0) or 0),
         ))
     return out
 
 
 def sort_key(m: RankedMiner) -> tuple:
-    """Champion → active sampling (highest CP first) → terminated."""
+    """Champion → active sampling (highest CP first) → cold → terminated."""
     if m.is_champion:
         return (0,)
     if m.status == "terminated":
-        return (2, -m.total_losses, -m.checkpoints_passed)
+        return (3, -m.total_losses, -m.checkpoints_passed)
+    if m.is_cold:
+        return (2, -m.checkpoints_passed, -m.average_score)
     # Active sampling: closeness to dethrone, then checkpoint depth, then avg
     # Sort by checkpoint progress (closest to dethrone first), then avg score
     return (1, -m.checkpoints_passed, -m.average_score)
@@ -319,6 +334,10 @@ async def print_rank_table():
                     challenge_str = "pairwise"
                 else:
                     challenge_str = f"L:{m.total_losses}/{M}"
+            elif m.is_cold:
+                status_str = "cold"
+                cp_str = f"{m.checkpoints_passed}/{dethrone_cp}"
+                challenge_str = "—"
             else:
                 status_str = "sampling"
                 cp_str = f"{m.checkpoints_passed}/{dethrone_cp}"
@@ -339,7 +358,11 @@ async def print_rank_table():
 
         # ── Footer ────────────────────────────────────────────────────────
         print("=" * table_width, flush=True)
-        sampling_count = sum(1 for m in miners if m.status == "sampling" and not m.is_champion)
+        cold_count = sum(1 for m in miners if m.is_cold)
+        sampling_count = sum(
+            1 for m in miners
+            if m.status == "sampling" and not m.is_champion and not m.is_cold
+        )
         terminated_count = sum(1 for m in miners if m.status == "terminated")
 
         if champion_present_uid is not None:
@@ -351,7 +374,8 @@ async def print_rank_table():
 
         print(
             f"Total: {len(miners)}  |  {champ_summary}  |  "
-            f"Sampling: {sampling_count}  |  Terminated: {terminated_count}",
+            f"Sampling: {sampling_count}  |  Cold: {cold_count}  |  "
+            f"Terminated: {terminated_count}",
             flush=True,
         )
         print("=" * table_width, flush=True)


### PR DESCRIPTION
## Summary
Miners whose challenge state is preserved across cold/hot cycles (per #379) stay with `status=sampling` in the scores table even after their chute goes offline. They then show up in `af get-rank` as "sampling" alongside actively-sampled challengers, which is misleading.

Split them into a separate `cold` bucket: `status == 'sampling'` but `total_samples == 0` in the latest scoring cycle.

Prod snapshot today: 244 rows → **Sampling: 15 · Cold: 110 · Terminated: 118 · Champion: 1**. Previously the footer said `Sampling: 125`, mixing 110 permanently-cold rows with 15 active samplers.

## What this change does
- `af get-rank` row status: prints `cold` for those miners (instead of `sampling`), with `challenge` column as `—`.
- Footer: adds `Cold: N` between Sampling and Terminated.
- Sort order: champion → active sampling (by CP) → cold (by CP) → terminated.

Display-only. No scorer / scheduler state is written.

## Why not also filter in the scheduler?
`MinersMonitor` already flips `is_valid=false` when a miner's chute goes non-hot (`miners_monitor.py:373`), so `MinersDAO.get_valid_miners()` already excludes chute-cold miners. The scheduler's selection loop iterates only those, so no extra cold-filter is needed there — it's already excluded at the source.

The af get-rank cold label only exists because the *scores* table lags the miners table: it keeps each challenger's preserved `challenge_info.status` until the next scoring cycle retires them. That lag is what this display change surfaces.

## Test plan
- [x] Unit-tested `RankedMiner.is_cold` + `sort_key` order (champion → active → cold → terminated).
- [x] Verified against prod scores snapshot: produces `Sampling: 15 / Cold: 110 / Terminated: 118`.
- [ ] Deploy and confirm the table renders cleanly, cold rows sort before terminated, footer counts match.