### PR TITLE
Honor is_valid across deployer / get-miner / get-rank

### DIFF
--- a/affine/api/models.py
+++ b/affine/api/models.py
@@ -96,6 +96,15 @@ class MinerScore(BaseModel):
     #   None        — no Targon deployment for this revision (Chutes-only)
     # Read by the CLI to mark which miners the Targon pool is hosting.
     targon_status: Optional[str] = None
+    # Validator-side admissibility, sourced from the miners table.
+    # is_valid=False means the validator has invalidated this miner
+    # (anticopy cheat, model_mismatch, repo-name violation, etc.) —
+    # sampling scheduler stops sampling them via get_valid_miners(),
+    # so their challenge_status may still read 'sampling' from a stale
+    # scoring snapshot. The CLI surfaces this so a miner that's been
+    # silently sidelined isn't shown as actively competing.
+    is_valid: Optional[bool] = None
+    invalid_reason: Optional[str] = None
 
 
 class ScoresResponse(BaseModel):

--- a/affine/api/routers/scores.py
+++ b/affine/api/routers/scores.py
@@ -51,6 +51,34 @@ async def _build_targon_status_map() -> dict:
     return out
 
 
+async def _build_validity_map() -> dict:
+    """Map hotkey -> (is_valid_bool, invalid_reason_str|None) from miners table.
+
+    Surfaces validator-side invalidation in the rank UI: scoring
+    snapshots only carry challenge_status, but a miner can be
+    challenge_status='sampling' while is_valid=False (e.g. anticopy
+    cheat, model_mismatch). Without this lookup the CLI shows them
+    as still competing when in reality sampling has stopped.
+
+    One full scan (256-row cap → cheap). Empty map on any DAO error
+    so a miners-table blip just hides reasons rather than 500ing.
+    """
+    try:
+        dao = MinersDAO()
+        miners = await dao.get_all_miners()
+    except Exception:
+        return {}
+    out: dict = {}
+    for m in miners:
+        hk = m.get("hotkey")
+        if not hk:
+            continue
+        # is_valid stored as 'true'/'false' string in the GSI partition key.
+        is_valid = str(m.get("is_valid") or "").lower() == "true"
+        out[hk] = (is_valid, m.get("invalid_reason") or None)
+    return out
+
+
 @router.get("/latest", response_model=ScoresResponse, dependencies=[Depends(rate_limit_read)])
 async def get_latest_scores(
     top: int = Query(32, description="Return top N miners by score", ge=1, le=256),
@@ -83,11 +111,15 @@ async def get_latest_scores(
         scores_list = scores_list[:top]
 
         targon_status = await _build_targon_status_map()
+        validity = await _build_validity_map()
 
         # Convert to response models with safe field access
-        miner_scores = [
-            MinerScore(
-                miner_hotkey=s.get("miner_hotkey"),
+        miner_scores = []
+        for s in scores_list:
+            hk = s.get("miner_hotkey")
+            is_valid, invalid_reason = validity.get(hk, (None, None))
+            miner_scores.append(MinerScore(
+                miner_hotkey=hk,
                 uid=s.get("uid"),
                 model_revision=s.get("model_revision"),
                 model=s.get("model"),
@@ -98,11 +130,11 @@ async def get_latest_scores(
                 total_samples=s.get("total_samples"),
                 challenge_info=s.get("challenge_info"),
                 targon_status=targon_status.get(
-                    (s.get("miner_hotkey"), s.get("model_revision"))
+                    (hk, s.get("model_revision"))
                 ),
-            )
-            for s in scores_list
-        ]
+                is_valid=is_valid,
+                invalid_reason=invalid_reason,
+            ))
 
         return ScoresResponse(
             block_number=block_number,

--- a/affine/database/cli.py
+++ b/affine/database/cli.py
@@ -1813,9 +1813,13 @@ async def cmd_get_miner(hotkey: str, revision: Optional[str]):
                 print(f"No miner found with revision matching '{revision}'")
                 return
         
-        # Get online miners for UID and model lookup
-        online_miners = await miners_dao.get_valid_miners()
-        miners_by_hotkey = {m['hotkey']: m for m in online_miners}
+        # Pull every miner row, not just is_valid='true' — otherwise an
+        # invalidated miner (anticopy cheat, model_mismatch, etc.) shows
+        # up as 'offline' here even though it has a record we want to
+        # surface, with the invalid_reason that explains why sampling
+        # stopped.
+        all_miners = await miners_dao.get_all_miners()
+        miners_by_hotkey = {m['hotkey']: m for m in all_miners}
 
         # Print each matching miner
         for i, stats in enumerate(matching_stats, 1):
@@ -1834,6 +1838,43 @@ async def cmd_get_miner(hotkey: str, revision: Optional[str]):
             print("=" * 120)
             print(f"MINER #{i}: {hotkey_val}")
             print("=" * 120)
+
+            # Effective status: is_valid (validator-side admissibility)
+            # gates *whether sampling is happening at all* via
+            # get_valid_miners(). challenge_status (sampling/terminated)
+            # only reflects challenge-game outcome. So a miner can read
+            # challenge_status='sampling' while is_valid='false' and
+            # actually have zero tasks generated — that's the case for
+            # anticopy cheat and other miners-monitor invalidations.
+            # Surface both, plus an EFFECTIVE label that makes the
+            # combined state obvious without having to cross-reference.
+            is_valid_str = miner_record.get('is_valid')
+            is_valid = str(is_valid_str or '').lower() == 'true'
+            invalid_reason = miner_record.get('invalid_reason') or ''
+            chal_status = stats.get('challenge_status', 'sampling')
+            term_reason = stats.get('termination_reason') or ''
+
+            if not miner_record:
+                effective = 'OFFLINE (not in miners table)'
+            elif not is_valid:
+                effective = f'TERMINATED (invalid: {invalid_reason or "no reason recorded"})'
+            elif chal_status == 'terminated':
+                effective = f'TERMINATED (challenge: {term_reason or "no reason recorded"})'
+            else:
+                effective = 'SAMPLING'
+
+            print("\n[STATUS]")
+            print(f"  Effective:        {effective}")
+            print(f"  Validator:        is_valid={is_valid_str if is_valid_str is not None else '-'}"
+                  + (f"  reason={invalid_reason}" if invalid_reason else ""))
+            print(f"  Challenge:        challenge_status={chal_status}"
+                  + (f"  reason={term_reason}" if term_reason else ""))
+            wins = stats.get('challenge_consecutive_wins', 0)
+            tot_losses = stats.get('challenge_total_losses', 0)
+            con_losses = stats.get('challenge_consecutive_losses', 0)
+            cp = stats.get('challenge_checkpoints_passed', 0)
+            print(f"                    consecutive_wins={wins}  total_losses={tot_losses}  "
+                  f"consecutive_losses={con_losses}  checkpoints_passed={cp}")
 
             # Basic Info
             print("\n[BASIC INFO]")

--- a/affine/src/miner/commands.py
+++ b/affine/src/miner/commands.py
@@ -494,13 +494,43 @@ async def get_miner_command(uid: int):
         data = await client.get(endpoint)
         if data:
             print(json.dumps(data, indent=2, ensure_ascii=False))
-            
+
             # Fetch and display sampling stats via API
             stats_endpoint = f"/miners/uid/{uid}/stats"
             stats_data = await client.get(stats_endpoint)
-            
-            # Display challenge state
+
             cs = stats_data.get('challenge_state') if stats_data else None
+
+            # Effective status: is_valid (validator-side admissibility,
+            # set by miners-monitor for anticopy / model_mismatch /
+            # repo-name / hf-fetch / etc.) gates whether sampling is
+            # actually happening — get_valid_miners() filters it.
+            # challenge_status (sampling/terminated) only reflects
+            # challenge-game outcome, so a miner can read 'sampling'
+            # there while is_valid=False has silently sidelined them.
+            # Surface the combined effective state up front so an
+            # operator doesn't have to cross-reference the JSON above
+            # with the CHAMPION CHALLENGE STATE section below.
+            is_valid_raw = data.get('is_valid')
+            is_valid = str(is_valid_raw or '').lower() == 'true'
+            invalid_reason = data.get('invalid_reason') or ''
+            chal_status = (cs or {}).get('challenge_status', 'sampling')
+            term_reason = (cs or {}).get('termination_reason') or ''
+
+            if not is_valid:
+                effective = f"TERMINATED (invalid: {invalid_reason or 'no reason recorded'})"
+            elif chal_status == 'terminated':
+                effective = f"TERMINATED (challenge: {term_reason or 'no reason recorded'})"
+            else:
+                effective = "SAMPLING"
+
+            print("\n" + "=" * 80)
+            print("EFFECTIVE STATUS")
+            print("=" * 80)
+            print(f"  Status:              {effective}")
+            print(f"  Validator admits:    is_valid={is_valid_raw if is_valid_raw is not None else '-'}"
+                  + (f"  reason={invalid_reason}" if invalid_reason else ""))
+
             if cs:
                 print("\n" + "="*80)
                 print("CHAMPION CHALLENGE STATE")

--- a/affine/src/miner/rank.py
+++ b/affine/src/miner/rank.py
@@ -96,13 +96,15 @@ class RankedMiner:
     scores_by_env: Dict[str, Dict[str, Any]]
     average_score: float
     is_champion: bool
-    status: str                    # 'sampling' | 'terminated'
+    status: str                    # challenge_status — 'sampling' | 'terminated'
     consecutive_wins: int
     total_losses: int
     consecutive_losses: int
     checkpoints_passed: int
     total_samples: int             # Samples produced in current scoring cycle
     targon_status: Optional[str]   # 'active' | 'deploying' | None — Targon acceleration
+    is_valid: Optional[bool]       # validator-side admissibility (anticopy etc.)
+    invalid_reason: Optional[str]
 
     @property
     def is_cold(self) -> bool:
@@ -112,14 +114,29 @@ class RankedMiner:
         return (
             not self.is_champion
             and self.status == "sampling"
+            and self.is_valid is not False  # invalid miners get their own bucket
             and self.total_samples == 0
         )
+
+    @property
+    def is_invalid(self) -> bool:
+        # validator-side invalidation (anticopy, model_mismatch, repo-name,
+        # etc.) — sampling scheduler stops sampling these via is_valid filter,
+        # so they shouldn't be displayed as 'sampling' even when their
+        # challenge_status snapshot still says so.
+        return self.is_valid is False
 
 
 def parse_ranked_miners(scores_list: List[Dict[str, Any]]) -> List[RankedMiner]:
     out = []
     for s in scores_list:
         ci = s.get("challenge_info") or {}
+        # is_valid arrives over the API as JSON bool (or None if the miners
+        # row was missing); preserve None vs False distinction so the UI
+        # only shows INVALID when we actually know the miner was rejected.
+        is_valid = s.get("is_valid")
+        if is_valid is not None:
+            is_valid = bool(is_valid)
         out.append(RankedMiner(
             uid=s.get("uid"),
             hotkey=s.get("miner_hotkey") or "",
@@ -134,6 +151,8 @@ def parse_ranked_miners(scores_list: List[Dict[str, Any]]) -> List[RankedMiner]:
             checkpoints_passed=int(ci.get("checkpoints_passed", 0) or 0),
             total_samples=int(s.get("total_samples", 0) or 0),
             targon_status=s.get("targon_status"),
+            is_valid=is_valid,
+            invalid_reason=s.get("invalid_reason"),
         ))
     return out
 
@@ -175,11 +194,18 @@ format_targon = format_boost
 
 
 def sort_key(m: RankedMiner) -> tuple:
-    """Champion → active sampling (highest CP first) → cold → terminated."""
+    """Champion → active sampling (highest CP first) → cold → invalid → terminated."""
     if m.is_champion:
         return (0,)
     if m.status == "terminated":
-        return (3, -m.total_losses, -m.checkpoints_passed)
+        return (4, -m.total_losses, -m.checkpoints_passed)
+    if m.is_invalid:
+        # validator-side rejection (anticopy / model_mismatch / repo-name /
+        # …): not in the competition anymore even though challenge_status
+        # might still read 'sampling' — group below cold but above
+        # challenge-terminated so operators can spot them as a distinct
+        # bucket.
+        return (3, -m.checkpoints_passed, -m.average_score)
     if m.is_cold:
         return (2, -m.checkpoints_passed, -m.average_score)
     # Active sampling: closeness to dethrone, then checkpoint depth, then avg
@@ -378,6 +404,17 @@ async def print_rank_table():
                     challenge_str = "pairwise"
                 else:
                     challenge_str = f"L:{m.total_losses}/{M}"
+            elif m.is_invalid:
+                # validator-side rejection: sampling has actually stopped
+                # via get_valid_miners() filter, so showing 'sampling' or
+                # 'cold' would be misleading. The reason (anticopy / etc.)
+                # goes in the Challenge column for at-a-glance triage.
+                status_str = "INVALID"
+                cp_str = "—"
+                reason = m.invalid_reason or ""
+                # Trim long reasons (anticopy carries the full target
+                # repo path); 24 chars fits the existing column width.
+                challenge_str = reason[:24] if reason else "invalid"
             elif m.is_cold:
                 status_str = "cold"
                 cp_str = f"{m.checkpoints_passed}/{dethrone_cp}"

--- a/affine/src/miner/rank.py
+++ b/affine/src/miner/rank.py
@@ -407,14 +407,30 @@ async def print_rank_table():
             elif m.is_invalid:
                 # validator-side rejection: sampling has actually stopped
                 # via get_valid_miners() filter, so showing 'sampling' or
-                # 'cold' would be misleading. The reason (anticopy / etc.)
-                # goes in the Challenge column for at-a-glance triage.
-                status_str = "INVALID"
+                # 'cold' would be misleading. Surface the *specific* cause
+                # in the Status column (a generic 'INVALID' loses the
+                # signal an operator needs); the detail tail (similarity
+                # scores, mismatched chute name, etc.) goes in Challenge.
+                reason = m.invalid_reason or "invalid"
+                kind, _, detail = reason.partition(":")
+                # Map raw miners-monitor reason keys to compact labels
+                # that fit the 11-char Status column without dropping
+                # information. Unknown reasons fall through truncated.
+                kind_label = {
+                    "anticopy": "anticopy",
+                    "chute_fetch_failed": "chute_fetch",
+                    "chute_slug_empty": "chute_empty",
+                    "chute_not_hot": "chute_cold",
+                    "model_mismatch": "model_mis",
+                    "model_name_missing_affine": "name_miss",
+                    "repo_name_not_ending_with_hotkey": "repo_name",
+                    "revision_mismatch": "rev_mis",
+                    "hf_model_fetch_failed": "hf_fetch",
+                    "multiple_commits": "multi_cmt",
+                }.get(kind, kind[:11])
+                status_str = kind_label
                 cp_str = "—"
-                reason = m.invalid_reason or ""
-                # Trim long reasons (anticopy carries the full target
-                # repo path); 24 chars fits the existing column width.
-                challenge_str = reason[:24] if reason else "invalid"
+                challenge_str = (detail[:24] if detail else "—")
             elif m.is_cold:
                 status_str = "cold"
                 cp_str = f"{m.checkpoints_passed}/{dethrone_cp}"

--- a/affine/src/miner/rank.py
+++ b/affine/src/miner/rank.py
@@ -430,7 +430,13 @@ async def print_rank_table():
                 }.get(kind, kind[:11])
                 status_str = kind_label
                 cp_str = "—"
-                challenge_str = (detail[:24] if detail else "—")
+                # Detail (similarity scores, mismatched chute name, etc.)
+                # is supplementary here — Status already names the kind.
+                # Truncate to the 11-char column width so a long detail
+                # doesn't shove the rest of the row out of alignment;
+                # operators drill in via `af get-miner <uid>` for the
+                # full invalid_reason if they need it.
+                challenge_str = (detail[:11] if detail else "—")
             elif m.is_cold:
                 status_str = "cold"
                 cp_str = f"{m.checkpoints_passed}/{dethrone_cp}"

--- a/affine/src/targon_deployer/service.py
+++ b/affine/src/targon_deployer/service.py
@@ -133,55 +133,61 @@ class TargonDeployerService:
     async def _resolve_targets(self) -> List[Tuple[str, str, str]]:
         """Compute the target set for this cycle.
 
-        Champion is always slot 0 (deployed regardless of Chutes state —
-        a cold-Chutes champion still earns the dethrone-protection slot).
-
-        The remaining slots are filled from sampling miners whose Chutes
-        endpoint is currently hot, ranked by:
+        Champion gets slot 0; remaining slots are filled from sampling
+        miners ranked by:
 
             (has_wins   DESC,   # consecutive_wins > 0 → True before False
              first_block ASC)   # within a tier, earliest submitter first
 
-        Why Chutes-hot is a hard filter for challengers: a cold Chutes is
-        the cheapest "miner has effectively dropped offline" signal we
-        have (template check failed, miner forgot to redeploy, deletion
-        in flight). Spending Targon GPU-hours on those slots throws money
-        away — the miner is likely to fail termination soon and the slot
-        churns. We'd rather leave the slot empty than waste it.
+        Eligibility filter (applies to *both* champion and challengers):
+          - is_valid == 'true'                   (validator admits it)
+          - chute_status == 'hot'                (Chutes is serving)
+          - challenge_status == 'sampling'       (challengers only)
+          - (hotkey, revision) != champion's     (no double counting)
 
-        Side effect: a previously-hot incumbent that goes cold is no
-        longer in the eligible set, so it falls out of the target set
-        and gets torn down on this reconcile. The slot opens up for a
-        currently-hot miner.
+        Why is_valid is required, not just chute_hot: the chute_hot
+        filter catches the *common* invalidation paths because most
+        of them clear chute_status as a side effect (chute_fetch_failed,
+        chute_slug_empty, chute_not_hot). But anticopy, model_mismatch,
+        repo-name violations, revision_mismatch, hf_model_fetch_failed,
+        and multiple_commits all leave chute_status='hot' while flipping
+        is_valid='false'. Sampling scheduler also gates on is_valid via
+        get_valid_miners(), so without the same gate here the deployer
+        burns GPU on miners no one is actually sampling. UID 187's
+        anticopy case is the canonical example.
 
-        Eligibility filter for challengers:
-          - challenge_status == 'sampling'      (terminated miners excluded)
-          - chute_status == 'hot'               (offline miners excluded)
-          - (hotkey, revision) != champion's    (avoid double counting)
+        Why is_valid applies to champion too: dethrone-protection is
+        meant to ride out a *transient Chutes blip* — short hiccups
+        in the network/CDN. validator-side invalidation (anticopy,
+        repo-name) is deterministic, not transient, and sampling
+        scheduler stops sampling the champion anyway. Keeping the
+        deployment costs GPU-hours for nothing. Once is_valid flips
+        back to 'true', the deployer recreates the slot on the next
+        reconcile.
+
+        Why Chutes-hot is a hard filter for challengers: a cold Chutes
+        is the cheapest "miner has effectively dropped offline" signal
+        we have. Spending Targon GPU-hours on those slots throws money
+        away — the miner is likely to churn soon. We'd rather leave
+        the slot empty than waste it.
+
+        Side effect: a previously-eligible incumbent that goes
+        invalid/cold falls out of the target set and gets torn down on
+        this reconcile, freeing the slot for the next queued candidate.
 
         Returns list of (hotkey, revision, role) where role ∈ {'champion','winner'}.
         """
         targets: List[Tuple[str, str, str]] = []
         seen: Set[Tuple[str, str]] = set()
 
-        champion = await self.config_dao.get_param_value("champion", default=None)
-        if champion and champion.get("hotkey") and champion.get("revision"):
-            champ_key = (champion["hotkey"], champion["revision"])
-            targets.append((champ_key[0], champ_key[1], "champion"))
-            seen.add(champ_key)
-
-        if self.max_deployments <= 1:
-            return targets
-
-        all_stats = await self.miner_stats_dao.get_all_historical_miners()
-
-        # Per-hotkey (first_block, chute_status) from the miners table.
-        # Bounded to ~256 rows so a single scan is cheaper than per-hotkey
-        # lookups, and first_block is per-hotkey (stable across revisions)
-        # so the join key is hotkey alone.
+        # Per-hotkey (first_block, chute_status, is_valid) from the
+        # miners table. Loaded up front because both the champion check
+        # and the challenger eligibility loop need is_valid + chute_hot.
+        # Bounded to ~256 rows → one scan is cheaper than per-hotkey lookups.
         miners = await self.miners_dao.get_all_miners()
         first_block_by_hotkey: Dict[str, int] = {}
         chute_hot_by_hotkey: Dict[str, bool] = {}
+        is_valid_by_hotkey: Dict[str, bool] = {}
         for m in miners:
             hk = m.get("hotkey")
             if not hk:
@@ -191,9 +197,29 @@ class TargonDeployerService:
             except (TypeError, ValueError):
                 pass
             chute_hot_by_hotkey[hk] = (m.get("chute_status") or "").lower() == "hot"
+            # is_valid is a string column ('true' / 'false') because it
+            # backs a GSI partition key; coerce defensively.
+            is_valid_by_hotkey[hk] = str(m.get("is_valid") or "").lower() == "true"
 
-        # (hotkey, revision) -> (has_wins, first_block) for hot, sampling miners.
-        # Cold Chutes are filtered out entirely (not just deprioritized).
+        champion = await self.config_dao.get_param_value("champion", default=None)
+        if (
+            champion
+            and champion.get("hotkey")
+            and champion.get("revision")
+            and is_valid_by_hotkey.get(champion["hotkey"], False)
+        ):
+            champ_key = (champion["hotkey"], champion["revision"])
+            targets.append((champ_key[0], champ_key[1], "champion"))
+            seen.add(champ_key)
+
+        if self.max_deployments <= 1:
+            return targets
+
+        all_stats = await self.miner_stats_dao.get_all_historical_miners()
+
+        # (hotkey, revision) -> (has_wins, first_block) for hot, valid,
+        # sampling miners. Cold/invalid miners are filtered out entirely
+        # (not just deprioritized) so they release their existing slot.
         eligible: Dict[Tuple[str, str], Tuple[bool, int]] = {}
         for s in all_stats:
             if s.get("challenge_status") != "sampling":
@@ -205,6 +231,8 @@ class TargonDeployerService:
             if (hotkey, revision) in seen:
                 continue
             if not chute_hot_by_hotkey.get(hotkey, False):
+                continue
+            if not is_valid_by_hotkey.get(hotkey, False):
                 continue
             wins = int(s.get("challenge_consecutive_wins", 0) or 0)
             has_wins = wins > 0


### PR DESCRIPTION
## Background — why this PR

The validator splits "miner is admissible" across two fields by design:

- \`miner_stats.challenge_status\` (\`'sampling'\` / \`'terminated'\`) — set by the scorer, reflects challenge-game outcome only (loss counts, Pareto domination).
- \`miners.is_valid\` (\`'true'\` / \`'false'\`) — set by miners-monitor, the umbrella validator-side admissibility flag (anticopy cheat, chute checks, repo-name, model-mismatch, hf-fetch failures, multiple commits, etc.).

The two are deliberately orthogonal. \`challenge_status\` has no opinion about anticopy; \`is_valid\` has no opinion about challenge wins/losses. Sampling scheduler is the canonical consumer — it filters via \`get_valid_miners()\` and stops sampling immediately when \`is_valid\` flips false. That's correct.

But other consumers were only reading half:

- **Targon deployer** filtered on \`challenge_status='sampling' + chute_status='hot'\`. The chute_hot filter caught most invalidations because they clear \`chute_status\` as a side effect — but anticopy / model_mismatch / repo-name / revision_mismatch / hf_model_fetch_failed / multiple_commits all leave \`chute_status='hot'\` while flipping \`is_valid='false'\`. Those slipped through, and the deployer kept burning GPU on miners no one was sampling.
- **\`af get-miner\`** showed only \`challenge_status\`, so an invalidated miner read as 'sampling'.
- **\`af db get-miner\`** likewise; further, it called \`get_valid_miners()\` for the lookup, so an invalidated miner appeared as 'offline'.
- **\`af get-rank\`** had no \`is_valid\` field on \`MinerScore\`, same blindspot.

## Fix — keep the two-field design, make every consumer honor both

1. **Targon deployer (\`service.py:_resolve_targets\`)**: add \`is_valid='true'\` to the eligibility filter for both champion and challengers.
2. **\`/scores/latest\` (\`scores.py\`)**: enrich \`MinerScore\` with \`is_valid\` + \`invalid_reason\`.
3. **\`af db get-miner\`**: prepend a \`[STATUS]\` section deriving the effective state. Switch the miner-record lookup to \`get_all_miners()\` so an invalidated miner isn't shown as 'offline'.
4. **\`af get-miner\`**: \`EFFECTIVE STATUS\` block after the JSON dump.
5. **\`af get-rank\`**: new INVALID bucket between cold and challenge-terminated; Status column shows the *specific* invalidation kind (anticopy / chute_fetch / model_mis / etc.) rather than a generic label, with the detail tail in the Challenge column.

## Behavioral change worth flagging

Once deployed, any active Targon deployment whose miner currently reads \`is_valid='false'\` (or whose champion is offline / not in the miners table) is released on the next reconcile. The freed slot is taken by the next queued candidate. Sampling for those miners is unaffected because it had already stopped via \`get_valid_miners()\`; sampling for the new candidate falls back to Chutes during the model-load window via the router's existing fallback chain.