### PR TITLE
Align scheduler DEFAULT_SLOTS/MIN_SLOTS with slots_adjuster (20)

### DIFF
--- a/affine/src/scheduler/sampling_scheduler.py
+++ b/affine/src/scheduler/sampling_scheduler.py
@@ -38,8 +38,8 @@ class PerMinerSamplingScheduler:
        cooldown needed.
     """
 
-    DEFAULT_SLOTS = 10
-    MIN_SLOTS = 10
+    DEFAULT_SLOTS = 20
+    MIN_SLOTS = 20
     MAX_SLOTS = 50
 
     # Rate limiting: allow actual sampling rate to exceed rotation rate by this margin
@@ -198,7 +198,7 @@ class PerMinerSamplingScheduler:
             miner: Miner dict with hotkey, revision
 
         Returns:
-            Number of slots (3-12, default 6)
+            Number of slots (MIN_SLOTS–MAX_SLOTS, default DEFAULT_SLOTS)
         """
         try:
             hotkey = miner['hotkey']


### PR DESCRIPTION
## Summary
`sampling_scheduler.py` still carried pre-#379 values `DEFAULT_SLOTS=10, MIN_SLOTS=10`, while `slots_adjuster.py` and the `miner_stats` default both say 20. The two files disagreed.

## Impact
- `_get_miner_slots` fell back to 10 when no stats record was present, so brand-new miners (and miners whose read momentarily failed) were briefly under-slotted until `MinerSlotsAdjuster` next ran and pulled them up to the 20 floor.
- Startup banner printed `default_slots=10`, which is just wrong.

## Fix
- Set the three constants to `DEFAULT_SLOTS=20, MIN_SLOTS=20, MAX_SLOTS=50` (MAX already matched).
- Replace the stale \`(3-12, default 6)\` docstring on `_get_miner_slots` with constant names so future floor changes don't leave lies behind.

## Test plan
- [x] Syntax check.
- [ ] Deploy; confirm scheduler boot log shows `default_slots=20`.
- [ ] Confirm newly registered / freshly redeployed miners receive 20 slots on first allocation (no longer start at 10).