### PR TITLE
anticopy: treat cheat like suspicious instead of hard-invalidate

### DIFF
--- a/affine/src/monitor/miners_monitor.py
+++ b/affine/src/monitor/miners_monitor.py
@@ -539,20 +539,20 @@ class MinersMonitor:
                     reason = f"{reason_prefix}={orig_model}"
                     if sim_str:
                         reason += f"({sim_str})"
-                    if ac_status == "cheat":
-                        info.mark_invalid(reason, permanent=True)
-                        logger.info(
-                            f"[MinersMonitor] Anti-copy flagged uid={uid}: "
-                            f"model={model} high similarity with {orig_model} [{sim_str}]"
-                        )
-                        return info
-                    # 'suspicious' is NOT an invalidation — only flags a
-                    # softer reason for downstream pareto margin tightening.
-                    # is_valid stays True; do not call mark_invalid.
+                    # Neither 'cheat' nor 'suspicious' triggers invalidation
+                    # anymore — both surface the same soft signal and let
+                    # stage2_pareto apply a tightened dominance margin
+                    # against the alleged source. Hard invalidation on
+                    # cheat caused false positives on legitimate fine-tunes
+                    # of an earlier base (e.g. uid 15 vs 213: 10pt SWE
+                    # improvement but logprobs still near-identical on
+                    # template tokens). is_valid stays True; do not call
+                    # mark_invalid.
                     info.invalid_reason = reason
                     logger.info(
-                        f"[MinersMonitor] Anti-copy suspicious uid={uid}: "
-                        f"model={model} high similarity with {orig_model} [{sim_str}]"
+                        f"[MinersMonitor] Anti-copy {ac_status} uid={uid}: "
+                        f"model={model} similarity with {orig_model} [{sim_str}] "
+                        f"(downgraded to soft flag, not invalidated)"
                     )
             except Exception as e:
                 logger.debug(f"[MinersMonitor] Anti-copy check failed for uid={uid}: {e}")

--- a/affine/src/scorer/stage2_pareto.py
+++ b/affine/src/scorer/stage2_pareto.py
@@ -62,8 +62,11 @@ class Stage2ParetoFilter:
         apply_anticopy_bias = (label == "pairwise")
 
         def _effective_margin(actor: MinerData, target: MinerData) -> float:
+            # Apply tightened margin against the alleged source for BOTH
+            # 'suspicious' and 'cheat' (cheat is no longer hard-invalidated
+            # by miners_monitor — both rely on this margin bias instead).
             if apply_anticopy_bias and (
-                getattr(actor, "anticopy_status", "clean") == "suspicious"
+                getattr(actor, "anticopy_status", "clean") in ("suspicious", "cheat")
                 and getattr(actor, "anticopy_target_uid", None) == target.uid
             ):
                 return margin * suspicious_multiplier


### PR DESCRIPTION
## Summary

- Cheat status no longer hard-invalidates a miner; both `cheat` and
  `suspicious` flow through the same soft path.
- `miners_monitor` records `invalid_reason` for visibility but keeps
  `is_valid=True`; the miner continues sampling/scoring.
- `stage2_pareto` applies `PARETO_SUSPICIOUS_MARGIN_MULTIPLIER` (×1.5)
  against the alleged source for both states.

## Motivation

The hard-invalidate path produced false positives on legitimate
fine-tunes of an earlier base. The current LOGPROBS-only signal — top-K
logprobs over the first 20 generated tokens — is dominated by template
tokens (\`<think>\`, \`THOUGHT:\` etc.) that all same-family models share
even after meaningful fine-tuning. A model that improves end-to-end
performance by several points on SWE-INFINITE can still register
logprob cosine ≈ 0.999 on these template tokens, which is enough to
trip the cheat threshold.

Hard invalidation in that case is wrong: the model is genuinely better
than its base. With the soft path, a model that truly outperforms its
alleged source by \`margin × 1.5\` can still dethrone; a real copy
lacking real improvement remains blocked at the tightened margin.

## Test plan
- [ ] Anti-copy round in staging produces \`cheat\` records but the
      flagged miners keep \`is_valid=True\` and continue sampling.
- [ ] Pairwise pareto applies the 1.5× margin only against the source
      uid recorded in \`copy_of\`.
- [ ] A fine-tuned model that beats its base by ≥ \`margin × 1.5\` in
      every env can still dethrone the base.