### PR TITLE
Remove dead 48h rate-limit exemption

### DIFF
--- a/affine/src/scheduler/sampling_scheduler.py
+++ b/affine/src/scheduler/sampling_scheduler.py
@@ -450,14 +450,6 @@ class PerMinerSamplingScheduler:
         if miner.get('uid', 0) == 0 or miner.get('uid', 0) > 1000:
             return False
 
-        # Models submitting for more than 48 hours (~14400 blocks at 12s/block)
-        # are exempt from rate limiting. By then, sampling has completed at least
-        # one full cycle (guaranteed by min_rate = sampling_count/48).
-        first_block = miner.get('first_block', 0)
-        block_number = miner.get('block_number', 0)
-        if first_block > 0 and block_number - first_block > 14400:
-            return False
-
         # Get config parameters (rate limiting is independent of rotation_enabled)
         rotation_count = sampling_config.get('rotation_count', 0)
         rotation_interval = sampling_config.get('rotation_interval', 0)


### PR DESCRIPTION
## Summary

Stale code cleanup. The `block_number - first_block > 14400` exemption in `_should_skip_env_for_miner` was tied to a `min_rate = sampling_count/48` guarantee that no longer exists.

## History

- **5207f92** (Feb 25): added the exemption with rationale "By then, sampling has completed at least one full cycle (guaranteed by min_rate = sampling_count/48)" — at the time, sampling windows were 200–250, so 48h was needed for a full cycle.
- **fdb05b3** (Apr 16, *Raise MAX_SLOTS to 50, remove 48h rate guarantee*): removed the `min_rate` guarantee, leaving this exemption with a comment citing logic that no longer exists.

## Why remove

- The exemption's load-bearing premise (min_rate guarantee) was removed 9+ days ago.
- Current sampling windows are 30–50, much smaller than the 200–250 the exemption was sized for.
- Even for "fast" miners, output is bounded by `_get_missing_task_ids` excluding already-sampled tasks — there's no scenario where bypassing rate-limit is needed for full coverage.
- Concretely, this exemption lets miners that have been submitting for 48h+ bypass the anti-memorization rate cap, which wasn't intentional after fdb05b3.

System-model exemption (uid == 0 or uid > 1000) is unrelated and preserved.

## Test plan

- [ ] Deploy to a validator and confirm post-48h miners now obey rate-limit (allocation rate ≤ rotation_rate × RATE_MARGIN per env)
- [ ] Confirm system models (uid == 0 or > 1000) still bypass rate-limit as expected