### PR TITLE
Track total_wins to mirror total_losses

### DIFF
--- a/affine/database/cli.py
+++ b/affine/database/cli.py
@@ -1870,11 +1870,13 @@ async def cmd_get_miner(hotkey: str, revision: Optional[str]):
             print(f"  Challenge:        challenge_status={chal_status}"
                   + (f"  reason={term_reason}" if term_reason else ""))
             wins = stats.get('challenge_consecutive_wins', 0)
+            tot_wins = stats.get('challenge_total_wins', 0)
             tot_losses = stats.get('challenge_total_losses', 0)
             con_losses = stats.get('challenge_consecutive_losses', 0)
             cp = stats.get('challenge_checkpoints_passed', 0)
-            print(f"                    consecutive_wins={wins}  total_losses={tot_losses}  "
-                  f"consecutive_losses={con_losses}  checkpoints_passed={cp}")
+            print(f"                    consecutive_wins={wins}  total_wins={tot_wins}  "
+                  f"total_losses={tot_losses}  consecutive_losses={con_losses}  "
+                  f"checkpoints_passed={cp}")
 
             # Basic Info
             print("\n[BASIC INFO]")

--- a/affine/database/dao/miner_stats.py
+++ b/affine/database/dao/miner_stats.py
@@ -491,6 +491,7 @@ class MinerStatsDAO(BaseDAO):
     # Fields that make up a miner's challenge state (loss/win counters etc.)
     _CHALLENGE_FIELDS = (
         'challenge_consecutive_wins',
+        'challenge_total_wins',
         'challenge_total_losses',
         'challenge_consecutive_losses',
         'challenge_checkpoints_passed',
@@ -502,6 +503,7 @@ class MinerStatsDAO(BaseDAO):
     def _challenge_defaults() -> Dict[str, Any]:
         return {
             'challenge_consecutive_wins': 0,
+            'challenge_total_wins': 0,
             'challenge_total_losses': 0,
             'challenge_consecutive_losses': 0,
             'challenge_checkpoints_passed': 0,
@@ -524,7 +526,8 @@ class MinerStatsDAO(BaseDAO):
         if not stats:
             return False
         for k in ('challenge_total_losses', 'challenge_consecutive_losses',
-                  'challenge_consecutive_wins', 'challenge_checkpoints_passed'):
+                  'challenge_consecutive_wins', 'challenge_total_wins',
+                  'challenge_checkpoints_passed'):
             if stats.get(k, 0):
                 return True
         if stats.get('challenge_status') == 'terminated':
@@ -590,6 +593,7 @@ class MinerStatsDAO(BaseDAO):
         checkpoints_passed: int,
         status: str,
         termination_reason: str = '',
+        total_wins: int = 0,
     ) -> None:
         """Update miner's champion challenge state.
 
@@ -619,6 +623,7 @@ class MinerStatsDAO(BaseDAO):
             Key={'pk': {'S': pk}, 'sk': {'S': sk}},
             UpdateExpression=(
                 'SET challenge_consecutive_wins = :cw, '
+                'challenge_total_wins = :tw, '
                 'challenge_total_losses = :tl, '
                 'challenge_consecutive_losses = :cl, '
                 'challenge_checkpoints_passed = :cp, '
@@ -639,6 +644,7 @@ class MinerStatsDAO(BaseDAO):
             ),
             ExpressionAttributeValues={
                 ':cw': {'N': str(consecutive_wins)},
+                ':tw': {'N': str(total_wins)},
                 ':tl': {'N': str(total_losses)},
                 ':cl': {'N': str(consecutive_losses)},
                 ':cp': {'N': str(checkpoints_passed)},
@@ -846,6 +852,7 @@ class MinerStatsDAO(BaseDAO):
                 'sampling_slots = if_not_exists(sampling_slots, :default_slots), '
                 'slots_last_adjusted_at = if_not_exists(slots_last_adjusted_at, :zero), '
                 'challenge_consecutive_wins = if_not_exists(challenge_consecutive_wins, :zero), '
+                'challenge_total_wins = if_not_exists(challenge_total_wins, :zero), '
                 'challenge_total_losses = if_not_exists(challenge_total_losses, :zero), '
                 'challenge_consecutive_losses = if_not_exists(challenge_consecutive_losses, :zero), '
                 'challenge_checkpoints_passed = if_not_exists(challenge_checkpoints_passed, :zero)'

--- a/affine/src/miner/commands.py
+++ b/affine/src/miner/commands.py
@@ -539,6 +539,7 @@ async def get_miner_command(uid: int):
                 print(f"  Status:              {status}")
                 print(f"  Checkpoints passed:  {cs.get('challenge_checkpoints_passed', 0)}")
                 print(f"  Consecutive wins:    {cs.get('challenge_consecutive_wins', 0)}")
+                print(f"  Total wins:          {cs.get('challenge_total_wins', 0)}")
                 print(f"  Total losses:        {cs.get('challenge_total_losses', 0)}")
                 print(f"  Consecutive losses:  {cs.get('challenge_consecutive_losses', 0)}")
                 if status == 'terminated':

--- a/affine/src/miner/rank.py
+++ b/affine/src/miner/rank.py
@@ -98,6 +98,7 @@ class RankedMiner:
     is_champion: bool
     status: str                    # challenge_status — 'sampling' | 'terminated'
     consecutive_wins: int
+    total_wins: int
     total_losses: int
     consecutive_losses: int
     checkpoints_passed: int
@@ -146,6 +147,7 @@ def parse_ranked_miners(scores_list: List[Dict[str, Any]]) -> List[RankedMiner]:
             is_champion=bool(ci.get("is_champion", False)),
             status=ci.get("status", "sampling"),
             consecutive_wins=int(ci.get("consecutive_wins", 0) or 0),
+            total_wins=int(ci.get("total_wins", 0) or 0),
             total_losses=int(ci.get("total_losses", 0) or 0),
             consecutive_losses=int(ci.get("consecutive_losses", 0) or 0),
             checkpoints_passed=int(ci.get("checkpoints_passed", 0) or 0),
@@ -447,8 +449,8 @@ async def print_rank_table():
                 parts = []
                 if m.checkpoints_passed >= dethrone_cp and m.consecutive_wins > 0:
                     parts.append("READY")
-                elif m.consecutive_wins > 0:
-                    parts.append(f"W:{m.consecutive_wins}")
+                elif m.total_wins > 0:
+                    parts.append(f"W:{m.total_wins}")
                 if m.total_losses > 0:
                     parts.append(f"L:{m.total_losses}/{M}")
                 challenge_str = " ".join(parts) if parts else "—"

--- a/affine/src/monitor/miners_monitor.py
+++ b/affine/src/monitor/miners_monitor.py
@@ -637,6 +637,7 @@ class MinersMonitor:
                     hotkey=miner.hotkey,
                     revision=miner.revision,
                     consecutive_wins=int(state.get('challenge_consecutive_wins', 0) or 0),
+                    total_wins=int(state.get('challenge_total_wins', 0) or 0),
                     total_losses=int(state.get('challenge_total_losses', 0) or 0),
                     consecutive_losses=int(state.get('challenge_consecutive_losses', 0) or 0),
                     checkpoints_passed=int(state.get('challenge_checkpoints_passed', 0) or 0),

--- a/affine/src/scorer/champion_challenge.py
+++ b/affine/src/scorer/champion_challenge.py
@@ -115,6 +115,7 @@ class ChampionChallenge:
         for miner in miners.values():
             p = prev.get(miner.hotkey, {})
             miner.challenge_consecutive_wins = p.get('challenge_consecutive_wins', 0)
+            miner.challenge_total_wins = p.get('challenge_total_wins', 0)
             miner.challenge_total_losses = p.get('challenge_total_losses', 0)
             miner.challenge_consecutive_losses = p.get('challenge_consecutive_losses', 0)
             miner.challenge_checkpoints_passed = p.get('challenge_checkpoints_passed', 0)
@@ -307,6 +308,7 @@ class ChampionChallenge:
 
             if cmp.b_dominates_a:
                 miner.challenge_consecutive_wins += 1
+                miner.challenge_total_wins += 1
                 miner.challenge_consecutive_losses = 0
                 logger.info(f"UID {uid} dominates at CP {cp} "
                             f"(wins: {miner.challenge_consecutive_wins})")
@@ -513,6 +515,7 @@ class ChampionChallenge:
 
     def _reset_state(self, miner: MinerData):
         miner.challenge_consecutive_wins = 0
+        miner.challenge_total_wins = 0
         miner.challenge_total_losses = 0
         miner.challenge_consecutive_losses = 0
         miner.challenge_checkpoints_passed = 0

--- a/affine/src/scorer/models.py
+++ b/affine/src/scorer/models.py
@@ -39,6 +39,7 @@ class MinerData:
 
     # Champion challenge state
     challenge_consecutive_wins: int = 0
+    challenge_total_wins: int = 0
     challenge_total_losses: int = 0
     challenge_consecutive_losses: int = 0
     challenge_checkpoints_passed: int = 0

--- a/affine/src/scorer/scorer.py
+++ b/affine/src/scorer/scorer.py
@@ -207,6 +207,7 @@ class Scorer:
             challenge_info = {
                 "status": miner.challenge_status,
                 "consecutive_wins": miner.challenge_consecutive_wins,
+                "total_wins": miner.challenge_total_wins,
                 "total_losses": miner.challenge_total_losses,
                 "consecutive_losses": miner.challenge_consecutive_losses,
                 "checkpoints_passed": miner.challenge_checkpoints_passed,
@@ -235,6 +236,7 @@ class Scorer:
                     hotkey=miner.hotkey,
                     revision=miner.model_revision,
                     consecutive_wins=miner.challenge_consecutive_wins,
+                    total_wins=miner.challenge_total_wins,
                     total_losses=miner.challenge_total_losses,
                     consecutive_losses=miner.challenge_consecutive_losses,
                     checkpoints_passed=miner.challenge_checkpoints_passed,


### PR DESCRIPTION
## Summary

Fix asymmetric challenge counters: today the model tracks cumulative `total_losses` but only `consecutive_wins` (which resets the moment a miner loses). After the first loss, the rank UI's `W:x` indicator disappears entirely — operators have no signal of past wins from the table view.

Add `challenge_total_wins` as the symmetric counterpart of `challenge_total_losses` — incremented on every win, reset only on champion-change full-state reset (same lifecycle as `total_losses`).

## Changes

| Layer | Change |
|---|---|
| `scorer/models.py` | `MinerData.challenge_total_wins: int = 0` |
| `scorer/champion_challenge.py` | Load from DB, increment on win, reset on champion-change |
| `database/dao/miner_stats.py` | Add to `_CHALLENGE_FIELDS`, `_challenge_defaults`, `_has_challenge_state`, `update_challenge_state` (signature + DDB SET), never-sampled `if_not_exists` initializer |
| `scorer/scorer.py` | Pass to `update_challenge_state`; include in `challenge_info` API payload |
| `monitor/miners_monitor.py` | Preserve through `_terminate_permanently_invalid` write |
| `miner/rank.py` | Add to `RankedMiner` + parser; `af get-rank` shows `W:total_wins` |
| `database/cli.py` / `miner/commands.py` | `af db get-miner` / `af get-miner` show `total_wins` field |

## Behavior

`af get-rank` Challenge column:
- Before: `W:3` → after one loss → `L:1/M`  (W lost)
- After:  `W:3` → after one loss → `W:3 L:1/M`  ✓

## Backwards compatibility

Old `miner_stats` rows without `challenge_total_wins` default to 0:
- DDB UpdateExpression always writes the field on next scorer cycle
- `if_not_exists` initializer covers the never-sampled termination path
- All read sites use `.get('challenge_total_wins', 0)` defaulting to 0

## Test plan

- [ ] After deploy + one scorer cycle: verify `af db get-miner <champion>` shows `total_wins > 0`
- [ ] Verify a miner with `consecutive_wins=0 total_losses>0 total_wins>0` renders as `W:N L:M/X` in `af get-rank`
- [ ] Verify champion-change resets `total_wins` to 0 alongside `total_losses`