### PR TITLE
Zero out weights when champion's chute is cold

### DIFF
--- a/affine/src/scorer/main.py
+++ b/affine/src/scorer/main.py
@@ -16,6 +16,7 @@ from affine.database.dao.score_snapshots import ScoreSnapshotsDAO
 from affine.database.dao.scores import ScoresDAO
 from affine.database.dao.anti_copy import AntiCopyDAO
 from affine.database.dao.miner_stats import MinerStatsDAO
+from affine.database.dao.miners import MinersDAO
 from affine.database.dao.system_config import SystemConfigDAO
 from affine.src.scorer.scorer import Scorer
 from affine.src.scorer.config import ScorerConfig
@@ -197,6 +198,23 @@ async def run_scoring_once(save_to_db: bool, range_type: str = "scoring"):
             anticopy_records=anticopy_records,
             print_summary=True,
         )
+
+        # If champion's chute is cold, zero out weights this round.
+        # Champion is the sole weight recipient, so zeroing them = no weights set.
+        if champion_state and champion_state.get('hotkey') and result.final_weights:
+            miners_dao = MinersDAO()
+            champion_record = await miners_dao.get_miner_by_hotkey(
+                champion_state['hotkey']
+            )
+            if champion_record and champion_record.get('chute_status') == 'cold':
+                logger.warning(
+                    f"Champion {champion_state['hotkey'][:8]}... chute is cold; "
+                    "zeroing all weights this round"
+                )
+                for uid in result.final_weights:
+                    result.final_weights[uid] = 0.0
+                for miner in result.miners.values():
+                    miner.normalized_weight = 0.0
 
         # Save to database if requested
         if save_to_db:


### PR DESCRIPTION
## Summary
- After `calculate_scores`, look up the champion's hotkey in `MinersDAO`. If `chute_status == 'cold'`, zero `result.final_weights` and every miner's `normalized_weight`.
- Champion is the sole weight recipient, so zeroing it makes `weight_setter.process_weights` return an empty payload and the validator skips the on-chain set this round — avoiding rewarding an offline model.

## Test plan
- [ ] Force the active champion's chute to cold and run `af -v servers scorer` once: expect the warning log and all-zero weights in the snapshot.
- [ ] Verify validator's `set_weights` short-circuits (no on-chain push) when all weights are 0.
- [ ] Hot champion path unchanged: regular run still assigns 1.0 to champion.