### PR TITLE
Bump NAVWORLD timeout to 1800s

### DIFF
--- a/affine/core/environments.py
+++ b/affine/core/environments.py
@@ -370,9 +370,9 @@ _ENV_CONFIGS_CANONICAL = {
         },
         eval_params={
             "temperature": 0.7,
-            "timeout": 1200,
+            "timeout": 1800,
         },
-        proxy_timeout=1260,
+        proxy_timeout=1860,
         cpu_limit="2000m",
     ),
 }


### PR DESCRIPTION
NAVWORLD is an agent-loop env — \`eval_params.timeout\` caps the model's total work per task. Recent FAILED entries hit the 1200s cap without the model actually being stuck, just legitimately slow on multi-turn navigation. Bumping to 1800s (with \`proxy_timeout: 1860s\` for the matching 60s grace) gives weaker miners enough rope to finish; the proxy still cuts after that, so genuinely stuck loops still get killed.