### PR TITLE
Auto-terminate miners: 36h cumulative cold + 48h never-sampled

### DIFF
--- a/affine/database/dao/miner_stats.py
+++ b/affine/database/dao/miner_stats.py
@@ -28,8 +28,14 @@ class MinerStatsDAO(BaseDAO):
     
     # A miner that has been cold for this many cumulative seconds (across
     # all causes — chute torn down, fetch failed, deployment unhealthy)
-    # is auto-terminated. 48h = 172800s.
-    COLD_TERMINATION_THRESHOLD_SECONDS = 48 * 3600
+    # AFTER having been sampled at least once is auto-terminated.
+    # 36h = 129600s.
+    COLD_TERMINATION_THRESHOLD_SECONDS = 36 * 3600
+
+    # A miner that has been registered on-chain for this many seconds and
+    # has STILL never produced a successful sample is auto-terminated.
+    # 48h = 172800s. Chain age is `(current_block - first_block) * 12`.
+    NEVER_SAMPLED_TERMINATION_THRESHOLD_SECONDS = 48 * 3600
 
     # Upper bound on the per-call cold-time delta. Refresh cadence is ~5
     # minutes, so a single missed cycle adds ~10min; if the monitor is
@@ -656,29 +662,41 @@ class MinerStatsDAO(BaseDAO):
         hotkey: str,
         revision: str,
         is_cold: bool,
+        chain_age_seconds: Optional[int] = None,
         backfill_last_seen_ms: Optional[int] = None,
     ) -> Optional[Dict[str, Any]]:
-        """Track cumulative cold time and auto-terminate at the threshold.
+        """Track cumulative cold time and auto-terminate at the thresholds.
 
-        Counted only after the miner has been observed sampling at least
-        once (`has_been_hot`). On the first call for a record that lacks
-        any prior tracking field, the caller may pass the most recent
-        sample timestamp via ``backfill_last_seen_ms`` so accumulated
-        cold time on long-cold miners is credited from that point.
+        Two termination paths:
+          - ``cold_too_long`` (36h): miner has been sampled at least once
+            (``has_been_hot``) and accumulated cumulative cold time
+            crosses ``COLD_TERMINATION_THRESHOLD_SECONDS``.
+          - ``never_sampled`` (48h): miner has been on-chain for at
+            least ``NEVER_SAMPLED_TERMINATION_THRESHOLD_SECONDS`` and
+            has still produced no successful samples.
+
+        On the first call for a record that lacks any prior tracking
+        field, the caller may pass the most recent sample timestamp via
+        ``backfill_last_seen_ms`` so accumulated cold time on long-cold
+        miners is credited from that point.
 
         Args:
             hotkey: miner hotkey
             revision: model revision
             is_cold: True if the miner is currently not actively sampling
                 (any cause: chute cold, fetch failed, deployment failed, …)
+            chain_age_seconds: seconds since the miner's commitment was
+                first revealed on chain. Used to terminate never-sampled
+                miners that have lingered too long.
             backfill_last_seen_ms: epoch milliseconds of most recent
                 sample. Used only when the record has no prior
                 ``last_status_check_at``. Implies the miner has been hot
                 in the past.
 
         Returns:
-            Subset of fields actually written, or None if the record
-            does not exist (never sampled — skip).
+            Subset of fields actually written, or None if there's
+            nothing to do (record missing AND not eligible for
+            never-sampled termination).
         """
         from affine.database.client import get_client
         client = get_client()
@@ -687,7 +705,14 @@ class MinerStatsDAO(BaseDAO):
         sk = self._make_sk(revision)
 
         existing = await self.get(pk, sk)
+
+        # Case B: no miner_stats row → miner has never been sampled.
+        # If chain age has crossed the never-sampled threshold, upsert
+        # a terminated record. Otherwise nothing to track yet.
         if not existing:
+            if (chain_age_seconds is not None
+                    and chain_age_seconds >= self.NEVER_SAMPLED_TERMINATION_THRESHOLD_SECONDS):
+                return await self._upsert_never_sampled_termination(hotkey, revision)
             return None
 
         if existing.get('challenge_status') == 'terminated':
@@ -721,17 +746,27 @@ class MinerStatsDAO(BaseDAO):
 
         new_status = existing.get('challenge_status', 'sampling')
         new_reason = existing.get('termination_reason', '') or ''
-        terminate_now = (
-            cold_total >= self.COLD_TERMINATION_THRESHOLD_SECONDS
-            and new_status != 'terminated'
-        )
-        if terminate_now:
+
+        if (cold_total >= self.COLD_TERMINATION_THRESHOLD_SECONDS
+                and new_status != 'terminated'):
             new_status = 'terminated'
             new_reason = 'cold_too_long'
             logger.info(
                 f"[ColdTermination] Terminating miner hk={hotkey[:8]}... "
                 f"rev={revision[:8]}... cold_seconds_total={cold_total} "
                 f"(>= {self.COLD_TERMINATION_THRESHOLD_SECONDS})"
+            )
+        elif (not has_been_hot
+                and chain_age_seconds is not None
+                and chain_age_seconds >= self.NEVER_SAMPLED_TERMINATION_THRESHOLD_SECONDS
+                and new_status != 'terminated'):
+            new_status = 'terminated'
+            new_reason = 'never_sampled'
+            logger.info(
+                f"[ColdTermination] Terminating never-sampled miner "
+                f"hk={hotkey[:8]}... rev={revision[:8]}... "
+                f"chain_age_seconds={chain_age_seconds} "
+                f"(>= {self.NEVER_SAMPLED_TERMINATION_THRESHOLD_SECONDS})"
             )
 
         try:
@@ -764,5 +799,80 @@ class MinerStatsDAO(BaseDAO):
             'last_status_check_at': now,
             'challenge_status': new_status,
             'termination_reason': new_reason,
+        }
+
+    async def _upsert_never_sampled_termination(
+        self,
+        hotkey: str,
+        revision: str,
+    ) -> Dict[str, Any]:
+        """Initialize a miner_stats record in 'terminated/never_sampled'
+        state for a miner that has been on-chain too long without ever
+        producing a sample.
+
+        Mirrors the if_not_exists initializer pattern from
+        ``update_challenge_state`` so the row has the full schema and
+        is safe for subsequent updates.
+        """
+        from affine.database.client import get_client
+        client = get_client()
+
+        pk = self._make_pk(hotkey)
+        sk = self._make_sk(revision)
+        now = int(time.time())
+
+        await client.update_item(
+            TableName=self.table_name,
+            Key={'pk': {'S': pk}, 'sk': {'S': sk}},
+            UpdateExpression=(
+                'SET challenge_status = :cs, '
+                'termination_reason = :tr, '
+                'cold_seconds_total = if_not_exists(cold_seconds_total, :zero), '
+                'has_been_hot = if_not_exists(has_been_hot, :false_b), '
+                'last_status_check_at = :now, '
+                'last_updated_at = :now, '
+                'hotkey = if_not_exists(hotkey, :hk), '
+                'revision = if_not_exists(revision, :rev), '
+                'model = if_not_exists(model, :empty_str), '
+                'first_seen_at = if_not_exists(first_seen_at, :now), '
+                'best_rank = if_not_exists(best_rank, :default_rank), '
+                'best_weight = if_not_exists(best_weight, :zero_f), '
+                'is_currently_online = if_not_exists(is_currently_online, :false_b), '
+                'env_stats = if_not_exists(env_stats, :empty_map), '
+                'sampling_stats = if_not_exists(sampling_stats, :empty_map), '
+                'sampling_slots = if_not_exists(sampling_slots, :default_slots), '
+                'slots_last_adjusted_at = if_not_exists(slots_last_adjusted_at, :zero), '
+                'challenge_consecutive_wins = if_not_exists(challenge_consecutive_wins, :zero), '
+                'challenge_total_losses = if_not_exists(challenge_total_losses, :zero), '
+                'challenge_consecutive_losses = if_not_exists(challenge_consecutive_losses, :zero), '
+                'challenge_checkpoints_passed = if_not_exists(challenge_checkpoints_passed, :zero)'
+            ),
+            ExpressionAttributeValues={
+                ':cs': {'S': 'terminated'},
+                ':tr': {'S': 'never_sampled'},
+                ':now': {'N': str(now)},
+                ':zero': {'N': '0'},
+                ':zero_f': {'N': '0.0'},
+                ':false_b': {'BOOL': False},
+                ':hk': {'S': hotkey},
+                ':rev': {'S': revision},
+                ':empty_str': {'S': ''},
+                ':default_rank': {'N': '999'},
+                ':empty_map': {'M': {}},
+                ':default_slots': {'N': '20'},
+            },
+        )
+
+        logger.info(
+            f"[ColdTermination] Terminating never-sampled miner "
+            f"(no prior stats) hk={hotkey[:8]}... rev={revision[:8]}..."
+        )
+
+        return {
+            'cold_seconds_total': 0,
+            'has_been_hot': False,
+            'last_status_check_at': now,
+            'challenge_status': 'terminated',
+            'termination_reason': 'never_sampled',
         }
 

--- a/affine/database/dao/miner_stats.py
+++ b/affine/database/dao/miner_stats.py
@@ -707,16 +707,13 @@ class MinerStatsDAO(BaseDAO):
         existing = await self.get(pk, sk)
 
         # Case B: no miner_stats row → miner has never been sampled.
-        # If the miner is currently cold AND chain age has crossed the
-        # never-sampled threshold, upsert a terminated record. We
-        # require is_cold here because a HOT miner with no row yet
-        # might just be one the validator hasn't picked up for sampling
-        # — terminating them would punish innocent miners after a
-        # validator restart or extended downtime. Once they go cold,
-        # the next refresh will catch them.
+        # If chain age has crossed the never-sampled threshold,
+        # upsert a terminated record. A miner that has been on-chain
+        # for 48h+ without a single successful sample is broken
+        # regardless of current chute_status, so terminate
+        # unconditionally on age.
         if not existing:
-            if (is_cold
-                    and chain_age_seconds is not None
+            if (chain_age_seconds is not None
                     and chain_age_seconds >= self.NEVER_SAMPLED_TERMINATION_THRESHOLD_SECONDS):
                 return await self._upsert_never_sampled_termination(hotkey, revision)
             return None

--- a/affine/database/dao/miner_stats.py
+++ b/affine/database/dao/miner_stats.py
@@ -707,10 +707,16 @@ class MinerStatsDAO(BaseDAO):
         existing = await self.get(pk, sk)
 
         # Case B: no miner_stats row → miner has never been sampled.
-        # If chain age has crossed the never-sampled threshold, upsert
-        # a terminated record. Otherwise nothing to track yet.
+        # If the miner is currently cold AND chain age has crossed the
+        # never-sampled threshold, upsert a terminated record. We
+        # require is_cold here because a HOT miner with no row yet
+        # might just be one the validator hasn't picked up for sampling
+        # — terminating them would punish innocent miners after a
+        # validator restart or extended downtime. Once they go cold,
+        # the next refresh will catch them.
         if not existing:
-            if (chain_age_seconds is not None
+            if (is_cold
+                    and chain_age_seconds is not None
                     and chain_age_seconds >= self.NEVER_SAMPLED_TERMINATION_THRESHOLD_SECONDS):
                 return await self._upsert_never_sampled_termination(hotkey, revision)
             return None

--- a/affine/database/dao/miner_stats.py
+++ b/affine/database/dao/miner_stats.py
@@ -26,6 +26,16 @@ class MinerStatsDAO(BaseDAO):
     4. Cleanup inactive miners: cleanup_inactive_miners()
     """
     
+    # A miner that has been cold for this many cumulative seconds (across
+    # all causes — chute torn down, fetch failed, deployment unhealthy)
+    # is auto-terminated. 48h = 172800s.
+    COLD_TERMINATION_THRESHOLD_SECONDS = 48 * 3600
+
+    # Upper bound on the per-call cold-time delta. Refresh cadence is ~5
+    # minutes, so a single missed cycle adds ~10min; if the monitor is
+    # down longer than this cap, we don't credit the gap as cold time.
+    COLD_TRACKING_DELTA_CAP_SECONDS = 600
+
     def __init__(self):
         self.table_name = get_table_name("miner_stats")
         super().__init__()
@@ -640,4 +650,119 @@ class MinerStatsDAO(BaseDAO):
                 ':zero': {'N': '0'},
             },
         )
+
+    async def update_cold_tracking(
+        self,
+        hotkey: str,
+        revision: str,
+        is_cold: bool,
+        backfill_last_seen_ms: Optional[int] = None,
+    ) -> Optional[Dict[str, Any]]:
+        """Track cumulative cold time and auto-terminate at the threshold.
+
+        Counted only after the miner has been observed sampling at least
+        once (`has_been_hot`). On the first call for a record that lacks
+        any prior tracking field, the caller may pass the most recent
+        sample timestamp via ``backfill_last_seen_ms`` so accumulated
+        cold time on long-cold miners is credited from that point.
+
+        Args:
+            hotkey: miner hotkey
+            revision: model revision
+            is_cold: True if the miner is currently not actively sampling
+                (any cause: chute cold, fetch failed, deployment failed, …)
+            backfill_last_seen_ms: epoch milliseconds of most recent
+                sample. Used only when the record has no prior
+                ``last_status_check_at``. Implies the miner has been hot
+                in the past.
+
+        Returns:
+            Subset of fields actually written, or None if the record
+            does not exist (never sampled — skip).
+        """
+        from affine.database.client import get_client
+        client = get_client()
+
+        pk = self._make_pk(hotkey)
+        sk = self._make_sk(revision)
+
+        existing = await self.get(pk, sk)
+        if not existing:
+            return None
+
+        if existing.get('challenge_status') == 'terminated':
+            return None
+
+        now = int(time.time())
+        cold_total = int(existing.get('cold_seconds_total', 0) or 0)
+        has_been_hot = bool(existing.get('has_been_hot', False))
+        last_check = existing.get('last_status_check_at')
+
+        if last_check is None:
+            if not is_cold:
+                has_been_hot = True
+                delta = 0
+            elif backfill_last_seen_ms:
+                has_been_hot = True
+                delta = max(0, now - int(backfill_last_seen_ms) // 1000)
+            else:
+                delta = 0
+        else:
+            try:
+                last_check_int = int(last_check)
+            except (ValueError, TypeError):
+                last_check_int = now
+            delta = max(0, min(now - last_check_int, self.COLD_TRACKING_DELTA_CAP_SECONDS))
+            if not is_cold:
+                has_been_hot = True
+
+        if is_cold and has_been_hot:
+            cold_total += delta
+
+        new_status = existing.get('challenge_status', 'sampling')
+        new_reason = existing.get('termination_reason', '') or ''
+        terminate_now = (
+            cold_total >= self.COLD_TERMINATION_THRESHOLD_SECONDS
+            and new_status != 'terminated'
+        )
+        if terminate_now:
+            new_status = 'terminated'
+            new_reason = 'cold_too_long'
+            logger.info(
+                f"[ColdTermination] Terminating miner hk={hotkey[:8]}... "
+                f"rev={revision[:8]}... cold_seconds_total={cold_total} "
+                f"(>= {self.COLD_TERMINATION_THRESHOLD_SECONDS})"
+            )
+
+        try:
+            await client.update_item(
+                TableName=self.table_name,
+                Key={'pk': {'S': pk}, 'sk': {'S': sk}},
+                UpdateExpression=(
+                    'SET cold_seconds_total = :ct, '
+                    'has_been_hot = :hbh, '
+                    'last_status_check_at = :now, '
+                    'last_updated_at = :now, '
+                    'challenge_status = :cs, '
+                    'termination_reason = :tr'
+                ),
+                ExpressionAttributeValues={
+                    ':ct': {'N': str(cold_total)},
+                    ':hbh': {'BOOL': has_been_hot},
+                    ':now': {'N': str(now)},
+                    ':cs': {'S': new_status},
+                    ':tr': {'S': new_reason},
+                },
+                ConditionExpression='attribute_exists(pk)',
+            )
+        except client.exceptions.ConditionalCheckFailedException:
+            return None
+
+        return {
+            'cold_seconds_total': cold_total,
+            'has_been_hot': has_been_hot,
+            'last_status_check_at': now,
+            'challenge_status': new_status,
+            'termination_reason': new_reason,
+        }
 

--- a/affine/database/dao/sample_results.py
+++ b/affine/database/dao/sample_results.py
@@ -217,6 +217,46 @@ class SampleResultsDAO(BaseDAO):
                     pass
         return None
     
+    async def get_latest_sample_timestamp_ms(
+        self,
+        miner_hotkey: str,
+        model_revision: str,
+        envs: List[str],
+    ) -> Optional[int]:
+        """Return the most recent sample timestamp (in milliseconds) for a
+        (hotkey, revision) pair across the given envs, or None if no sample
+        has ever been recorded.
+
+        Used by cold-time tracking to backfill an existing miner's last
+        observed activity when no in-band tracking exists yet.
+        """
+        client = get_client()
+        latest_ms: Optional[int] = None
+
+        for env in envs:
+            pk = self._make_pk(miner_hotkey, model_revision, env)
+            params = {
+                'TableName': self.table_name,
+                'KeyConditionExpression': 'pk = :pk',
+                'ExpressionAttributeValues': {':pk': {'S': pk}},
+                'ProjectionExpression': '#ts',
+                'ExpressionAttributeNames': {'#ts': 'timestamp'},
+            }
+            items = await self._query_all_pages(client, params)
+            for item in items:
+                ts_field = item.get('timestamp', {})
+                ts_raw = ts_field.get('N') if isinstance(ts_field, dict) else None
+                if ts_raw is None:
+                    continue
+                try:
+                    ts = int(ts_raw)
+                except (ValueError, TypeError):
+                    continue
+                if latest_ms is None or ts > latest_ms:
+                    latest_ms = ts
+
+        return latest_ms
+
     async def get_completed_task_ids(
         self,
         miner_hotkey: str,

--- a/affine/src/monitor/miners_monitor.py
+++ b/affine/src/monitor/miners_monitor.py
@@ -627,6 +627,64 @@ class MinersMonitor:
                 logger.warning(
                     f"[MinersMonitor] Failed to release chute for uid={miner.uid}: {e}, marked cold")
 
+    async def _update_cold_tracking(self, miners: list) -> None:
+        """Accumulate cold-time and auto-terminate miners that have been
+        non-hot for too long.
+
+        Cold = anything other than actively-sampling-hot. We start the
+        clock only once a miner has produced at least one sample, so
+        brand-new miners that have never come up don't get terminated.
+        For miners that already exist when this is first deployed, we
+        backfill the clock from the most recent sample timestamp.
+        """
+        from affine.database.dao.miner_stats import MinerStatsDAO
+        from affine.database.dao.sample_results import SampleResultsDAO
+
+        miner_stats_dao = MinerStatsDAO()
+        sample_dao = SampleResultsDAO()
+
+        envs = await self.config_dao.get_sampling_environments()
+
+        for miner in miners:
+            if miner.uid == 0 or miner.uid > 1000:
+                continue
+            if not miner.hotkey or not miner.revision:
+                continue
+
+            is_cold = miner.chute_status != 'hot'
+
+            try:
+                existing = await miner_stats_dao.get_miner_stats(
+                    miner.hotkey, miner.revision)
+                if not existing:
+                    # Never sampled — skip.
+                    continue
+
+                backfill_ms = None
+                if existing.get('last_status_check_at') is None and envs:
+                    backfill_ms = await sample_dao.get_latest_sample_timestamp_ms(
+                        miner.hotkey, miner.revision, envs)
+
+                result = await miner_stats_dao.update_cold_tracking(
+                    hotkey=miner.hotkey,
+                    revision=miner.revision,
+                    is_cold=is_cold,
+                    backfill_last_seen_ms=backfill_ms,
+                )
+
+                if result and result.get('challenge_status') == 'terminated' \
+                        and result.get('termination_reason') == 'cold_too_long':
+                    logger.info(
+                        f"[MinersMonitor] Miner uid={miner.uid} "
+                        f"hk={miner.hotkey[:8]}... terminated for cold_too_long "
+                        f"(cold_seconds_total={result.get('cold_seconds_total')})"
+                    )
+            except Exception as e:
+                logger.warning(
+                    f"[MinersMonitor] cold-tracking update failed for "
+                    f"uid={miner.uid}: {e}"
+                )
+
     async def refresh_miners(self) -> Dict[str, MinerInfo]:
         """Refresh and validate all miners
         
@@ -794,6 +852,8 @@ class MinersMonitor:
                     first_block=miner.block,
                     template_check_result=miner.template_check_result,
                 )
+
+            await self._update_cold_tracking(miners)
 
             valid_miners = {m.key(): m for m in miners if m.is_valid}
 

--- a/affine/src/monitor/miners_monitor.py
+++ b/affine/src/monitor/miners_monitor.py
@@ -627,15 +627,17 @@ class MinersMonitor:
                 logger.warning(
                     f"[MinersMonitor] Failed to release chute for uid={miner.uid}: {e}, marked cold")
 
-    async def _update_cold_tracking(self, miners: list) -> None:
-        """Accumulate cold-time and auto-terminate miners that have been
-        non-hot for too long.
+    async def _update_cold_tracking(self, miners: list, current_block: int) -> None:
+        """Accumulate cold-time and auto-terminate stale miners.
 
-        Cold = anything other than actively-sampling-hot. We start the
-        clock only once a miner has produced at least one sample, so
-        brand-new miners that have never come up don't get terminated.
-        For miners that already exist when this is first deployed, we
-        backfill the clock from the most recent sample timestamp.
+        Two termination triggers:
+          - cold_too_long: miner has produced samples in the past but
+            cumulative cold time has crossed the 36h threshold.
+          - never_sampled: miner has been on-chain for 48h+ without ever
+            producing a successful sample.
+
+        For miners that already exist when this is first deployed, the
+        cold clock is backfilled from the most recent sample timestamp.
         """
         from affine.database.dao.miner_stats import MinerStatsDAO
         from affine.database.dao.sample_results import SampleResultsDAO
@@ -645,6 +647,10 @@ class MinersMonitor:
 
         envs = await self.config_dao.get_sampling_environments()
 
+        # Bittensor produces a block ≈ every 12 seconds. miner.block is
+        # the chain block at which the model commitment was first revealed.
+        SECONDS_PER_BLOCK = 12
+
         for miner in miners:
             if miner.uid == 0 or miner.uid > 1000:
                 continue
@@ -653,15 +659,16 @@ class MinersMonitor:
 
             is_cold = miner.chute_status != 'hot'
 
+            chain_age_seconds = None
+            if miner.block and current_block and current_block > miner.block:
+                chain_age_seconds = (current_block - miner.block) * SECONDS_PER_BLOCK
+
             try:
                 existing = await miner_stats_dao.get_miner_stats(
                     miner.hotkey, miner.revision)
-                if not existing:
-                    # Never sampled — skip.
-                    continue
 
                 backfill_ms = None
-                if existing.get('last_status_check_at') is None and envs:
+                if existing and existing.get('last_status_check_at') is None and envs:
                     backfill_ms = await sample_dao.get_latest_sample_timestamp_ms(
                         miner.hotkey, miner.revision, envs)
 
@@ -669,16 +676,19 @@ class MinersMonitor:
                     hotkey=miner.hotkey,
                     revision=miner.revision,
                     is_cold=is_cold,
+                    chain_age_seconds=chain_age_seconds,
                     backfill_last_seen_ms=backfill_ms,
                 )
 
-                if result and result.get('challenge_status') == 'terminated' \
-                        and result.get('termination_reason') == 'cold_too_long':
-                    logger.info(
-                        f"[MinersMonitor] Miner uid={miner.uid} "
-                        f"hk={miner.hotkey[:8]}... terminated for cold_too_long "
-                        f"(cold_seconds_total={result.get('cold_seconds_total')})"
-                    )
+                if result and result.get('challenge_status') == 'terminated':
+                    reason = result.get('termination_reason', '')
+                    if reason in ('cold_too_long', 'never_sampled'):
+                        logger.info(
+                            f"[MinersMonitor] Miner uid={miner.uid} "
+                            f"hk={miner.hotkey[:8]}... terminated ({reason}) "
+                            f"cold_seconds_total={result.get('cold_seconds_total')} "
+                            f"chain_age_seconds={chain_age_seconds}"
+                        )
             except Exception as e:
                 logger.warning(
                     f"[MinersMonitor] cold-tracking update failed for "
@@ -853,7 +863,7 @@ class MinersMonitor:
                     template_check_result=miner.template_check_result,
                 )
 
-            await self._update_cold_tracking(miners)
+            await self._update_cold_tracking(miners, current_block=current_block)
 
             valid_miners = {m.key(): m for m in miners if m.is_valid}
 

--- a/affine/src/monitor/miners_monitor.py
+++ b/affine/src/monitor/miners_monitor.py
@@ -638,62 +638,89 @@ class MinersMonitor:
 
         For miners that already exist when this is first deployed, the
         cold clock is backfilled from the most recent sample timestamp.
+
+        Best-effort: any failure is logged but never propagates out of
+        the refresh loop, so cold tracking can never break miner
+        validation or scheduling.
         """
-        from affine.database.dao.miner_stats import MinerStatsDAO
-        from affine.database.dao.sample_results import SampleResultsDAO
+        try:
+            from affine.database.dao.miner_stats import MinerStatsDAO
+            from affine.database.dao.sample_results import SampleResultsDAO
 
-        miner_stats_dao = MinerStatsDAO()
-        sample_dao = SampleResultsDAO()
-
-        envs = await self.config_dao.get_sampling_environments()
-
-        # Bittensor produces a block ≈ every 12 seconds. miner.block is
-        # the chain block at which the model commitment was first revealed.
-        SECONDS_PER_BLOCK = 12
-
-        for miner in miners:
-            if miner.uid == 0 or miner.uid > 1000:
-                continue
-            if not miner.hotkey or not miner.revision:
-                continue
-
-            is_cold = miner.chute_status != 'hot'
-
-            chain_age_seconds = None
-            if miner.block and current_block and current_block > miner.block:
-                chain_age_seconds = (current_block - miner.block) * SECONDS_PER_BLOCK
+            miner_stats_dao = MinerStatsDAO()
+            sample_dao = SampleResultsDAO()
 
             try:
-                existing = await miner_stats_dao.get_miner_stats(
-                    miner.hotkey, miner.revision)
-
-                backfill_ms = None
-                if existing and existing.get('last_status_check_at') is None and envs:
-                    backfill_ms = await sample_dao.get_latest_sample_timestamp_ms(
-                        miner.hotkey, miner.revision, envs)
-
-                result = await miner_stats_dao.update_cold_tracking(
-                    hotkey=miner.hotkey,
-                    revision=miner.revision,
-                    is_cold=is_cold,
-                    chain_age_seconds=chain_age_seconds,
-                    backfill_last_seen_ms=backfill_ms,
-                )
-
-                if result and result.get('challenge_status') == 'terminated':
-                    reason = result.get('termination_reason', '')
-                    if reason in ('cold_too_long', 'never_sampled'):
-                        logger.info(
-                            f"[MinersMonitor] Miner uid={miner.uid} "
-                            f"hk={miner.hotkey[:8]}... terminated ({reason}) "
-                            f"cold_seconds_total={result.get('cold_seconds_total')} "
-                            f"chain_age_seconds={chain_age_seconds}"
-                        )
+                envs = await self.config_dao.get_sampling_environments()
             except Exception as e:
                 logger.warning(
-                    f"[MinersMonitor] cold-tracking update failed for "
-                    f"uid={miner.uid}: {e}"
+                    f"[MinersMonitor] failed to load sampling envs for "
+                    f"cold-tracking backfill: {e}"
                 )
+                envs = []
+
+            # Bittensor produces a block ≈ every 12 seconds. miner.block is
+            # the chain block at which the model commitment was first revealed.
+            SECONDS_PER_BLOCK = 12
+
+            for miner in miners:
+                if miner.uid == 0 or miner.uid > 1000:
+                    continue
+                if not miner.hotkey or not miner.revision:
+                    continue
+
+                is_cold = miner.chute_status != 'hot'
+
+                chain_age_seconds = None
+                if miner.block and current_block and current_block > miner.block:
+                    chain_age_seconds = (current_block - miner.block) * SECONDS_PER_BLOCK
+
+                try:
+                    existing = await miner_stats_dao.get_miner_stats(
+                        miner.hotkey, miner.revision)
+
+                    # Backfill only when:
+                    # - record exists (otherwise no fields to backfill)
+                    # - this is the first cold-tracking call for the row
+                    # - the miner is currently cold (a hot miner doesn't
+                    #   need a backfilled cold clock — its has_been_hot
+                    #   flips True this cycle and starts fresh)
+                    # - we have an env list to look up samples in
+                    backfill_ms = None
+                    if (existing
+                            and existing.get('last_status_check_at') is None
+                            and is_cold
+                            and envs):
+                        backfill_ms = await sample_dao.get_latest_sample_timestamp_ms(
+                            miner.hotkey, miner.revision, envs)
+
+                    result = await miner_stats_dao.update_cold_tracking(
+                        hotkey=miner.hotkey,
+                        revision=miner.revision,
+                        is_cold=is_cold,
+                        chain_age_seconds=chain_age_seconds,
+                        backfill_last_seen_ms=backfill_ms,
+                    )
+
+                    if result and result.get('challenge_status') == 'terminated':
+                        reason = result.get('termination_reason', '')
+                        if reason in ('cold_too_long', 'never_sampled'):
+                            logger.info(
+                                f"[MinersMonitor] Miner uid={miner.uid} "
+                                f"hk={miner.hotkey[:8]}... terminated ({reason}) "
+                                f"cold_seconds_total={result.get('cold_seconds_total')} "
+                                f"chain_age_seconds={chain_age_seconds}"
+                            )
+                except Exception as e:
+                    logger.warning(
+                        f"[MinersMonitor] cold-tracking update failed for "
+                        f"uid={miner.uid}: {e}"
+                    )
+        except Exception as e:
+            logger.error(
+                f"[MinersMonitor] cold-tracking pass failed at top level: {e}",
+                exc_info=True,
+            )
 
     async def refresh_miners(self) -> Dict[str, MinerInfo]:
         """Refresh and validate all miners

--- a/tests/test_cold_tracking.py
+++ b/tests/test_cold_tracking.py
@@ -399,6 +399,72 @@ class TestNeverSampledTermination:
 
         assert r["termination_reason"] == "cold_too_long"
 
+    @pytest.mark.asyncio
+    async def test_no_record_hot_miner_chain_age_over_48h_NOT_terminated(self):
+        """Safety: a HOT miner with no stats row yet — even on-chain
+        for 48h+ — must not be terminated. This guards against
+        validator-restart-after-downtime scenarios where good miners
+        haven't been picked up for sampling yet."""
+        dao, client = make_dao_with_mock_client()
+        client.get_item.return_value = {}  # no record
+
+        with patched_clients(client):
+            r = await dao.update_cold_tracking(
+                HK, REV, is_cold=False,           # HOT
+                chain_age_seconds=72 * 3600,
+            )
+
+        assert r is None
+        client.update_item.assert_not_called()
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# Hot miner is never wrongly terminated
+# ─────────────────────────────────────────────────────────────────────────
+
+
+class TestHotMinerSafety:
+
+    @pytest.mark.asyncio
+    async def test_existing_record_hot_chain_age_over_48h_not_terminated(self):
+        """An existing-record hot miner over 48h chain age must not
+        terminate. has_been_hot flips True via the is_cold=False
+        branch so the never_sampled condition is False."""
+        dao, client = make_dao_with_mock_client()
+        client.get_item.return_value = serialize_get_response(stats_row(
+            has_been_hot=False,  # was never observed hot before
+        ))
+
+        with patched_clients(client):
+            r = await dao.update_cold_tracking(
+                HK, REV, is_cold=False,           # currently HOT now
+                chain_age_seconds=72 * 3600,
+            )
+
+        assert r["challenge_status"] == "sampling"
+        assert r["has_been_hot"] is True
+
+    @pytest.mark.asyncio
+    async def test_already_terminated_hot_miner_no_op(self):
+        """Even if challenge_status was set to terminated externally
+        (e.g., champion_loss), and miner is now hot, we don't touch
+        the row."""
+        dao, client = make_dao_with_mock_client()
+        client.get_item.return_value = serialize_get_response(stats_row(
+            challenge_status="terminated",
+            termination_reason="champion_loss",
+            has_been_hot=True,
+        ))
+
+        with patched_clients(client):
+            r = await dao.update_cold_tracking(
+                HK, REV, is_cold=False,
+                chain_age_seconds=72 * 3600,
+            )
+
+        assert r is None
+        client.update_item.assert_not_called()
+
 
 # ─────────────────────────────────────────────────────────────────────────
 # Threshold constants

--- a/tests/test_cold_tracking.py
+++ b/tests/test_cold_tracking.py
@@ -1,0 +1,502 @@
+"""Unit tests for cold-time tracking and auto-termination.
+
+Covers:
+- MinerStatsDAO.update_cold_tracking — cumulative cold accumulation,
+  delta cap, both termination paths (cold_too_long @ 36h sampled,
+  never_sampled @ 48h on-chain), backfill from sample_results,
+  clock-drift / negative-delta safety, idempotency once terminated.
+- MinerStatsDAO._upsert_never_sampled_termination — record creation
+  for miners with no prior stats row.
+- SampleResultsDAO.get_latest_sample_timestamp_ms — max timestamp
+  across env partitions, None when no samples exist.
+
+DynamoDB is mocked at the client level so no real AWS calls occur.
+"""
+
+import time
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from affine.database.dao.miner_stats import MinerStatsDAO
+from affine.database.dao.sample_results import SampleResultsDAO
+
+
+HK = "5HotkeyHotkeyHotkeyHotkeyHotkeyHotkey"
+REV = "rev_abcdef0123456789"
+
+
+def make_mock_client():
+    """Build a mock DynamoDB client with the methods we exercise."""
+    mock_client = MagicMock()
+    mock_client.get_item = AsyncMock()
+    mock_client.update_item = AsyncMock()
+    mock_client.query = AsyncMock()
+
+    class _CCFE(Exception):
+        pass
+
+    mock_client.exceptions = MagicMock()
+    mock_client.exceptions.ConditionalCheckFailedException = _CCFE
+    return mock_client
+
+
+def patched_clients(mock_client):
+    """Context-manager bundle that re-binds get_client at every import site
+    update_cold_tracking touches: base_dao (via BaseDAO.get), the
+    in-function import in miner_stats, and sample_results."""
+    from contextlib import ExitStack
+
+    stack = ExitStack()
+    stack.enter_context(patch(
+        "affine.database.base_dao.get_client", return_value=mock_client))
+    stack.enter_context(patch(
+        "affine.database.client.get_client", return_value=mock_client))
+    stack.enter_context(patch(
+        "affine.database.dao.sample_results.get_client", return_value=mock_client))
+    return stack
+
+
+def make_dao_with_mock_client():
+    """Returns (dao, mock_client) ready for use under `patched_clients`."""
+    mock_client = make_mock_client()
+    # init_client guards prevent constructing the DAO without a client;
+    # patch the client check during DAO construction too.
+    with patched_clients(mock_client):
+        dao = MinerStatsDAO()
+    return dao, mock_client
+
+
+def stats_row(**overrides):
+    """Build an existing miner_stats row (already deserialized dict)."""
+    base = {
+        "pk": f"HOTKEY#{HK}",
+        "sk": f"REV#{REV}",
+        "hotkey": HK,
+        "revision": REV,
+        "model": "test/model",
+        "challenge_status": "sampling",
+        "termination_reason": "",
+    }
+    base.update(overrides)
+    return base
+
+
+def serialize_get_response(row):
+    """Convert a plain dict into a DynamoDB get_item response shape
+    that BaseDAO._deserialize understands."""
+    if row is None:
+        return {}
+    item = {}
+    for k, v in row.items():
+        if isinstance(v, bool):
+            item[k] = {"BOOL": v}
+        elif isinstance(v, int):
+            item[k] = {"N": str(v)}
+        elif isinstance(v, float):
+            item[k] = {"N": str(v)}
+        elif isinstance(v, str):
+            item[k] = {"S": v}
+        elif isinstance(v, dict):
+            item[k] = {"M": {}}
+        elif v is None:
+            item[k] = {"NULL": True}
+        else:
+            item[k] = {"S": str(v)}
+    return {"Item": item}
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# update_cold_tracking — basic / no-op paths
+# ─────────────────────────────────────────────────────────────────────────
+
+
+class TestUpdateColdTrackingNoOps:
+
+    @pytest.mark.asyncio
+    async def test_no_record_no_chain_age_returns_none(self):
+        dao, client = make_dao_with_mock_client()
+        client.get_item.return_value = {}  # missing record
+
+        with patched_clients(client):
+            result = await dao.update_cold_tracking(HK, REV, is_cold=True)
+
+        assert result is None
+        client.update_item.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_no_record_chain_age_below_threshold_skip(self):
+        """No record + chain age < 48h → skip (not yet eligible)."""
+        dao, client = make_dao_with_mock_client()
+        client.get_item.return_value = {}
+
+        with patched_clients(client):
+            result = await dao.update_cold_tracking(
+                HK, REV, is_cold=True,
+                chain_age_seconds=(48 * 3600) - 1,
+            )
+
+        assert result is None
+        client.update_item.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_already_terminated_returns_none(self):
+        dao, client = make_dao_with_mock_client()
+        client.get_item.return_value = serialize_get_response(stats_row(
+            challenge_status="terminated",
+            termination_reason="champion_loss",
+            cold_seconds_total=10,
+        ))
+
+        with patched_clients(client):
+            result = await dao.update_cold_tracking(HK, REV, is_cold=True)
+
+        assert result is None
+        client.update_item.assert_not_called()
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# update_cold_tracking — first-call paths
+# ─────────────────────────────────────────────────────────────────────────
+
+
+class TestFirstCall:
+
+    @pytest.mark.asyncio
+    async def test_first_call_hot_sets_has_been_hot(self):
+        dao, client = make_dao_with_mock_client()
+        client.get_item.return_value = serialize_get_response(stats_row())
+
+        with patched_clients(client):
+            r = await dao.update_cold_tracking(HK, REV, is_cold=False)
+
+        assert r["has_been_hot"] is True
+        assert r["cold_seconds_total"] == 0
+        assert r["challenge_status"] == "sampling"
+        client.update_item.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_first_call_cold_no_backfill_no_credit(self):
+        """No prior tracking, cold, no backfill, never sampled →
+        cold time stays 0 and has_been_hot stays False."""
+        dao, client = make_dao_with_mock_client()
+        client.get_item.return_value = serialize_get_response(stats_row())
+
+        with patched_clients(client):
+            r = await dao.update_cold_tracking(HK, REV, is_cold=True)
+
+        assert r["cold_seconds_total"] == 0
+        assert r["has_been_hot"] is False
+        assert r["challenge_status"] == "sampling"
+
+    @pytest.mark.asyncio
+    async def test_first_call_cold_with_backfill_3d(self):
+        """Backfill from a 3-day-old sample → terminated for cold_too_long
+        (3d > 36h)."""
+        dao, client = make_dao_with_mock_client()
+        client.get_item.return_value = serialize_get_response(stats_row())
+        now_ms = int(time.time() * 1000)
+        three_days_ago_ms = now_ms - (3 * 86400 * 1000)
+
+        with patched_clients(client):
+            r = await dao.update_cold_tracking(
+                HK, REV, is_cold=True,
+                backfill_last_seen_ms=three_days_ago_ms,
+            )
+
+        assert r["has_been_hot"] is True
+        # ~3d = 259200s; allow ±5s slop for time.time() drift between calls
+        assert abs(r["cold_seconds_total"] - 3 * 86400) < 5
+        assert r["challenge_status"] == "terminated"
+        assert r["termination_reason"] == "cold_too_long"
+
+    @pytest.mark.asyncio
+    async def test_first_call_cold_backfill_under_threshold(self):
+        """Backfill 10h ago → has_been_hot=True, cold credited but under 36h."""
+        dao, client = make_dao_with_mock_client()
+        client.get_item.return_value = serialize_get_response(stats_row())
+        ten_hours_ago_ms = int(time.time() * 1000) - (10 * 3600 * 1000)
+
+        with patched_clients(client):
+            r = await dao.update_cold_tracking(
+                HK, REV, is_cold=True,
+                backfill_last_seen_ms=ten_hours_ago_ms,
+            )
+
+        assert r["has_been_hot"] is True
+        assert abs(r["cold_seconds_total"] - 10 * 3600) < 5
+        assert r["challenge_status"] == "sampling"
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# update_cold_tracking — incremental updates
+# ─────────────────────────────────────────────────────────────────────────
+
+
+class TestIncremental:
+
+    @pytest.mark.asyncio
+    async def test_subsequent_cold_within_cap(self):
+        """5min after last check, cold → cold_total += 300s (within cap)."""
+        dao, client = make_dao_with_mock_client()
+        now = int(time.time())
+        client.get_item.return_value = serialize_get_response(stats_row(
+            cold_seconds_total=1000,
+            has_been_hot=True,
+            last_status_check_at=now - 300,
+        ))
+
+        with patched_clients(client):
+            r = await dao.update_cold_tracking(HK, REV, is_cold=True)
+
+        # delta should be ~300; total ≈ 1300
+        assert 1290 <= r["cold_seconds_total"] <= 1310
+        assert r["has_been_hot"] is True
+
+    @pytest.mark.asyncio
+    async def test_subsequent_cold_over_cap_clamped(self):
+        """If last check was 2h ago, only 600s (cap) credited."""
+        dao, client = make_dao_with_mock_client()
+        now = int(time.time())
+        client.get_item.return_value = serialize_get_response(stats_row(
+            cold_seconds_total=0,
+            has_been_hot=True,
+            last_status_check_at=now - 7200,
+        ))
+
+        with patched_clients(client):
+            r = await dao.update_cold_tracking(HK, REV, is_cold=True)
+
+        assert r["cold_seconds_total"] == 600  # capped
+
+    @pytest.mark.asyncio
+    async def test_subsequent_hot_does_not_grow(self):
+        dao, client = make_dao_with_mock_client()
+        now = int(time.time())
+        client.get_item.return_value = serialize_get_response(stats_row(
+            cold_seconds_total=5000,
+            has_been_hot=True,
+            last_status_check_at=now - 300,
+        ))
+
+        with patched_clients(client):
+            r = await dao.update_cold_tracking(HK, REV, is_cold=False)
+
+        assert r["cold_seconds_total"] == 5000  # unchanged
+        assert r["has_been_hot"] is True
+
+    @pytest.mark.asyncio
+    async def test_negative_delta_clamped(self):
+        """Clock drift: last_status_check_at in the future → delta=0."""
+        dao, client = make_dao_with_mock_client()
+        now = int(time.time())
+        client.get_item.return_value = serialize_get_response(stats_row(
+            cold_seconds_total=100,
+            has_been_hot=True,
+            last_status_check_at=now + 10_000,  # future
+        ))
+
+        with patched_clients(client):
+            r = await dao.update_cold_tracking(HK, REV, is_cold=True)
+
+        assert r["cold_seconds_total"] == 100  # unchanged
+
+    @pytest.mark.asyncio
+    async def test_threshold_crossing_terminates(self):
+        dao, client = make_dao_with_mock_client()
+        now = int(time.time())
+        # Just below threshold; one more 300s tick should push over.
+        client.get_item.return_value = serialize_get_response(stats_row(
+            cold_seconds_total=MinerStatsDAO.COLD_TERMINATION_THRESHOLD_SECONDS - 100,
+            has_been_hot=True,
+            last_status_check_at=now - 300,
+        ))
+
+        with patched_clients(client):
+            r = await dao.update_cold_tracking(HK, REV, is_cold=True)
+
+        assert r["challenge_status"] == "terminated"
+        assert r["termination_reason"] == "cold_too_long"
+        assert r["cold_seconds_total"] >= MinerStatsDAO.COLD_TERMINATION_THRESHOLD_SECONDS
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# update_cold_tracking — never-sampled chain-age path
+# ─────────────────────────────────────────────────────────────────────────
+
+
+class TestNeverSampledTermination:
+
+    @pytest.mark.asyncio
+    async def test_no_record_chain_age_over_48h_terminates(self):
+        """No miner_stats row + chain age ≥ 48h → upsert terminated/never_sampled."""
+        dao, client = make_dao_with_mock_client()
+        client.get_item.return_value = {}  # no record
+
+        with patched_clients(client):
+            r = await dao.update_cold_tracking(
+                HK, REV, is_cold=True,
+                chain_age_seconds=48 * 3600 + 1,
+            )
+
+        assert r is not None
+        assert r["challenge_status"] == "terminated"
+        assert r["termination_reason"] == "never_sampled"
+        client.update_item.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_existing_record_never_hot_chain_age_over_48h(self):
+        """Stub record exists (e.g., from update_challenge_state init) but
+        miner has never been hot, and chain age > 48h → terminate."""
+        dao, client = make_dao_with_mock_client()
+        client.get_item.return_value = serialize_get_response(stats_row(
+            has_been_hot=False,
+            cold_seconds_total=0,
+        ))
+
+        with patched_clients(client):
+            r = await dao.update_cold_tracking(
+                HK, REV, is_cold=True,
+                chain_age_seconds=48 * 3600 + 100,
+            )
+
+        assert r["challenge_status"] == "terminated"
+        assert r["termination_reason"] == "never_sampled"
+
+    @pytest.mark.asyncio
+    async def test_chain_age_below_48h_no_termination(self):
+        """Stub record, never hot, chain age < 48h → no termination."""
+        dao, client = make_dao_with_mock_client()
+        client.get_item.return_value = serialize_get_response(stats_row(
+            has_been_hot=False,
+        ))
+
+        with patched_clients(client):
+            r = await dao.update_cold_tracking(
+                HK, REV, is_cold=True,
+                chain_age_seconds=24 * 3600,
+            )
+
+        assert r["challenge_status"] == "sampling"
+
+    @pytest.mark.asyncio
+    async def test_has_been_hot_uses_36h_not_48h(self):
+        """Once a miner has been hot, the never_sampled clock no longer
+        applies. Cold path uses the 36h threshold."""
+        dao, client = make_dao_with_mock_client()
+        now = int(time.time())
+        # cold_total just over 36h
+        client.get_item.return_value = serialize_get_response(stats_row(
+            has_been_hot=True,
+            cold_seconds_total=MinerStatsDAO.COLD_TERMINATION_THRESHOLD_SECONDS + 50,
+            last_status_check_at=now - 30,
+        ))
+
+        with patched_clients(client):
+            r = await dao.update_cold_tracking(
+                HK, REV, is_cold=True,
+                chain_age_seconds=24 * 3600,  # under 48h, irrelevant
+            )
+
+        assert r["termination_reason"] == "cold_too_long"
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# Threshold constants
+# ─────────────────────────────────────────────────────────────────────────
+
+
+class TestThresholdConstants:
+
+    def test_cold_threshold_is_36h(self):
+        assert MinerStatsDAO.COLD_TERMINATION_THRESHOLD_SECONDS == 36 * 3600
+
+    def test_never_sampled_threshold_is_48h(self):
+        assert MinerStatsDAO.NEVER_SAMPLED_TERMINATION_THRESHOLD_SECONDS == 48 * 3600
+
+    def test_delta_cap_is_600s(self):
+        assert MinerStatsDAO.COLD_TRACKING_DELTA_CAP_SECONDS == 600
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# get_latest_sample_timestamp_ms
+# ─────────────────────────────────────────────────────────────────────────
+
+
+class TestGetLatestSampleTimestamp:
+
+    @pytest.mark.asyncio
+    async def test_no_envs_returns_none(self):
+        dao = SampleResultsDAO()
+        client = MagicMock()
+        client.query = AsyncMock(return_value={"Items": []})
+
+        with patch("affine.database.dao.sample_results.get_client", return_value=client):
+            ts = await dao.get_latest_sample_timestamp_ms(HK, REV, [])
+
+        assert ts is None
+        client.query.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_no_samples_returns_none(self):
+        dao = SampleResultsDAO()
+        client = MagicMock()
+        client.query = AsyncMock(return_value={"Items": []})
+
+        with patch("affine.database.dao.sample_results.get_client", return_value=client):
+            ts = await dao.get_latest_sample_timestamp_ms(HK, REV, ["GAME"])
+
+        assert ts is None
+
+    @pytest.mark.asyncio
+    async def test_single_env_max_timestamp(self):
+        dao = SampleResultsDAO()
+        client = MagicMock()
+        client.query = AsyncMock(return_value={
+            "Items": [
+                {"timestamp": {"N": "1700000000000"}},
+                {"timestamp": {"N": "1700001000000"}},  # max
+                {"timestamp": {"N": "1699999000000"}},
+            ]
+        })
+
+        with patch("affine.database.dao.sample_results.get_client", return_value=client):
+            ts = await dao.get_latest_sample_timestamp_ms(HK, REV, ["GAME"])
+
+        assert ts == 1700001000000
+
+    @pytest.mark.asyncio
+    async def test_multi_env_max_across_partitions(self):
+        dao = SampleResultsDAO()
+        # Each call returns different max timestamps; we want overall max.
+        responses = [
+            {"Items": [{"timestamp": {"N": "1000"}}]},
+            {"Items": [{"timestamp": {"N": "5000"}}]},  # max
+            {"Items": [{"timestamp": {"N": "3000"}}]},
+        ]
+        client = MagicMock()
+        client.query = AsyncMock(side_effect=responses)
+
+        with patch("affine.database.dao.sample_results.get_client", return_value=client):
+            ts = await dao.get_latest_sample_timestamp_ms(
+                HK, REV, ["GAME", "MEMORY", "DISTILL"])
+
+        assert ts == 5000
+        assert client.query.call_count == 3
+
+    @pytest.mark.asyncio
+    async def test_skip_malformed_timestamp(self):
+        """Items with non-numeric or missing timestamp are skipped."""
+        dao = SampleResultsDAO()
+        client = MagicMock()
+        client.query = AsyncMock(return_value={
+            "Items": [
+                {},  # missing timestamp
+                {"timestamp": {"S": "not-a-number"}},  # wrong type
+                {"timestamp": {"N": "12345"}},
+            ]
+        })
+
+        with patch("affine.database.dao.sample_results.get_client", return_value=client):
+            ts = await dao.get_latest_sample_timestamp_ms(HK, REV, ["GAME"])
+
+        assert ts == 12345

--- a/tests/test_cold_tracking.py
+++ b/tests/test_cold_tracking.py
@@ -400,22 +400,23 @@ class TestNeverSampledTermination:
         assert r["termination_reason"] == "cold_too_long"
 
     @pytest.mark.asyncio
-    async def test_no_record_hot_miner_chain_age_over_48h_NOT_terminated(self):
-        """Safety: a HOT miner with no stats row yet — even on-chain
-        for 48h+ — must not be terminated. This guards against
-        validator-restart-after-downtime scenarios where good miners
-        haven't been picked up for sampling yet."""
+    async def test_no_record_hot_miner_chain_age_over_48h_terminated(self):
+        """A miner with no stats row that has been on-chain for 48h+
+        is terminated regardless of current chute state. 48h is enough
+        time for any working miner+validator pair to produce at least
+        one sample; failure to do so means the deployment is broken."""
         dao, client = make_dao_with_mock_client()
         client.get_item.return_value = {}  # no record
 
         with patched_clients(client):
             r = await dao.update_cold_tracking(
-                HK, REV, is_cold=False,           # HOT
+                HK, REV, is_cold=False,           # current state irrelevant
                 chain_age_seconds=72 * 3600,
             )
 
-        assert r is None
-        client.update_item.assert_not_called()
+        assert r is not None
+        assert r["challenge_status"] == "terminated"
+        assert r["termination_reason"] == "never_sampled"
 
 
 # ─────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
Two new termination paths driven by the miners-monitor refresh loop.

| Trigger | Threshold | `termination_reason` |
|---|---|---|
| Sampled miner accumulates non-hot wall-time | 36h | `cold_too_long` |
| Miner has been on-chain with zero samples | 48h | `never_sampled` |

`is_cold` is `chute_status != 'hot'`, so any reason for not actively sampling counts (chute cold, fetch failed, deployment failed, …). For pre-existing miners the cold clock is **backfilled** from the most recent `sample_results.timestamp` on first encounter, so long-cold miners are credited their accumulated cold time on the next refresh. Chain age is `(current_block - first_block) * 12s`.

## Schema additions on `miner_stats`
| Field | Type | Purpose |
|---|---|---|
| `cold_seconds_total` | N | queryable cumulative cold seconds |
| `has_been_hot` | BOOL | guards the 36h path; flips True on first hot observation or backfill |
| `last_status_check_at` | N | per-cycle delta computation |

`termination_reason` is reused with new values `cold_too_long` / `never_sampled`.

For never-sampled miners that have no `miner_stats` row yet, the row is upserted with `if_not_exists` initialisers for every other field (mirrors `update_challenge_state`) so subsequent updates stay safe.

## Bounds & safety
- Per-call delta capped at `COLD_TRACKING_DELTA_CAP_SECONDS = 600` (refresh cadence is 300s; one missed cycle absorbed, longer monitor downtime not credited).
- Negative deltas (clock drift) clamped to 0.
- Skips system miners (uid==0 or uid>1000) and miners without hotkey/revision.
- Already-terminated rows short-circuit (no double-terminate).
- Once `has_been_hot=True`, the 48h never-sampled clock no longer applies — only the 36h cumulative-cold clock.
