### PR TITLE
Extend SWE-INFINITE timeout to 8h to ride out Chutes outages

### DIFF
--- a/affine/core/environments.py
+++ b/affine/core/environments.py
@@ -197,7 +197,7 @@ _ENV_CONFIGS_CANONICAL = {
         name="swe-infinite",
         docker_image="affinefoundation/swebench:infinite",
         env_type="swebench",
-        env_vars={"UVICORN_WORKERS": "15"},
+        env_vars={"UVICORN_WORKERS": "15", "MSWEA_MODEL_RETRY_STOP_AFTER_ATTEMPT": "30"},
         required_env_vars=["DOCKER_HUB_USERNAME", "DOCKER_HUB_TOKEN", "HF_TOKEN"],
         mem_limit="10g",
         volumes={
@@ -209,9 +209,9 @@ _ENV_CONFIGS_CANONICAL = {
         eval_params={
             "max_iterations": 50,
             "temperature": 0.0,
-            "timeout": 7200,
+            "timeout": 28800,
         },
-        proxy_timeout=7300,
+        proxy_timeout=29000,
     ),
     "print": EnvConfig(
         name="print",


### PR DESCRIPTION
Tasks were hitting the 7300s outer timeout while miniswe's litellm tenacity loop kept retrying transient Chutes 429/503 ("Infrastructure is at maximum capacity" / "No instances available") — the agent was making slow but real progress between flaky calls and got killed before finishing. With the slot queue empty (pending=0, running=168) we have slot-time to spare; trade it for higher completion rate during upstream incidents.

- timeout: 7200 -> 28800 (8h), proxy_timeout matched
- MSWEA_MODEL_RETRY_STOP_AFTER_ATTEMPT 10 -> 30 so the inner litellm retry budget grows in step with the outer timeout (otherwise a single call still gives up after ~7min and bubbles out before the chute can recover)

Bound chosen from max_iterations=50 * worst-case ~7min per turn.