### PR TITLE
Restore dynamic dataset_range + legacy terminated bootstrap + rank TERMINATED display

### DIFF
--- a/affine/api/models.py
+++ b/affine/api/models.py
@@ -29,6 +29,10 @@ class MinerScore(BaseModel):
     total_samples: int
     is_valid: Optional[bool] = None
     invalid_reason: Optional[str] = None
+    # Surfaced so ``af get-rank`` can display TERMINATED for legacy- and
+    # battle-loser miners (``challenge_status`` starting with ``terminated_``).
+    challenge_status: Optional[str] = None
+    termination_reason: Optional[str] = None
 
 
 class ScoresResponse(BaseModel):

--- a/affine/api/routers/scores.py
+++ b/affine/api/routers/scores.py
@@ -23,13 +23,17 @@ router = APIRouter(prefix="/scores", tags=["Scores"])
 
 
 async def _build_validity_map() -> dict:
-    """Map hotkey -> (is_valid_bool, invalid_reason_str|None) from miners table.
+    """Map hotkey -> (is_valid, invalid_reason, challenge_status,
+    termination_reason) from the miners table.
 
-    Surfaces validator-side invalidation in the rank UI: scoring
-    snapshots only carry challenge_status, but a miner can be
-    challenge_status='sampling' while is_valid=False (e.g. anticopy
-    cheat, model_mismatch). Without this lookup the CLI shows them
-    as still competing when in reality sampling has stopped.
+    Surfaces validator-side state in the rank UI:
+      - ``is_valid`` flags monitor-side rejections (model_mismatch,
+        anticopy, multiple_commits, …)
+      - ``challenge_status`` flags terminated_won / terminated_lost
+        (set by the flow scheduler at DECIDE, and by the one-shot
+        ``af db bootstrap-legacy-terminated`` for pre-refactor
+        terminate carry-over). Without this lookup the CLI shows
+        legacy-terminated miners as VALID even though they're out.
 
     One full scan (256-row cap → cheap). Empty map on any DAO error
     so a miners-table blip just hides reasons rather than 500ing.
@@ -46,7 +50,12 @@ async def _build_validity_map() -> dict:
             continue
         # is_valid stored as 'true'/'false' string in the GSI partition key.
         is_valid = str(m.get("is_valid") or "").lower() == "true"
-        out[hk] = (is_valid, m.get("invalid_reason") or None)
+        out[hk] = (
+            is_valid,
+            m.get("invalid_reason") or None,
+            m.get("challenge_status") or None,
+            m.get("termination_reason") or None,
+        )
     return out
 
 
@@ -87,7 +96,8 @@ async def get_latest_scores(
         miner_scores = []
         for s in scores_list:
             hk = s.get("miner_hotkey")
-            is_valid, invalid_reason = validity.get(hk, (None, None))
+            is_valid, invalid_reason, challenge_status, termination_reason = \
+                validity.get(hk, (None, None, None, None))
             miner_scores.append(MinerScore(
                 miner_hotkey=hk,
                 uid=s.get("uid"),
@@ -100,6 +110,8 @@ async def get_latest_scores(
                 total_samples=s.get("total_samples"),
                 is_valid=is_valid,
                 invalid_reason=invalid_reason,
+                challenge_status=challenge_status,
+                termination_reason=termination_reason,
             ))
 
         return ScoresResponse(

--- a/affine/database/cli.py
+++ b/affine/database/cli.py
@@ -114,6 +114,13 @@ async def _cmd_load_config(json_file: str) -> None:
     try:
         dao = SystemConfigDAO()
         for key, value in payload.items():
+            # When seeding ``environments``, resolve any
+            # ``dataset_range_source`` so the static fallback in the
+            # JSON file doesn't shrink an env that's accumulated new
+            # task_ids since the file was last edited (SWE-INFINITE,
+            # DISTILL grow over time).
+            if key == "environments" and isinstance(value, dict):
+                value = await _resolve_env_dataset_ranges(value)
             param_type = _param_type_of(value)
             await dao.set_param(
                 param_name=key,
@@ -127,6 +134,36 @@ async def _cmd_load_config(json_file: str) -> None:
         print(f"✓ Loaded {len(payload)} keys")
     finally:
         await close_client()
+
+
+async def _resolve_env_dataset_ranges(environments: dict) -> dict:
+    """For each env with a ``dataset_range_source``, drop the static
+    ``dataset_range`` from the seed payload. The scheduler resolves
+    the range from the URL on every window refresh, so the seed value
+    would only get overwritten anyway — and worse, would shrink the
+    range below what's already accumulated in the DB if the JSON file
+    is stale.
+
+    No network call here; the URL fetch happens at window-refresh time
+    inside ``FlowScheduler._refresh_task_ids``."""
+    out = dict(environments)
+    for env_name, env_cfg in out.items():
+        if not isinstance(env_cfg, dict):
+            continue
+        sampling = env_cfg.get("sampling")
+        if not isinstance(sampling, dict):
+            continue
+        if not sampling.get("dataset_range_source"):
+            continue
+        if "dataset_range" not in sampling:
+            continue
+        sampling = {k: v for k, v in sampling.items() if k != "dataset_range"}
+        env_cfg = dict(env_cfg)
+        env_cfg["sampling"] = sampling
+        out[env_name] = env_cfg
+        print(f"  · {env_name}: skipping static dataset_range "
+              f"(dataset_range_source will resolve at window refresh)")
+    return out
 
 
 def _param_type_of(value) -> str:
@@ -864,6 +901,221 @@ def sample_progress(window, miner):
       - timestamp of last write + freshness ``age`` of the worker status
     """
     asyncio.run(_cmd_sample_progress(window, miner))
+
+
+@db.command("bootstrap-legacy-terminated")
+@click.option(
+    "--release-uid", "release_uids", multiple=True, type=int,
+    help="UID to leave at challenge_status='pending' even if legacy "
+         "miner_stats says terminated. Repeatable.",
+)
+@click.option("--execute", is_flag=True, default=False,
+              help="Actually write. Default is dry-run.")
+def bootstrap_legacy_terminated(release_uids, execute):
+    """One-shot: read pre-refactor ``affine_miner_stats`` and set
+    ``miners.challenge_status='terminated_lost'`` for every (hotkey,
+    revision) that's still in the current subnet AND was 'terminated'
+    pre-refactor.
+
+    Old ``miner_stats`` table is the only place the pre-refactor scorer
+    persisted terminated state (the new flow keeps that state on
+    ``miners.challenge_status`` directly). Without this bootstrap, every
+    legacy miner re-enters the queue as 'pending' — including miners
+    that lost their one-shot challenge in the old system.
+
+    ``--release-uid`` overrides the legacy verdict for specific UIDs:
+    those rows are forced back to 'pending' (or left at 'pending' if
+    they would have been promoted to terminated_lost).
+
+    Idempotent: rerunning a second time finds the targets already
+    terminated_lost and skips them.
+    """
+    asyncio.run(_cmd_bootstrap_legacy_terminated(
+        release_uids=set(release_uids), execute=execute,
+    ))
+
+
+async def _cmd_bootstrap_legacy_terminated(
+    *, release_uids: set, execute: bool,
+) -> None:
+    from affine.database.client import get_client
+    from affine.database import init_client, close_client
+    await init_client()
+    c = get_client()
+
+    def u(v):
+        if not isinstance(v, dict) or len(v) != 1:
+            return v
+        (t, val), = v.items()
+        if t == "S":
+            return val
+        if t == "N":
+            try:
+                return int(val)
+            except ValueError:
+                return float(val)
+        if t == "BOOL":
+            return val
+        if t == "NULL":
+            return None
+        if t == "M":
+            return {k: u(x) for k, x in val.items()}
+        return val
+
+    # 1. Scan legacy miner_stats for terminated rows.
+    legacy_terminated = []
+    last = None
+    while True:
+        kwargs = {
+            "TableName": "affine_miner_stats",
+            "FilterExpression": "challenge_status = :t",
+            "ExpressionAttributeValues": {":t": {"S": "terminated"}},
+        }
+        if last:
+            kwargs["ExclusiveStartKey"] = last
+        r = await c.scan(**kwargs)
+        for it in r.get("Items", []):
+            legacy_terminated.append({
+                "hotkey": u(it.get("hotkey", {})),
+                "revision": u(it.get("revision", {})),
+                "reason": u(it.get("termination_reason", {})) or "",
+            })
+        last = r.get("LastEvaluatedKey")
+        if not last:
+            break
+
+    # 2. Scan current miners table (small — ≤256 rows).
+    current = {}
+    last = None
+    while True:
+        kwargs = {"TableName": "affine_miners"}
+        if last:
+            kwargs["ExclusiveStartKey"] = last
+        r = await c.scan(**kwargs)
+        for it in r.get("Items", []):
+            hk = u(it.get("hotkey", {}))
+            if hk:
+                current[hk] = {
+                    "uid": u(it.get("uid", {})),
+                    "revision": u(it.get("revision", {})),
+                    "challenge_status": u(it.get("challenge_status", {})),
+                }
+        last = r.get("LastEvaluatedKey")
+        if not last:
+            break
+
+    # 3. Plan.
+    will_terminate = []
+    will_release = []
+    skip_no_match = 0
+    skip_new_rev = 0
+    skip_already = 0
+
+    seen_uids = set()
+    for row in legacy_terminated:
+        hk = row["hotkey"]
+        rev = row["revision"]
+        if not hk:
+            continue
+        cur = current.get(hk)
+        if cur is None:
+            skip_no_match += 1
+            continue
+        if cur["revision"] != rev:
+            skip_new_rev += 1
+            continue
+        uid = cur["uid"]
+        seen_uids.add(uid)
+        if uid in release_uids:
+            will_release.append({
+                "uid": uid, "hotkey": hk, "revision": rev,
+                "reason": row["reason"],
+            })
+            continue
+        if cur["challenge_status"] == "terminated_lost":
+            skip_already += 1
+            continue
+        will_terminate.append({
+            "uid": uid, "hotkey": hk, "revision": rev,
+            "reason": row["reason"],
+        })
+
+    # Release UIDs the user explicitly listed even if they're not in
+    # legacy-terminated (they may already be 'pending'; explicit set
+    # makes the intent durable in the log).
+    for uid in sorted(release_uids):
+        if uid not in seen_uids and uid in {
+            cur["uid"] for cur in current.values()
+        }:
+            hk = next(
+                hk for hk, cur in current.items() if cur["uid"] == uid
+            )
+            will_release.append({
+                "uid": uid, "hotkey": hk,
+                "revision": current[hk]["revision"],
+                "reason": "(not in legacy terminated; explicit release)",
+            })
+
+    click.echo(f"legacy terminated rows:           {len(legacy_terminated)}")
+    click.echo(f"  hotkey no longer in subnet:     {skip_no_match}")
+    click.echo(f"  new revision (fresh chance):    {skip_new_rev}")
+    click.echo(f"  already terminated_lost:        {skip_already}")
+    click.echo(f"  RELEASE (--release-uid):        {len(will_release)}")
+    click.echo(f"  TERMINATE:                      {len(will_terminate)}")
+
+    if not execute:
+        click.echo("\n=== DRY RUN (use --execute to write) ===")
+        for it in will_terminate[:200]:
+            click.echo(
+                f"  TERMINATE uid={it['uid']:>3} hk={it['hotkey'][:8]} "
+                f"rev={it['revision'][:8]} reason={it['reason'][:60]}"
+            )
+        for it in will_release:
+            click.echo(
+                f"  RELEASE   uid={it['uid']:>3} hk={it['hotkey'][:8]} "
+                f"rev={it['revision'][:8]} reason={it['reason'][:60]}"
+            )
+        await close_client()
+        return
+
+    click.echo("\n=== EXECUTING ===")
+    for it in will_terminate:
+        try:
+            await c.update_item(
+                TableName="affine_miners",
+                Key={"pk": {"S": f"UID#{it['uid']}"}},
+                UpdateExpression=(
+                    "SET challenge_status = :s, "
+                    "termination_reason = :r, "
+                    "terminated_from_legacy = :t"
+                ),
+                ExpressionAttributeValues={
+                    ":s": {"S": "terminated_lost"},
+                    ":r": {"S": it["reason"]},
+                    ":t": {"BOOL": True},
+                },
+            )
+            click.echo(f"  terminated uid={it['uid']}")
+        except Exception as e:
+            click.echo(f"  uid={it['uid']} FAILED: {e}")
+    for it in will_release:
+        try:
+            await c.update_item(
+                TableName="affine_miners",
+                Key={"pk": {"S": f"UID#{it['uid']}"}},
+                UpdateExpression=(
+                    "SET challenge_status = :s "
+                    "REMOVE termination_reason, terminated_from_legacy"
+                ),
+                ExpressionAttributeValues={
+                    ":s": {"S": "pending"},
+                },
+            )
+            click.echo(f"  released   uid={it['uid']} → pending")
+        except Exception as e:
+            click.echo(f"  uid={it['uid']} FAILED: {e}")
+
+    await close_client()
 
 
 def main():

--- a/affine/database/system_config.json
+++ b/affine/database/system_config.json
@@ -7,7 +7,12 @@
       "sampling": {
         "sampling_count": 300,
         "dataset_range": [[0, 5000]],
-        "sampling_mode": "latest"
+        "sampling_mode": "latest",
+        "dataset_range_source": {
+          "url": "https://pub-7882418a56434a479bf9a7febd660b36.r2.dev/bugs/metadata.json",
+          "field": "tasks.completed_up_to",
+          "range_type": "zero_to_value"
+        }
       }
     },
     "DISTILL": {
@@ -16,7 +21,12 @@
       "sampling": {
         "sampling_count": 300,
         "dataset_range": [[0, 1000]],
-        "sampling_mode": "latest"
+        "sampling_mode": "latest",
+        "dataset_range_source": {
+          "url": "https://pub-4546777cb27840ec91b892f19eb5742b.r2.dev/metadata.json",
+          "field": "completed_up_to",
+          "range_type": "zero_to_value"
+        }
       }
     },
     "LIVEWEB": {

--- a/affine/src/miner/rank.py
+++ b/affine/src/miner/rank.py
@@ -142,6 +142,11 @@ def _status_for(
     if row.get("is_valid") is False:
         reason = str(row.get("invalid_reason") or "invalid")
         return reason.split(":", 1)[0][:11]
+    # Terminated by DECIDE (new flow) or by the legacy-terminated
+    # bootstrap CLI — out of the queue regardless of is_valid.
+    chal_status = str(row.get("challenge_status") or "")
+    if chal_status.startswith("terminated_"):
+        return "TERMINATED"
     if uid == battle_uid:
         return "BATTLING"
     if uid in queue_positions:
@@ -157,6 +162,8 @@ def _colored_status(status: str, *, is_invalid: bool) -> str:
         return _ansi(text, "1;96")
     if status.startswith("QUEUE #"):
         return _ansi(text, "1;94")
+    if status == "TERMINATED":
+        return _ansi(text, "1;91")  # bright red — same as monitor-invalid
     if is_invalid:
         return _ansi(text, "1;91")
     if status == "VALID":

--- a/affine/src/scheduler/flow.py
+++ b/affine/src/scheduler/flow.py
@@ -232,16 +232,32 @@ class FlowScheduler:
         ``SAMPLE_BUFFER_RATIO`` so the contest can decide as soon as
         the (champion ∩ challenger) overlap reaches the base
         ``sampling_count``. Slow-tail / errored task_ids in the buffer
-        portion are simply abandoned."""
-        env_configs = {
-            env: EnvSamplingConfig(
+        portion are simply abandoned.
+
+        Envs with a ``dataset_range_source`` (SWE-INFINITE, DISTILL —
+        datasets that grow over time) get their ``dataset_range``
+        resolved against the remote metadata before sampling. Falls
+        back to the static config range on any resolver failure.
+        """
+        from affine.src.scorer.dataset_range_resolver import resolve_dataset_range
+
+        env_configs: Dict[str, EnvSamplingConfig] = {}
+        for env, cfg in envs.items():
+            resolved_range = cfg.dataset_range
+            if cfg.dataset_range_source:
+                fresh = await resolve_dataset_range(cfg.dataset_range_source)
+                if fresh is not None and fresh != cfg.dataset_range:
+                    logger.info(
+                        f"FlowScheduler: dataset_range for {env} refreshed via "
+                        f"source: {cfg.dataset_range} → {fresh}"
+                    )
+                    resolved_range = fresh
+            env_configs[env] = EnvSamplingConfig(
                 env=env,
                 sampling_count=math.ceil(cfg.sampling_count * (1 + SAMPLE_BUFFER_RATIO)),
-                dataset_range=cfg.dataset_range,
+                dataset_range=resolved_range,
                 mode=cfg.sampling_mode,
             )
-            for env, cfg in envs.items()
-        }
         task_ids = self.sampler.generate(
             window_id=current_block // self.cfg.window_blocks,
             block_start=current_block,

--- a/affine/src/scorer/dataset_range_resolver.py
+++ b/affine/src/scorer/dataset_range_resolver.py
@@ -1,0 +1,83 @@
+"""Resolve an env's ``dataset_range`` from a remote metadata URL.
+
+Some envs (SWE-INFINITE, DISTILL) accumulate new task_ids over time as
+new bugs / examples land in their public dataset. The dataset publishes
+a small metadata JSON exposing the current top index; we fetch that
+once per window refresh and produce a ``[[0, latest - 1]]`` range so
+``mode='latest'`` picks the freshest task_ids.
+
+Falls back to ``None`` on any failure — callers should keep the static
+``dataset_range`` already in ``system_config`` when this returns ``None``.
+
+Config shape on the env (under ``sampling``):
+
+    "dataset_range_source": {
+        "url": "https://example.com/metadata.json",
+        "field": "tasks.completed_up_to",
+        "range_type": "zero_to_value"
+    }
+
+Only ``range_type='zero_to_value'`` is supported today; if a future env
+needs a different shape (e.g. ``offset_window``), add the case in
+:func:`resolve_dataset_range` rather than letting callers handle the
+fallback.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any, Dict, List, Optional
+
+import aiohttp
+
+from affine.core.setup import logger
+
+
+def _extract(data: Dict[str, Any], path: str) -> Any:
+    """Read a value out of nested-dict JSON by dot-notation path."""
+    cur = data
+    for key in path.split("."):
+        cur = cur[key]
+    return cur
+
+
+async def resolve_dataset_range(
+    source: Dict[str, Any], *, timeout: float = 10.0,
+) -> Optional[List[List[int]]]:
+    """Fetch ``source.url``, read ``source.field`` (dot path), return
+    ``[[0, value - 1]]``. Returns ``None`` on any failure so callers
+    fall back to the static range already on the env config."""
+    url = source.get("url")
+    field = source.get("field")
+    range_type = source.get("range_type", "zero_to_value")
+    if not url or not field:
+        return None
+    if range_type != "zero_to_value":
+        logger.error(
+            f"dataset_range_source: unsupported range_type={range_type!r} "
+            f"(only 'zero_to_value' is implemented)"
+        )
+        return None
+    try:
+        async with aiohttp.ClientSession() as session:
+            async with session.get(
+                url, timeout=aiohttp.ClientTimeout(total=timeout),
+            ) as resp:
+                if resp.status != 200:
+                    logger.warning(
+                        f"dataset_range_source {url}: HTTP {resp.status}"
+                    )
+                    return None
+                data = await resp.json(content_type=None)
+        value = int(_extract(data, field))
+    except (aiohttp.ClientError, asyncio.TimeoutError) as e:
+        logger.warning(f"dataset_range_source fetch failed for {url}: {e}")
+        return None
+    except (KeyError, TypeError, ValueError) as e:
+        logger.warning(
+            f"dataset_range_source parse failed for {url} field={field!r}: {e}"
+        )
+        return None
+    if value <= 0:
+        return [[0, 0]]
+    return [[0, value - 1]]

--- a/affine/src/scorer/window_state.py
+++ b/affine/src/scorer/window_state.py
@@ -90,6 +90,12 @@ class EnvConfig:
     sampling_count: int
     dataset_range: List[List[int]]
     sampling_mode: str = "random"  # 'random' | 'latest'
+    # Optional remote source for the dataset's current top index. When
+    # set, the scheduler resolves ``dataset_range`` from this URL at
+    # each window refresh so envs whose dataset accumulates new
+    # task_ids (SWE-INFINITE, DISTILL) always sample the freshest tail.
+    # Shape: ``{"url": str, "field": str, "range_type": "zero_to_value"}``.
+    dataset_range_source: Optional[Dict[str, Any]] = None
 
 
 # ---- store protocol -------------------------------------------------------
@@ -333,10 +339,12 @@ def _env_from_payload(payload: Any) -> EnvConfig:
             sampling_count=0, dataset_range=[], sampling_mode="random",
         )
     sampling = payload.get("sampling") or payload.get("window_config") or {}
+    src = sampling.get("dataset_range_source")
     return EnvConfig(
         display_name=str(payload.get("display_name", "")),
         enabled=bool(payload.get("enabled", True)),
         sampling_count=int(sampling.get("sampling_count", 0)),
         dataset_range=list(sampling.get("dataset_range", []) or []),
         sampling_mode=str(sampling.get("sampling_mode", "random")),
+        dataset_range_source=src if isinstance(src, dict) else None,
     )

--- a/tests/test_dataset_range_resolver.py
+++ b/tests/test_dataset_range_resolver.py
@@ -1,0 +1,133 @@
+"""Tests for ``affine.src.scorer.dataset_range_resolver``.
+
+The resolver hits a remote URL; mock ``aiohttp.ClientSession`` so the
+tests run offline. We cover: happy path, dot-notation field path, HTTP
+non-200, missing field, malformed JSON, unsupported range_type,
+zero/negative values, and the empty-source guard.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import aiohttp
+
+from affine.src.scorer.dataset_range_resolver import resolve_dataset_range
+
+
+def _mock_response(status: int, body):
+    """Build an aiohttp-style async context manager that returns a fake
+    response object."""
+    resp = MagicMock()
+    resp.status = status
+    resp.json = AsyncMock(return_value=body)
+    cm = MagicMock()
+    cm.__aenter__ = AsyncMock(return_value=resp)
+    cm.__aexit__ = AsyncMock(return_value=None)
+    return cm
+
+
+def _mock_session(status: int, body):
+    """Build an aiohttp.ClientSession that yields ``_mock_response``."""
+    sess = MagicMock()
+    sess.get = MagicMock(return_value=_mock_response(status, body))
+    sess.__aenter__ = AsyncMock(return_value=sess)
+    sess.__aexit__ = AsyncMock(return_value=None)
+    return sess
+
+
+def _run(coro):
+    return asyncio.get_event_loop().run_until_complete(coro) if False else asyncio.run(coro)
+
+
+def test_resolves_zero_to_value():
+    sess = _mock_session(200, {"completed_up_to": 1000})
+    with patch.object(aiohttp, "ClientSession", return_value=sess):
+        result = _run(resolve_dataset_range({
+            "url": "http://example/m.json",
+            "field": "completed_up_to",
+            "range_type": "zero_to_value",
+        }))
+    assert result == [[0, 999]]
+
+
+def test_dot_notation_path():
+    sess = _mock_session(200, {"tasks": {"completed_up_to": 5000}})
+    with patch.object(aiohttp, "ClientSession", return_value=sess):
+        result = _run(resolve_dataset_range({
+            "url": "http://example/m.json",
+            "field": "tasks.completed_up_to",
+            "range_type": "zero_to_value",
+        }))
+    assert result == [[0, 4999]]
+
+
+def test_http_non_200_returns_none():
+    sess = _mock_session(503, {})
+    with patch.object(aiohttp, "ClientSession", return_value=sess):
+        result = _run(resolve_dataset_range({
+            "url": "http://example/m.json",
+            "field": "completed_up_to",
+            "range_type": "zero_to_value",
+        }))
+    assert result is None
+
+
+def test_missing_field_returns_none():
+    sess = _mock_session(200, {"other": 1000})
+    with patch.object(aiohttp, "ClientSession", return_value=sess):
+        result = _run(resolve_dataset_range({
+            "url": "http://example/m.json",
+            "field": "completed_up_to",
+            "range_type": "zero_to_value",
+        }))
+    assert result is None
+
+
+def test_unsupported_range_type_returns_none():
+    result = _run(resolve_dataset_range({
+        "url": "http://example/m.json",
+        "field": "completed_up_to",
+        "range_type": "unknown_shape",
+    }))
+    assert result is None
+
+
+def test_zero_value_returns_degenerate_range():
+    sess = _mock_session(200, {"completed_up_to": 0})
+    with patch.object(aiohttp, "ClientSession", return_value=sess):
+        result = _run(resolve_dataset_range({
+            "url": "http://example/m.json",
+            "field": "completed_up_to",
+            "range_type": "zero_to_value",
+        }))
+    assert result == [[0, 0]]
+
+
+def test_negative_value_returns_degenerate_range():
+    sess = _mock_session(200, {"completed_up_to": -5})
+    with patch.object(aiohttp, "ClientSession", return_value=sess):
+        result = _run(resolve_dataset_range({
+            "url": "http://example/m.json",
+            "field": "completed_up_to",
+            "range_type": "zero_to_value",
+        }))
+    assert result == [[0, 0]]
+
+
+def test_missing_url_returns_none():
+    result = _run(resolve_dataset_range({
+        "field": "x",
+        "range_type": "zero_to_value",
+    }))
+    assert result is None
+
+
+def test_missing_field_key_returns_none():
+    result = _run(resolve_dataset_range({
+        "url": "http://example/m.json",
+        "range_type": "zero_to_value",
+    }))
+    assert result is None

--- a/tests/test_miner_rank.py
+++ b/tests/test_miner_rank.py
@@ -157,6 +157,65 @@ def test_rank_table_groups_invalid_miners_below_valid_rows():
     assert "model_misma" in out
 
 
+def test_rank_table_shows_terminated_for_terminated_lost():
+    """challenge_status='terminated_lost' (set by DECIDE or by the
+    legacy-terminated bootstrap CLI) should render TERMINATED — out of
+    the queue, distinct from VALID/CHAMPION/BATTLING."""
+    scores = {
+        "block_number": 100,
+        "calculated_at": 0,
+        "scores": [
+            {
+                "uid": 5,
+                "miner_hotkey": "lost-prior",
+                "model": "org/lost",
+                "overall_score": 0.0,
+                "is_valid": True,
+                "challenge_status": "terminated_lost",
+                "termination_reason": "lost_to_champion:5GepM",
+                "scores_by_env": {},
+            },
+            {
+                "uid": 6,
+                "miner_hotkey": "good",
+                "model": "org/good",
+                "overall_score": 0.0,
+                "is_valid": True,
+                "challenge_status": "pending",
+                "scores_by_env": {},
+            },
+        ],
+    }
+
+    out = _render_rank(None, None, scores)
+
+    assert "TERMINATED" in out
+    # Terminated row is rendered; UID column shows it's our miner.
+    assert "5" in out
+
+
+def test_rank_table_terminated_won_also_renders_terminated():
+    """Champion winners that left the throne (terminated_won) — also TERMINATED."""
+    scores = {
+        "block_number": 100,
+        "calculated_at": 0,
+        "scores": [
+            {
+                "uid": 5,
+                "miner_hotkey": "ex-champ",
+                "model": "org/ex",
+                "overall_score": 0.0,
+                "is_valid": True,
+                "challenge_status": "terminated_won",
+                "scores_by_env": {},
+            },
+        ],
+    }
+
+    out = _render_rank(None, None, scores)
+    assert "TERMINATED" in out
+
+
 def test_rank_table_does_not_show_unknown_status_for_missing_validity():
     scores = {
         "block_number": 100,


### PR DESCRIPTION
Two missing pieces from the refactor cutover, both about preserving pre-refactor state the new flow silently dropped, plus the rank-table plumbing needed to see the result.

## Summary

### 1. Dynamic ``dataset_range`` for SWE-INFINITE / DISTILL

Pre-refactor each env's ``sampling_config`` carried a ``dataset_range_source`` pointer to a remote R2 metadata URL; the sampling_scheduler re-resolved it every rotation so as new task_ids landed the range grew. The refactor (PR #449) dropped both the resolver module and the schema field. Production has been stuck on ``dataset_range=[[0, 5000]]`` for SWE while live metadata reports ``completed_up_to=9875`` — ``mode='latest'`` was sampling 4670-4999, the middle of the dataset, not the tail.

- New ``affine/src/scorer/dataset_range_resolver.py`` — async fetch + dot-notation extract, falls back to ``None`` on any failure so callers keep the static range.
- ``EnvConfig`` carries an optional ``dataset_range_source``; flow resolver fires it at every window refresh.
- ``af db load-config`` skips the static ``dataset_range`` field when ``dataset_range_source`` is set — the static fallback in the seed JSON can never shrink the DB's resolved range.

### 2. ``af db bootstrap-legacy-terminated`` one-shot CLI

Pre-refactor terminated state lived on ``affine_miner_stats.challenge_status`` (DAO deleted by the refactor; physical table retained per plan's "orphan tables" policy). The new ``miners.challenge_status`` field defaults to ``pending``, so every legacy-terminated miner re-entered the queue.

CLI scans legacy ``miner_stats`` for terminated rows, cross-references current miners by (hotkey, revision), and sets ``challenge_status='terminated_lost'`` for matches. Revision changes get a fresh chance (plan section J). ``--release-uid`` overrides for specific UIDs. Idempotent, defaults to dry-run.

### 3. ``af get-rank`` shows TERMINATED

``_build_validity_map`` now also surfaces ``challenge_status`` + ``termination_reason``; ``_status_for`` returns ``TERMINATED`` for ``terminated_*``; ``_colored_status`` paints it bright red.

## Test plan

- [x] 184 tests pass (9 new for resolver, 2 for rank TERMINATED)
- [ ] After merge: run ``af db load-config`` then ``af db bootstrap-legacy-terminated --release-uid 228 --execute`` to backfill 114 historical terminated miners (UID 228 explicitly released)
- [ ] ``af get-rank`` should show those 114 as red TERMINATED