### PR TITLE
Re-enable anticopy service

### DIFF
--- a/affine/src/anticopy/main.py
+++ b/affine/src/anticopy/main.py
@@ -158,18 +158,6 @@ class AntiCopyService:
 
     async def _run_detection(self):
         """Run one round of copy detection."""
-        # Detection is OFF by default while the LOGPROBS env is being
-        # reworked (n_tokens=20 plus template-heavy prompts gives near-1.0
-        # logprob cosine even for legitimate fine-tunes of the same base).
-        # Set ANTICOPY_ENABLED=1 to re-enable after the env is updated and
-        # detector thresholds are recalibrated. No DB writes happen while
-        # disabled, so existing anti_copy_results rows are NOT refreshed —
-        # they will age out via TTL or need manual cleanup.
-        import os
-        if os.getenv("ANTICOPY_ENABLED", "0") != "1":
-            logger.info("[AntiCopy] disabled by default (set ANTICOPY_ENABLED=1 to enable), skipping detection")
-            return
-
         miners = await self._fetch_miners()
         if len(miners) < 2:
             logger.warning("[AntiCopy] Not enough miners for comparison, skipping")

--- a/compose/docker-compose.backend.yml
+++ b/compose/docker-compose.backend.yml
@@ -107,6 +107,19 @@ services:
       - /var/log/affine/targon_deployer:/var/log/affine/targon_deployer
     command: ["-v", "servers", "targon-deployer"]
 
+  # Anti-Copy Detection - Model copy detection service
+  anticopy:
+    image: affinefoundation/affine:latest
+    container_name: affine-anticopy
+    restart: unless-stopped
+    mem_reservation: "2g"
+    mem_limit: "4g"
+    env_file:
+      - .env
+    volumes:
+      - /var/log/affine/anticopy:/var/log/affine/anticopy
+    command: ["-v", "servers", "anticopy"]
+
   # Scorer - Weight calculation service
   scorer:
     image: affinefoundation/affine:latest
@@ -133,7 +146,7 @@ services:
     restart: unless-stopped
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
-    command: --interval 30 affine-api affine-scheduler affine-executor affine-teacher affine-monitor affine-scorer affine-targon-deployer
+    command: --interval 30 affine-api affine-scheduler affine-executor affine-teacher affine-monitor affine-anticopy affine-scorer affine-targon-deployer
 
 networks:
   default:


### PR DESCRIPTION
## Summary
- Remove the `ANTICOPY_ENABLED` env guard added in #447 so `_run_detection` runs every cycle again.
- Restore the `anticopy` service in `compose/docker-compose.backend.yml` and add `affine-anticopy` back to the watchtower update list.

The report for false positive is malicious; we should re-enable anticopy before the new system launch. Soft-cheat behavior from #443 and the SWE concurrency cap from #447 are left untouched.

## Test plan
- [ ] Bring up backend compose stack and confirm `affine-anticopy` container is running.
- [ ] Tail `/var/log/affine/anticopy` to verify detection rounds execute (no more `disabled by default` log line).
- [ ] Spot-check `anti_copy_results` rows are being written.