### PR TITLE
Soft-cheat anticopy + SWE concurrency cap

### DIFF
--- a/affine/src/anticopy/main.py
+++ b/affine/src/anticopy/main.py
@@ -158,6 +158,18 @@ class AntiCopyService:
 
     async def _run_detection(self):
         """Run one round of copy detection."""
+        # Detection is OFF by default while the LOGPROBS env is being
+        # reworked (n_tokens=20 plus template-heavy prompts gives near-1.0
+        # logprob cosine even for legitimate fine-tunes of the same base).
+        # Set ANTICOPY_ENABLED=1 to re-enable after the env is updated and
+        # detector thresholds are recalibrated. No DB writes happen while
+        # disabled, so existing anti_copy_results rows are NOT refreshed —
+        # they will age out via TTL or need manual cleanup.
+        import os
+        if os.getenv("ANTICOPY_ENABLED", "0") != "1":
+            logger.info("[AntiCopy] disabled by default (set ANTICOPY_ENABLED=1 to enable), skipping detection")
+            return
+
         miners = await self._fetch_miners()
         if len(miners) < 2:
             logger.warning("[AntiCopy] Not enough miners for comparison, skipping")

--- a/affine/src/executor/config.py
+++ b/affine/src/executor/config.py
@@ -8,6 +8,9 @@ ENV_MAX_CONCURRENT = {
     "LGC-v2": 300,
     "LIVEWEB": 50,
     "NAVWORLD": 100,
+    "SWE-PRO": 80,
+    "SWE-SYNTH": 80,
+    "SWE-INFINITE": 80,
 }
 
 # Default max concurrent tasks if environment not found in config

--- a/affine/src/monitor/miners_monitor.py
+++ b/affine/src/monitor/miners_monitor.py
@@ -539,20 +539,20 @@ class MinersMonitor:
                     reason = f"{reason_prefix}={orig_model}"
                     if sim_str:
                         reason += f"({sim_str})"
-                    if ac_status == "cheat":
-                        info.mark_invalid(reason, permanent=True)
-                        logger.info(
-                            f"[MinersMonitor] Anti-copy flagged uid={uid}: "
-                            f"model={model} high similarity with {orig_model} [{sim_str}]"
-                        )
-                        return info
-                    # 'suspicious' is NOT an invalidation — only flags a
-                    # softer reason for downstream pareto margin tightening.
-                    # is_valid stays True; do not call mark_invalid.
+                    # Neither 'cheat' nor 'suspicious' triggers invalidation
+                    # anymore — both surface the same soft signal and let
+                    # stage2_pareto apply a tightened dominance margin
+                    # against the alleged source. Hard invalidation on
+                    # cheat caused false positives on legitimate fine-tunes
+                    # of an earlier base (e.g. uid 15 vs 213: 10pt SWE
+                    # improvement but logprobs still near-identical on
+                    # template tokens). is_valid stays True; do not call
+                    # mark_invalid.
                     info.invalid_reason = reason
                     logger.info(
-                        f"[MinersMonitor] Anti-copy suspicious uid={uid}: "
-                        f"model={model} high similarity with {orig_model} [{sim_str}]"
+                        f"[MinersMonitor] Anti-copy {ac_status} uid={uid}: "
+                        f"model={model} similarity with {orig_model} [{sim_str}] "
+                        f"(downgraded to soft flag, not invalidated)"
                     )
             except Exception as e:
                 logger.debug(f"[MinersMonitor] Anti-copy check failed for uid={uid}: {e}")

--- a/affine/src/scorer/stage2_pareto.py
+++ b/affine/src/scorer/stage2_pareto.py
@@ -62,8 +62,11 @@ class Stage2ParetoFilter:
         apply_anticopy_bias = (label == "pairwise")
 
         def _effective_margin(actor: MinerData, target: MinerData) -> float:
+            # Apply tightened margin against the alleged source for BOTH
+            # 'suspicious' and 'cheat' (cheat is no longer hard-invalidated
+            # by miners_monitor — both rely on this margin bias instead).
             if apply_anticopy_bias and (
-                getattr(actor, "anticopy_status", "clean") == "suspicious"
+                getattr(actor, "anticopy_status", "clean") in ("suspicious", "cheat")
                 and getattr(actor, "anticopy_target_uid", None) == target.uid
             ):
                 return margin * suspicious_multiplier

--- a/compose/docker-compose.backend.yml
+++ b/compose/docker-compose.backend.yml
@@ -107,19 +107,6 @@ services:
       - /var/log/affine/targon_deployer:/var/log/affine/targon_deployer
     command: ["-v", "servers", "targon-deployer"]
 
-  # Anti-Copy Detection - Model copy detection service
-  anticopy:
-    image: affinefoundation/affine:latest
-    container_name: affine-anticopy
-    restart: unless-stopped
-    mem_reservation: "2g"
-    mem_limit: "4g"
-    env_file:
-      - .env
-    volumes:
-      - /var/log/affine/anticopy:/var/log/affine/anticopy
-    command: ["-v", "servers", "anticopy"]
-
   # Scorer - Weight calculation service
   scorer:
     image: affinefoundation/affine:latest
@@ -146,7 +133,7 @@ services:
     restart: unless-stopped
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
-    command: --interval 30 affine-api affine-scheduler affine-executor affine-teacher affine-monitor affine-anticopy affine-scorer affine-targon-deployer
+    command: --interval 30 affine-api affine-scheduler affine-executor affine-teacher affine-monitor affine-scorer affine-targon-deployer
 
 networks:
   default:


### PR DESCRIPTION
## Summary
- Treat anticopy cheat verdict as suspicious instead of hard-invalidating
- Disable anticopy service by default (compose entry removed; in-process detection gated by `ANTICOPY_ENABLED=1`) while LOGPROBS env is being reworked
- Cap SWE-PRO / SWE-SYNTH / SWE-INFINITE executor concurrency at 80 (was default 200)
In the new system we need re-design how anti copy worked. Remove this for smooth move.


## Test plan
- [ ] `docker compose -f compose/docker-compose.backend.yml config` parses without the removed service
- [ ] Executor logs show `SWE-*=80` on startup
- [ ] Confirm existing `affine-anticopy` container is stopped/removed on hosts after deploy