### PR TITLE
Targon router: case-insensitive env match (fixes 100% SWE-INFINITE drop)

### DIFF
--- a/affine/core/providers/router.py
+++ b/affine/core/providers/router.py
@@ -46,13 +46,15 @@ def _parse_accelerated_envs() -> Optional[Set[str]]:
     contexts, highest completion-token counts), so the paid Targon GPUs
     earn back their cost fastest there. Operators add ``swe-pro`` /
     ``swe-synth`` as the pool grows. Sentinels for "all envs eligible":
-    ``*`` or ``all``. Reading at import time is fine because this is a
-    deployment-time toggle, not a request-time knob.
+    ``*`` or ``all``. Whitelist is lowercased so callers passing the
+    canonical-uppercase task env (e.g. ``SWE-INFINITE``) still match.
+    Reading at import time is fine because this is a deployment-time
+    toggle, not a request-time knob.
     """
     raw = os.getenv("TARGON_ACCELERATED_ENVS", "swe-infinite").strip()
     if not raw or raw in ("*", "all", "ALL"):
         return None
-    parts = {p.strip() for p in raw.split(",") if p.strip()}
+    parts = {p.strip().lower() for p in raw.split(",") if p.strip()}
     return parts or None
 
 
@@ -118,9 +120,13 @@ class ProviderRouter:
         # Env gating: if a whitelist is configured and this env isn't on it,
         # skip Targon entirely. We still consult Chutes — non-accelerated
         # envs should keep sampling, just not eat Targon capacity.
+        # task_pool stores env in canonical-uppercase form (e.g.
+        # ``SWE-INFINITE``); whitelist is lowercased on parse, so compare
+        # against the lowercased value.
+        env_lc = (env or "").lower()
         targon_eligible = (
             TARGON_ACCELERATED_ENVS is None
-            or (env is not None and env in TARGON_ACCELERATED_ENVS)
+            or (env_lc and env_lc in TARGON_ACCELERATED_ENVS)
         )
 
         chute_info = await self._instance_info(self.chutes, miner_record)

--- a/affine/src/targon_deployer/__main__.py
+++ b/affine/src/targon_deployer/__main__.py
@@ -54,7 +54,12 @@ async def run_service():
 def main(verbosity):
     """Affine Targon Deployer - reconcile Targon deployments with the champion."""
     if verbosity is not None:
-        setup_logging(int(verbosity))
+        # Pass component explicitly — auto-detection scans sys.argv for
+        # known service names and our entry point isn't on that list, so
+        # without this the file handler lands at /var/log/affine/affine/
+        # instead of the per-service /var/log/affine/targon_deployer/
+        # directory the compose volume mounts.
+        setup_logging(int(verbosity), component="targon_deployer")
     asyncio.run(run_service())
 
 


### PR DESCRIPTION
## What

Production task rows store env in canonical-uppercase form (e.g. `SWE-INFINITE`), but the env-whitelist parser kept whatever case the operator wrote in the env var (default ships as `swe-infinite`). The mismatch made `"SWE-INFINITE" in {"swe-infinite"}` false, so:

  1. Every SWE-INFINITE task fell off the Targon-eligible path
  2. Then hit cold Chutes for the same accelerated miners
  3. Then got released back to pending as "No live provider"

Result: every SWE-INFINITE task was dropped on the floor — 100% of the accelerated traffic the deployer was paying Targon GPU-hours to absorb.

## Fix

Lowercase both sides of the comparison: at whitelist parse time *and* on the per-task `env` argument. Now `SWE-INFINITE`, `swe-infinite`, mixed case in `TARGON_ACCELERATED_ENVS`, etc. all resolve correctly.

## Verification

The router-side log signature for the bug:

```
WARNING [affine] No live provider for miner 5EWt7AErr1Qn... (env=SWE-INFINITE, ...), releasing
```

After this fix, an active Targon deployment for that miner gets routed.