### PR TITLE
Accelerate NAVWORLD

### DIFF
--- a/affine/database/system_config.json
+++ b/affine/database/system_config.json
@@ -44,6 +44,7 @@
     "NAVWORLD": {
       "enabled_for_sampling": true,
       "enabled_for_scoring": true,
+      "accelerated": true,
       "sampling_config": {
         "dataset_range": [[0, 1000000000]],
         "sampling_count": 40,


### PR DESCRIPTION
Adds \`accelerated: true\` on NAVWORLD. SWE-INFINITE and MEMORY were already on; LIVEWEB / LOGPROBS / DISTILL / TERMINAL stay on the standard provider for now.

The earlier draft of this PR flipped all five remaining envs at once — pulled back to just NAVWORLD so we can watch the accelerated pool absorb the new load before going wider.