### PR TITLE
Add per-env evaluate concurrency cap

### DIFF
--- a/affine/api/routers/scores.py
+++ b/affine/api/routers/scores.py
@@ -19,8 +19,24 @@ from affine.database.dao.scores import ScoresDAO
 from affine.database.dao.score_snapshots import ScoreSnapshotsDAO
 from affine.database.dao.miner_stats import MinerStatsDAO
 from affine.database.dao.miners import MinersDAO
+from affine.database.dao.system_config import SystemConfigDAO
+from affine.src.scorer.window_state import StateStore
 
 router = APIRouter(prefix="/scores", tags=["Scores"])
+
+
+class _StaticConfigStore:
+    def __init__(self, data: dict):
+        self._data = data
+
+    async def get(self, key: str, default=None):
+        return self._data.get(key, default)
+
+    async def set(self, key: str, value) -> None:
+        self._data[key] = value
+
+    async def delete(self, key: str) -> bool:
+        return self._data.pop(key, None) is not None
 
 
 async def _build_validity_map() -> dict:
@@ -58,6 +74,28 @@ async def _build_validity_map() -> dict:
     return out
 
 
+async def _scoring_env_names() -> set[str] | None:
+    raw = await SystemConfigDAO().get_param_value("environments", default=None)
+    if raw is None:
+        return None
+    if not isinstance(raw, dict):
+        return set()
+    envs = await StateStore(_StaticConfigStore({"environments": raw})).get_scoring_environments()
+    return set(envs.keys())
+
+
+def _filter_scores_by_env(scores_by_env, scoring_envs: set[str] | None):
+    if not isinstance(scores_by_env, dict):
+        return {}
+    if scoring_envs is None:
+        return scores_by_env
+    return {
+        env: payload
+        for env, payload in scores_by_env.items()
+        if env in scoring_envs
+    }
+
+
 @router.get("/latest", response_model=ScoresResponse, dependencies=[Depends(rate_limit_read)])
 async def get_latest_scores(
     top: int = Query(32, description="Return top N miners by score", ge=1, le=256),
@@ -86,6 +124,7 @@ async def get_latest_scores(
         scores_list = scores_data.get("scores", [])
         
         validity = await _build_validity_map()
+        scoring_envs = await _scoring_env_names()
         scores_list = [
             s for s in scores_list
             if s.get("miner_hotkey") in validity
@@ -109,7 +148,9 @@ async def get_latest_scores(
                 first_block=s.get("first_block"),
                 overall_score=s.get("overall_score"),
                 average_score=s.get("average_score"),
-                scores_by_env=s.get("scores_by_env"),
+                scores_by_env=_filter_scores_by_env(
+                    s.get("scores_by_env"), scoring_envs,
+                ),
                 total_samples=s.get("total_samples"),
                 is_valid=is_valid,
                 invalid_reason=invalid_reason,
@@ -182,6 +223,7 @@ async def get_score_by_uid(
         is_valid, invalid_reason, challenge_status, termination_reason = (
             await _build_validity_map()
         ).get(hk, (None, None, None, None))
+        scoring_envs = await _scoring_env_names()
         return MinerScore(
             miner_hotkey=hk,
             uid=miner_score.get("uid"),
@@ -190,7 +232,9 @@ async def get_score_by_uid(
             first_block=miner_score.get("first_block"),
             overall_score=miner_score.get("overall_score"),
             average_score=miner_score.get("average_score"),
-            scores_by_env=miner_score.get("scores_by_env"),
+            scores_by_env=_filter_scores_by_env(
+                miner_score.get("scores_by_env"), scoring_envs,
+            ),
             total_samples=miner_score.get("total_samples"),
             is_valid=is_valid,
             invalid_reason=invalid_reason,

--- a/affine/cli/main.py
+++ b/affine/cli/main.py
@@ -248,21 +248,23 @@ def get_miner(uid_arg, uid, hotkey):
     asyncio.run(get_miner_command(uid=uid if uid is not None else uid_arg, hotkey=hotkey))
 
 
-@cli.command("get-rank", context_settings={"ignore_unknown_options": True, "allow_extra_args": True})
-@click.pass_context
-def get_rank(ctx):
+@cli.command("get-rank")
+@click.option("--reason", "show_reason", is_flag=True,
+              help="Show brief invalid or termination reason column")
+def get_rank(show_reason):
     """Query and display miner ranking table.
 
     Shows the live window state (champion/challenger/phase/progress),
     the public rank/status snapshot.
 
+    \b
     Example:
         af get-rank
+        af get-rank --reason
     """
-    from affine.src.miner.main import get_rank as miner_get_rank
+    from affine.src.miner.rank import get_rank_command
 
-    sys.argv = ["get-rank"] + ctx.args
-    miner_get_rank.main(standalone_mode=False)
+    asyncio.run(get_rank_command(show_reason=show_reason))
 
 
 @cli.command("miner-deploy", context_settings={"ignore_unknown_options": True, "allow_extra_args": True})

--- a/affine/database/cli.py
+++ b/affine/database/cli.py
@@ -794,9 +794,7 @@ async def _cmd_sample_progress(window_spec: str, miner_filter: str) -> None:
         now = time.time()
         worker_status: dict = {}
         for env_name in envs:
-            if envs[env_name].get(
-                "enabled_for_sampling", envs[env_name].get("enabled", True),
-            ):
+            if envs[env_name].get("enabled_for_sampling", False):
                 worker_status[env_name] = await sc.get_param_value(f"worker_status_{env_name}")
 
         win_label = window_spec if win_secs > 0 else "all-time"
@@ -815,9 +813,7 @@ async def _cmd_sample_progress(window_spec: str, miner_filter: str) -> None:
 
             for env_name in sorted(envs.keys()):
                 cfg = envs[env_name]
-                if not cfg.get(
-                    "enabled_for_sampling", cfg.get("enabled", True),
-                ):
+                if not cfg.get("enabled_for_sampling", False):
                     click.echo(f"{env_name:<14}  (disabled)")
                     continue
 

--- a/affine/database/dao/system_config.py
+++ b/affine/database/dao/system_config.py
@@ -134,10 +134,10 @@ class SystemConfigDAO(BaseDAO):
     
     # Environment Configuration Management
     #
-    # The queue-window flow has a single ``enabled`` flag per env; the old
-    # split between ``enabled_for_sampling`` and ``enabled_for_scoring`` is
-    # gone. ``WindowStateStore.get_environments()`` is the only consumer
-    # and filters by ``enabled`` directly, so no helper here.
+    # Environment rows use two independent gates:
+    #   enabled_for_sampling controls task-id materialization/executor work.
+    #   enabled_for_scoring controls DECIDE/rank score columns.
+    # The legacy ``enabled`` key is accepted by StateStore as a sampling alias.
 
     # Blacklist Configuration Management
     

--- a/affine/database/dao/system_config.py
+++ b/affine/database/dao/system_config.py
@@ -137,7 +137,6 @@ class SystemConfigDAO(BaseDAO):
     # Environment rows use two independent gates:
     #   enabled_for_sampling controls task-id materialization/executor work.
     #   enabled_for_scoring controls DECIDE/rank score columns.
-    # The legacy ``enabled`` key is accepted by StateStore as a sampling alias.
 
     # Blacklist Configuration Management
     

--- a/affine/src/executor/config.py
+++ b/affine/src/executor/config.py
@@ -17,10 +17,15 @@ to gate anything, just so a runaway pending list can't schedule tens of
 thousands of coroutines into asyncio at once.
 """
 
-# Saturation point on the inference backend (b300: 8 × 60 per-card).
-# The shared global semaphore is sized to this so the inference cluster
-# is the bottleneck, not the executor.
-GLOBAL_DISPATCH_BUDGET = 480
+# Total executor in-flight budget. The b300 inference cluster saturates
+# around 480 (8 × 60 per-card), and that's still the bottleneck for envs
+# that hit it (SWE-INFINITE, MEMORY, NAVWORLD, TERMINAL). 600 adds
+# headroom for envs that don't go through b300 — LIVEWEB runs against
+# its own SSH hosts for web scraping, so its in-flight share doesn't
+# consume GPU capacity. Pair with per-env ``max_concurrent`` caps
+# (EnvConfig.max_concurrent) to keep any single env from monopolising
+# the shared pool.
+GLOBAL_DISPATCH_BUDGET = 600
 
 # Per-worker asyncio-side safety floor. Never the real gate — the
 # global sem above is. Set high so dispatch never blocks on local

--- a/affine/src/executor/main.py
+++ b/affine/src/executor/main.py
@@ -2,7 +2,7 @@
 ``af servers executor`` — manager that spawns one subprocess per env.
 
 The manager process does very little hot-path work: it spawns N
-``WorkerProcess`` instances (one per enabled env), restarts them if
+``WorkerProcess`` instances (one per sampling-enabled env), restarts them if
 they die, prints a periodic ``[STATUS]`` line for operators, and owns
 the cross-process IPC primitives (``BoundedSemaphore`` for global
 dispatch budget; one ``Value(c_int)`` per env for live in-flight
@@ -197,8 +197,7 @@ class ExecutorManager:
 async def _enabled_envs() -> List[str]:
     """Read system_config.environments and return sampling-enabled env keys.
 
-    Accepts both the new ``enabled_for_sampling`` key and the legacy
-    ``enabled`` alias so an unmigrated DB doesn't go silent.
+    Only ``enabled_for_sampling`` starts executor workers.
     """
     config_dao = SystemConfigDAO()
     envs_raw = await config_dao.get_param_value("environments", default={}) or {}
@@ -206,7 +205,7 @@ async def _enabled_envs() -> List[str]:
     for name, cfg in envs_raw.items():
         if not isinstance(cfg, dict):
             continue
-        sampling_flag = cfg.get("enabled_for_sampling", cfg.get("enabled", True))
+        sampling_flag = cfg.get("enabled_for_sampling", False)
         if sampling_flag:
             out.append(name)
     return out

--- a/affine/src/executor/main.py
+++ b/affine/src/executor/main.py
@@ -32,7 +32,7 @@ from affine.src.scorer.dao_adapters import SampleResultsAdapter
 
 
 HEALTH_CHECK_INTERVAL_SEC = 10
-STATUS_PRINT_INTERVAL_SEC = 30
+STATUS_PRINT_INTERVAL_SEC = 60
 
 
 class ExecutorManager:

--- a/affine/src/executor/main.py
+++ b/affine/src/executor/main.py
@@ -122,7 +122,7 @@ class ExecutorManager:
         separately) and per-env in-flight from the shared
         ``in_flight_values`` Values. Format:
 
-            [STATUS] running=N/480 | env@done/target +delta in Xs rate:Y/h
+            [STATUS] running=N/GLOBAL_DISPATCH_BUDGET | env@done/target +delta in Xs rate:Y/h
                 run:R | env2@... | total +D in Xs rate:Y/h
 
         First print after start is the baseline (delta+rate omitted).
@@ -223,22 +223,19 @@ async def _enabled_envs() -> List[str]:
 
 
 async def _env_concurrency_caps(envs: List[str]) -> Dict[str, int]:
-    """Read ``EnvConfig.max_concurrent`` for the named envs. Returns a
-    dict of only the envs that have a positive cap configured."""
+    """Read ``EnvConfig.max_concurrent`` for the named envs via the
+    shared ``_env_from_payload`` parser. Returns a dict of only the
+    envs that have a positive cap configured — sharing the parser
+    keeps the int/bool/str validation in one place."""
+    from affine.src.scorer.window_state import _env_from_payload
+
     config_dao = SystemConfigDAO()
     envs_raw = await config_dao.get_param_value("environments", default={}) or {}
     out: Dict[str, int] = {}
     for name in envs:
-        cfg = envs_raw.get(name) or {}
-        sampling = cfg.get("sampling") or cfg.get("window_config") or {}
-        raw = sampling.get("max_concurrent")
-        cap: Optional[int] = None
-        if isinstance(raw, int) and raw > 0:
-            cap = raw
-        elif isinstance(raw, str) and raw.isdigit() and int(raw) > 0:
-            cap = int(raw)
-        if cap is not None:
-            out[name] = cap
+        cfg = _env_from_payload(envs_raw.get(name))
+        if cfg.max_concurrent:
+            out[name] = cfg.max_concurrent
     return out
 
 

--- a/affine/src/executor/main.py
+++ b/affine/src/executor/main.py
@@ -216,7 +216,9 @@ async def _run() -> None:
     await init_client()
     envs = await _enabled_envs()
     if not envs:
-        logger.error("executor: no enabled envs in system_config.environments")
+        logger.error(
+            "executor: no sampling-enabled envs in system_config.environments"
+        )
         return
 
     manager = ExecutorManager(envs=envs, verbosity=1)

--- a/affine/src/executor/main.py
+++ b/affine/src/executor/main.py
@@ -18,7 +18,7 @@ from __future__ import annotations
 import asyncio
 import multiprocessing
 import signal
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Optional
 
 import click
 
@@ -36,9 +36,19 @@ STATUS_PRINT_INTERVAL_SEC = 30
 
 
 class ExecutorManager:
-    def __init__(self, envs: List[str], *, verbosity: int = 1):
+    def __init__(
+        self,
+        envs: List[str],
+        *,
+        verbosity: int = 1,
+        env_concurrency_caps: Optional[Dict[str, int]] = None,
+    ):
         self.envs = envs
         self.verbosity = verbosity
+        # Optional per-env evaluate-concurrency caps. Sourced from
+        # ``EnvConfig.max_concurrent`` (system_config). Envs absent
+        # from this dict only contend on the global semaphore.
+        self.env_concurrency_caps = env_concurrency_caps or {}
         self.mp_ctx = multiprocessing.get_context("spawn")
         # Single cross-process bounded semaphore = the real concurrency
         # gate. Sized to the b300 saturation point so the inference
@@ -75,6 +85,7 @@ class ExecutorManager:
                 in_flight_value=self.in_flight_values[env],
                 max_concurrent=get_max_concurrent(env),
                 verbosity=self.verbosity,
+                env_concurrency_cap=self.env_concurrency_caps.get(env),
             )
             wp.start()
             self.workers.append(wp)
@@ -211,6 +222,26 @@ async def _enabled_envs() -> List[str]:
     return out
 
 
+async def _env_concurrency_caps(envs: List[str]) -> Dict[str, int]:
+    """Read ``EnvConfig.max_concurrent`` for the named envs. Returns a
+    dict of only the envs that have a positive cap configured."""
+    config_dao = SystemConfigDAO()
+    envs_raw = await config_dao.get_param_value("environments", default={}) or {}
+    out: Dict[str, int] = {}
+    for name in envs:
+        cfg = envs_raw.get(name) or {}
+        sampling = cfg.get("sampling") or cfg.get("window_config") or {}
+        raw = sampling.get("max_concurrent")
+        cap: Optional[int] = None
+        if isinstance(raw, int) and raw > 0:
+            cap = raw
+        elif isinstance(raw, str) and raw.isdigit() and int(raw) > 0:
+            cap = int(raw)
+        if cap is not None:
+            out[name] = cap
+    return out
+
+
 async def _run() -> None:
     await init_client()
     envs = await _enabled_envs()
@@ -220,7 +251,13 @@ async def _run() -> None:
         )
         return
 
-    manager = ExecutorManager(envs=envs, verbosity=1)
+    caps = await _env_concurrency_caps(envs)
+    if caps:
+        logger.info(f"executor: per-env concurrency caps = {caps}")
+
+    manager = ExecutorManager(
+        envs=envs, verbosity=1, env_concurrency_caps=caps,
+    )
     await manager.start()
 
     stop_event = asyncio.Event()

--- a/affine/src/executor/worker.py
+++ b/affine/src/executor/worker.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 import asyncio
 import random
 import time
+from contextlib import nullcontext
 from typing import Any, Dict, List, Optional
 
 from affine.core.setup import logger
@@ -46,6 +47,7 @@ class ExecutorWorker:
         warmup_sec: float = 240.0,
         global_sem: Any = None,
         in_flight_value: Any = None,
+        env_concurrency_cap: Optional[int] = None,
     ):
         self.worker_id = worker_id
         self.env = env
@@ -56,6 +58,17 @@ class ExecutorWorker:
         # is sized at ``max_concurrent`` and only exists as a defensive
         # floor against scheduling tens of thousands of coroutines.
         self._global_sem = global_sem
+        # Optional in-process asyncio semaphore that caps concurrent
+        # evaluate() calls for THIS env's worker. Set from
+        # ``EnvConfig.max_concurrent`` so a flaky env can't burn the
+        # whole global dispatch budget retrying — see LIVEWEB
+        # Stooq-lock incident, PR #459. None = no per-env cap.
+        self.env_concurrency_cap = env_concurrency_cap
+        self._env_sem: Optional[asyncio.Semaphore] = (
+            asyncio.Semaphore(env_concurrency_cap)
+            if env_concurrency_cap is not None and env_concurrency_cap > 0
+            else None
+        )
         # Per-env ``mp.Value(c_int, lock=False)`` for the manager's
         # ``[STATUS]`` printer to read live in-flight without IPC ping.
         # Single writer (this worker), single reader (manager); aligned
@@ -430,6 +443,21 @@ class ExecutorWorker:
             hotkey=miner.hotkey, model=miner.model, revision=miner.revision,
             base_url=base_url,
         )
+        # Per-env cap (if configured) is acquired BEFORE the global slot
+        # so a flaky env can't transiently hold global capacity while
+        # waiting on its own sem. ``nullcontext`` makes this a no-op for
+        # envs without a cap.
+        env_gate = self._env_sem if self._env_sem is not None else nullcontext()
+        async with env_gate:
+            await self._evaluate_and_persist_gated(
+                miner=miner, task_id=task_id, base_url=base_url,
+                refresh_block=refresh_block, miner_obj=miner_obj,
+            )
+
+    async def _evaluate_and_persist_gated(
+        self, *, miner: MinerSnapshot, task_id: int, base_url: str,
+        refresh_block: int, miner_obj: "_Miner",
+    ) -> None:
         # Wait until the cross-process global semaphore yields a slot.
         # Envs with bigger pending lists submit more concurrent acquire
         # attempts and so win a proportional share of the b300 budget —

--- a/affine/src/executor/worker_process.py
+++ b/affine/src/executor/worker_process.py
@@ -22,12 +22,17 @@ def run_worker_subprocess(
     global_sem: Any,
     in_flight_value: Any,
     verbosity: int = 1,
+    env_concurrency_cap: Optional[int] = None,
 ) -> None:
     """Subprocess entry point — runs one ExecutorWorker until killed.
 
     ``global_sem`` is the cross-process ``BoundedSemaphore`` every
     worker contends on before each evaluate. It's the real concurrency
     gate; the per-worker ``max_concurrent`` is a defensive floor.
+
+    ``env_concurrency_cap`` is the optional per-env in-flight evaluate
+    cap (an asyncio semaphore inside this process). ``None`` means no
+    extra cap — only the global semaphore gates dispatch.
 
     ``in_flight_value`` is a ``multiprocessing.Value(c_int, lock=False)``
     the worker increments/decrements around each evaluate so the manager
@@ -45,6 +50,7 @@ def run_worker_subprocess(
         worker = ExecutorWorker(
             worker_id=worker_id, env=env, max_concurrent=max_concurrent,
             global_sem=global_sem, in_flight_value=in_flight_value,
+            env_concurrency_cap=env_concurrency_cap,
         )
         loop.run_until_complete(worker.initialize())
         worker.start()
@@ -85,6 +91,7 @@ class WorkerProcess:
         *,
         max_concurrent: int = 60,
         verbosity: int = 1,
+        env_concurrency_cap: Optional[int] = None,
     ):
         self.worker_id = worker_id
         self.env = env
@@ -92,6 +99,7 @@ class WorkerProcess:
         self.global_sem = global_sem
         self.in_flight_value = in_flight_value
         self.verbosity = verbosity
+        self.env_concurrency_cap = env_concurrency_cap
         self._proc: Optional[multiprocessing.Process] = None
 
     def start(self) -> None:
@@ -100,12 +108,18 @@ class WorkerProcess:
             target=run_worker_subprocess,
             args=(self.worker_id, self.env, self.max_concurrent,
                   self.global_sem, self.in_flight_value,
-                  self.verbosity),
+                  self.verbosity, self.env_concurrency_cap),
             name=f"executor-{self.env}",
             daemon=False,
         )
         self._proc.start()
-        logger.info(f"[{self.env}] subprocess started pid={self._proc.pid}")
+        cap_str = (
+            f", env_cap={self.env_concurrency_cap}"
+            if self.env_concurrency_cap is not None else ""
+        )
+        logger.info(
+            f"[{self.env}] subprocess started pid={self._proc.pid}{cap_str}"
+        )
 
     def is_alive(self) -> bool:
         return self._proc is not None and self._proc.is_alive()

--- a/affine/src/miner/main.py
+++ b/affine/src/miner/main.py
@@ -82,9 +82,11 @@ def get_miner(uid_arg, uid, hotkey):
 
 
 @click.command("get-rank")
-def get_rank():
+@click.option("--reason", "show_reason", is_flag=True,
+              help="Show brief invalid or termination reason column")
+def get_rank(show_reason):
     """Show the current ranking table + live window state."""
-    asyncio.run(get_rank_command())
+    asyncio.run(get_rank_command(show_reason=show_reason))
 
 
 @click.command("miner-deploy")

--- a/affine/src/miner/rank.py
+++ b/affine/src/miner/rank.py
@@ -220,6 +220,8 @@ def _print_rank_table(
     window: Optional[Dict[str, Any]],
     queue: Optional[List[Dict[str, Any]]],
     scores_resp: Optional[Dict[str, Any]],
+    *,
+    show_reason: bool = False,
 ) -> None:
     if not scores_resp or not scores_resp.get("scores"):
         print("No scores found")
@@ -255,7 +257,10 @@ def _print_rank_table(
 
     header_parts = ["Hotkey  ", " UID", "⚡| Model                    "]
     header_parts.extend(f"{env[:24]:>24}" for env in envs)
-    header_parts.extend(["  Status   ", " Reason           ", " Weight "])
+    header_parts.append("  Status   ")
+    if show_reason:
+        header_parts.append(" Reason           ")
+    header_parts.append(" Weight ")
     header_line = " | ".join(header_parts)
     width = max(88, len(header_line))
 
@@ -316,11 +321,12 @@ def _print_rank_table(
         for env in envs:
             live_count = row_live_counts.get(env)
             row_parts.append(f"{_env_cell(scores_by_env.get(env), live_count):>24}")
-        row_parts.extend([
-            _colored_status(status, is_invalid=(row.get("is_valid") is False)),
-            f"{_reason_for(row, status):18s}",
-            f"{_as_float(row.get('overall_score')):>7.4f}",
-        ])
+        row_parts.append(
+            _colored_status(status, is_invalid=(row.get("is_valid") is False))
+        )
+        if show_reason:
+            row_parts.append(f"{_reason_for(row, status):18s}")
+        row_parts.append(f"{_as_float(row.get('overall_score')):>7.4f}")
         print(" | ".join(row_parts))
 
     print(_ansi("=" * width, "2"))
@@ -336,7 +342,7 @@ def _print_rank_table(
     print(f"Sampling: {_ansi('⚡', '1;92')} marks miners in the current live sampling set")
     print(_ansi("=" * width, "2"))
 
-async def get_rank_command() -> None:
+async def get_rank_command(*, show_reason: bool = False) -> None:
     try:
         async with cli_api_client() as client:
             payload = await _fetch_rank_payload(client)
@@ -348,4 +354,5 @@ async def get_rank_command() -> None:
         payload.get("window") if isinstance(payload.get("window"), dict) else None,
         payload.get("queue") if isinstance(payload.get("queue"), list) else None,
         payload.get("scores") if isinstance(payload.get("scores"), dict) else None,
+        show_reason=show_reason,
     )

--- a/affine/src/miner/rank.py
+++ b/affine/src/miner/rank.py
@@ -182,7 +182,7 @@ def _colored_status(status: str, *, is_invalid: bool) -> str:
 def _sampling_mark(uid: Any, champion_uid: Optional[int], battle_uid: Optional[int]) -> str:
     if uid == champion_uid or uid == battle_uid:
         return _ansi("⚡", "1;92")
-    return " "
+    return "  "
 
 
 def _sort_scores(

--- a/affine/src/miner/rank.py
+++ b/affine/src/miner/rank.py
@@ -325,12 +325,6 @@ def _print_rank_table(
         f"  |  Queue head: {queue_count}  |  Valid: {valid}  |  Invalid: {invalid}"
     )
     print(f"Sampling: {_ansi('⚡', '1;92')} marks miners in the current live sampling set")
-    if queue:
-        head = ", ".join(
-            f"#{row.get('position')} UID {row.get('uid')}"
-            for row in queue[:_QUEUE_PREVIEW]
-        )
-        print(f"Queue: {head}")
     print(_ansi("=" * width, "2"))
 
 async def get_rank_command() -> None:

--- a/affine/src/miner/rank.py
+++ b/affine/src/miner/rank.py
@@ -139,14 +139,14 @@ def _status_for(
     uid = row.get("uid")
     if uid == champion_uid:
         return "CHAMPION"
-    if row.get("is_valid") is False:
-        reason = str(row.get("invalid_reason") or "invalid")
-        return reason.split(":", 1)[0][:11]
     # Terminated lifecycle state lives in miner_stats, not the current
     # miners snapshot.
     chal_status = str(row.get("challenge_status") or "")
     if chal_status == "terminated":
         return "TERMINATED"
+    if row.get("is_valid") is False:
+        reason = str(row.get("invalid_reason") or "invalid")
+        return reason.split(":", 1)[0][:11]
     if uid == battle_uid:
         return "BATTLING"
     if uid in queue_positions:

--- a/affine/src/miner/rank.py
+++ b/affine/src/miner/rank.py
@@ -186,20 +186,20 @@ def _sort_scores(
 ) -> List[Dict[str, Any]]:
     def key(row: Dict[str, Any]) -> tuple:
         uid = row.get("uid")
+        chal_status = str(row.get("challenge_status") or "")
         if uid == champion_uid:
             bucket = 0
         elif uid == battle_uid:
             bucket = 1
         elif uid in queue_positions:
             bucket = 2
-        elif row.get("is_valid") is False:
+        elif row.get("is_valid") is False or chal_status == "terminated":
             bucket = 4
         else:
             bucket = 3
         return (
             bucket,
             queue_positions.get(uid, 9999),
-            -_as_float(row.get("overall_score")),
             int(uid if isinstance(uid, int) else 9999),
         )
 

--- a/affine/src/miner/rank.py
+++ b/affine/src/miner/rank.py
@@ -193,8 +193,10 @@ def _sort_scores(
             bucket = 1
         elif uid in queue_positions:
             bucket = 2
-        elif row.get("is_valid") is False or chal_status == "terminated":
+        elif chal_status == "terminated":
             bucket = 4
+        elif row.get("is_valid") is False:
+            bucket = 5
         else:
             bucket = 3
         return (

--- a/affine/src/miner/rank.py
+++ b/affine/src/miner/rank.py
@@ -154,6 +154,14 @@ def _status_for(
     return "VALID"
 
 
+def _reason_for(row: Dict[str, Any], status: str) -> str:
+    if status == "TERMINATED":
+        return _short(row.get("termination_reason"), 18)
+    if row.get("is_valid") is False:
+        return _short(row.get("invalid_reason"), 18)
+    return ""
+
+
 def _colored_status(status: str, *, is_invalid: bool) -> str:
     text = f"{status:>11}"
     if status == "CHAMPION":
@@ -247,7 +255,7 @@ def _print_rank_table(
 
     header_parts = ["Hotkey  ", " UID", "⚡| Model                    "]
     header_parts.extend(f"{env[:24]:>24}" for env in envs)
-    header_parts.extend(["  Status   ", " Weight "])
+    header_parts.extend(["  Status   ", " Reason           ", " Weight "])
     header_line = " | ".join(header_parts)
     width = max(88, len(header_line))
 
@@ -310,6 +318,7 @@ def _print_rank_table(
             row_parts.append(f"{_env_cell(scores_by_env.get(env), live_count):>24}")
         row_parts.extend([
             _colored_status(status, is_invalid=(row.get("is_valid") is False)),
+            f"{_reason_for(row, status):18s}",
             f"{_as_float(row.get('overall_score')):>7.4f}",
         ])
         print(" | ".join(row_parts))

--- a/affine/src/scheduler/flow.py
+++ b/affine/src/scheduler/flow.py
@@ -150,7 +150,7 @@ class FlowScheduler:
     async def tick(self, current_block: int) -> None:
         envs = await self.state.get_environments()
         if not envs:
-            logger.warning("FlowScheduler: no enabled envs; skipping tick")
+            logger.warning("FlowScheduler: no sampling-enabled envs; skipping tick")
             return
 
         battle = await self.state.get_battle()

--- a/affine/src/scheduler/flow.py
+++ b/affine/src/scheduler/flow.py
@@ -361,7 +361,7 @@ class FlowScheduler:
         envs: Mapping[str, EnvConfig], task_state: TaskIdState,
     ) -> bool:
         """True iff ``miner`` has ≥ ``sampling_count`` current-refresh
-        samples in every enabled env. The pool is oversampled to
+        samples in every sampling-enabled env. The pool is oversampled to
         ``ceil(sampling_count * 1.1)`` to absorb the slow-tail; we only
         require the base count to be ready, so a single slow / errored
         task at the end doesn't block decide."""

--- a/affine/src/scorer/window_state.py
+++ b/affine/src/scorer/window_state.py
@@ -370,16 +370,9 @@ def _env_from_payload(payload: Any) -> EnvConfig:
         )
     sampling = payload.get("sampling") or payload.get("window_config") or {}
     src = sampling.get("dataset_range_source")
-    # ``enabled_for_sampling`` is the explicit name; fall back to the
-    # legacy ``enabled`` key so an unmigrated row keeps working until
-    # ``af db load-config`` rewrites it under the new shape.
-    sampling_flag = payload.get(
-        "enabled_for_sampling",
-        payload.get("enabled", True),
-    )
     return EnvConfig(
         display_name=str(payload.get("display_name", "")),
-        enabled_for_sampling=bool(sampling_flag),
+        enabled_for_sampling=bool(payload.get("enabled_for_sampling", False)),
         # Default True so existing envs keep their pre-flag behavior
         # (sampling and scoring both on). New envs opt out of scoring
         # explicitly by setting ``enabled_for_scoring: false``.

--- a/affine/src/scorer/window_state.py
+++ b/affine/src/scorer/window_state.py
@@ -109,6 +109,13 @@ class EnvConfig:
     # task_ids (SWE-INFINITE, DISTILL) always sample the freshest tail.
     # Shape: ``{"url": str, "field": str, "range_type": "zero_to_value"}``.
     dataset_range_source: Optional[Dict[str, Any]] = None
+    # Optional per-env in-flight evaluate cap. When ``None`` the env
+    # only contends on the shared global semaphore. When set, an
+    # additional asyncio semaphore in the env's worker subprocess caps
+    # concurrent evaluate() calls to this many — used to isolate flaky
+    # envs (LIVEWEB infra-retry storm in PR #459) so their failure loops
+    # cannot starve other envs out of the global dispatch budget.
+    max_concurrent: Optional[int] = None
 
 
 # ---- store protocol -------------------------------------------------------
@@ -370,6 +377,16 @@ def _env_from_payload(payload: Any) -> EnvConfig:
         )
     sampling = payload.get("sampling") or payload.get("window_config") or {}
     src = sampling.get("dataset_range_source")
+    raw_cap = sampling.get("max_concurrent")
+    cap: Optional[int] = None
+    if isinstance(raw_cap, bool):
+        # bool is an int subclass; ignore stray True/False so we don't
+        # silently end up with cap=1 from ``max_concurrent: True``.
+        cap = None
+    elif isinstance(raw_cap, int) and raw_cap > 0:
+        cap = raw_cap
+    elif isinstance(raw_cap, str) and raw_cap.isdigit() and int(raw_cap) > 0:
+        cap = int(raw_cap)
     return EnvConfig(
         display_name=str(payload.get("display_name", "")),
         enabled_for_sampling=bool(payload.get("enabled_for_sampling", False)),
@@ -381,4 +398,5 @@ def _env_from_payload(payload: Any) -> EnvConfig:
         dataset_range=list(sampling.get("dataset_range", []) or []),
         sampling_mode=str(sampling.get("sampling_mode", "random")),
         dataset_range_source=src if isinstance(src, dict) else None,
+        max_concurrent=cap,
     )

--- a/affine/src/teacher/__init__.py
+++ b/affine/src/teacher/__init__.py
@@ -11,8 +11,8 @@ path. Two pieces:
   - :class:`TeacherMover` (``mover.py``) periodically promotes a random
     subset of pending rollouts to the **public** R2 bucket so the
     DISTILL environment container can read them during scoring. Stays
-    paused while ``system_config.environments.DISTILL.enabled`` is
-    false.
+    paused while ``system_config.environments.DISTILL.enabled_for_sampling``
+    is false.
 
 Both run together inside ``af servers teacher``; the public DISTILL
 scoring loop is independent and unchanged.

--- a/affine/src/teacher/mover.py
+++ b/affine/src/teacher/mover.py
@@ -113,9 +113,9 @@ class TeacherMover:
         The queue-window refactor removed per-env ``rotation_interval`` /
         ``rotation_count`` from SystemConfig; the mover now drives its
         own cadence via ``MOVER_PROMOTE_INTERVAL_SEC`` /
-        ``MOVER_PROMOTE_COUNT`` module constants. The only field we
-        still consult on the DISTILL env is its ``enabled`` flag, which
-        we honor so the mover pauses when DISTILL is paused.
+        ``MOVER_PROMOTE_COUNT`` module constants. The only environment
+        gate it honors is ``enabled_for_sampling``: if DISTILL is not
+        sampling, the public bucket should not keep rotating fresh tasks.
         """
         try:
             environments = await self._config_dao.get_param_value(
@@ -312,7 +312,7 @@ class TeacherMover:
             f"public={self.public_bucket} "
             f"(interval={MOVER_PROMOTE_INTERVAL_SEC}s, "
             f"count={MOVER_PROMOTE_COUNT}, gated by "
-            f"SystemConfig.environments.{DISTILL_ENV_KEY}.enabled)"
+            f"SystemConfig.environments.{DISTILL_ENV_KEY}.enabled_for_sampling)"
         )
         self.running = True
         while self.running:
@@ -328,7 +328,7 @@ class TeacherMover:
             interval_sec, target_count, enabled = cfg
             if not enabled:
                 logger.info(
-                    f"[MOVER] {DISTILL_ENV_KEY}.enabled is false, "
+                    f"[MOVER] {DISTILL_ENV_KEY}.enabled_for_sampling is false, "
                     f"pausing for {interval_sec}s"
                 )
                 await self._sleep_interruptible(interval_sec)

--- a/affine/src/teacher/mover.py
+++ b/affine/src/teacher/mover.py
@@ -3,7 +3,7 @@ Teacher Mover - Promotes teacher rollouts from the private to public bucket.
 
 Runs alongside teacher_worker. Each tick:
   1. Reads the DISTILL env config from SystemConfig (DynamoDB) to pick up
-     the current rotation_interval/rotation_count and enabled flag.
+     the sampling gate.
   2. Lists pending/{env}/* in the private bucket.
   3. Builds a candidate pool from all pending envs (with optional
      low-priority deprioritization via ``LOW_PRIORITY_ENVS``).
@@ -108,7 +108,7 @@ class TeacherMover:
     # ---------------- SystemConfig lookup ----------------
 
     async def _read_distill_config(self) -> Optional[Tuple[int, int, bool]]:
-        """Return ``(interval_sec, count, enabled)``.
+        """Return ``(interval_sec, count, sampling_enabled)``.
 
         The queue-window refactor removed per-env ``rotation_interval`` /
         ``rotation_count`` from SystemConfig; the mover now drives its
@@ -128,14 +128,10 @@ class TeacherMover:
         distill = environments.get(DISTILL_ENV_KEY)
         if not distill:
             return None
-        # Pause the mover when the env's sampling pipeline is off — the
-        # bucket would just accumulate stale rollouts. Accepts the new
-        # ``enabled_for_sampling`` name plus the legacy ``enabled``
-        # alias so an unmigrated DB still drains correctly.
-        enabled = bool(distill.get(
-            "enabled_for_sampling", distill.get("enabled", False),
-        ))
-        return MOVER_PROMOTE_INTERVAL_SEC, MOVER_PROMOTE_COUNT, enabled
+        # Pause the mover when the env's sampling pipeline is off; the bucket
+        # would just accumulate stale rollouts.
+        sampling_enabled = bool(distill.get("enabled_for_sampling", False))
+        return MOVER_PROMOTE_INTERVAL_SEC, MOVER_PROMOTE_COUNT, sampling_enabled
 
     # ---------------- Listing & metadata ----------------
 
@@ -325,8 +321,8 @@ class TeacherMover:
                 await self._sleep_interruptible(CONFIG_RETRY_SLEEP_SEC)
                 continue
 
-            interval_sec, target_count, enabled = cfg
-            if not enabled:
+            interval_sec, target_count, sampling_enabled = cfg
+            if not sampling_enabled:
                 logger.info(
                     f"[MOVER] {DISTILL_ENV_KEY}.enabled_for_sampling is false, "
                     f"pausing for {interval_sec}s"

--- a/tests/test_api_contract.py
+++ b/tests/test_api_contract.py
@@ -82,6 +82,9 @@ class _FakeSystemConfigDAO:
     async def get_param(self, key):
         return self.rows.get(key)
 
+    async def get_param_value(self, key, default=None):
+        return self.rows.get(key, default)
+
 
 def test_public_server_does_not_mount_internal_logs_by_default():
     from affine.api.server import app
@@ -269,6 +272,11 @@ async def test_scores_latest_filters_to_current_miners(monkeypatch):
             },
         }),
     )
+    monkeypatch.setattr(
+        scores_router,
+        "SystemConfigDAO",
+        lambda: _FakeSystemConfigDAO({}),
+    )
 
     response = await get_latest_scores(
         top=256,
@@ -305,6 +313,71 @@ async def test_scores_latest_filters_to_current_miners(monkeypatch):
     assert [row.uid for row in response.scores] == [7]
     assert response.scores[0].challenge_status == "terminated"
     assert response.scores[0].termination_reason == "lost_to_champion:abc"
+
+
+@pytest.mark.asyncio
+async def test_scores_latest_filters_disabled_scoring_envs(monkeypatch):
+    monkeypatch.setattr(
+        scores_router,
+        "MinersDAO",
+        lambda: _FakeMinersDAO({
+            ("uid", 7): {
+                "uid": 7,
+                "hotkey": "current-hk",
+                "revision": "current-rev",
+                "is_valid": "true",
+            },
+        }),
+    )
+    monkeypatch.setattr(
+        scores_router,
+        "MinerStatsDAO",
+        lambda: _FakeMinerStatsDAO({}),
+    )
+    monkeypatch.setattr(
+        scores_router,
+        "SystemConfigDAO",
+        lambda: _FakeSystemConfigDAO({
+            "environments": {
+                "SWE": {
+                    "enabled_for_sampling": True,
+                    "enabled_for_scoring": True,
+                    "sampling": {"sampling_count": 10, "dataset_range": [[0, 100]]},
+                },
+                "DISTILL": {
+                    "enabled_for_sampling": True,
+                    "enabled_for_scoring": False,
+                    "sampling": {"sampling_count": 10, "dataset_range": [[0, 100]]},
+                },
+            },
+        }),
+    )
+
+    response = await get_latest_scores(
+        top=256,
+        dao=_FakeScoresDAO({
+            "block_number": 123,
+            "calculated_at": 456,
+            "scores": [
+                {
+                    "uid": 7,
+                    "miner_hotkey": "current-hk",
+                    "model_revision": "current-rev",
+                    "model": "org/current",
+                    "first_block": 2,
+                    "overall_score": 1.0,
+                    "average_score": 1.0,
+                    "scores_by_env": {
+                        "SWE": {"score": 0.8},
+                        "DISTILL": {"score": 0.9},
+                    },
+                    "total_samples": 20,
+                },
+            ],
+        }),
+    )
+
+    assert response.scores[0].scores_by_env == {"SWE": {"score": 0.8}}
 
 
 @pytest.mark.asyncio

--- a/tests/test_cross_service_contract.py
+++ b/tests/test_cross_service_contract.py
@@ -94,11 +94,11 @@ async def test_environments_filter_disabled_envs():
     doesn't fork a worker for a disabled env."""
     kv = InMemoryConfigStore()
     kv.data["environments"] = {
-        "ENABLED": {"display_name": "On", "enabled": True,
+        "ENABLED": {"display_name": "On", "enabled_for_sampling": True,
                     "sampling": {"sampling_count": 100,
                                  "dataset_range": [[0, 1000]],
                                  "sampling_mode": "random"}},
-        "DISABLED": {"display_name": "Off", "enabled": False,
+        "DISABLED": {"display_name": "Off", "enabled_for_sampling": False,
                      "sampling": {"sampling_count": 100,
                                   "dataset_range": [[0, 1000]],
                                   "sampling_mode": "random"}},
@@ -153,13 +153,13 @@ async def test_legacy_env_payload_shape_still_works():
     accepts both so a partial migration doesn't break the scheduler."""
     kv = InMemoryConfigStore()
     kv.data["environments"] = {
-        "OLD": {"display_name": "X", "enabled": True,
+        "OLD": {"display_name": "X", "enabled_for_sampling": True,
                 "window_config": {  # legacy key
                     "sampling_count": 50,
                     "dataset_range": [[0, 999]],
                     "sampling_mode": "latest",
                 }},
-        "NEW": {"display_name": "Y", "enabled": True,
+        "NEW": {"display_name": "Y", "enabled_for_sampling": True,
                 "sampling": {  # current key
                     "sampling_count": 100,
                     "dataset_range": [[0, 999]],

--- a/tests/test_executor_worker.py
+++ b/tests/test_executor_worker.py
@@ -157,3 +157,146 @@ def test_global_slot_helpers_noop_when_unwired():
         worker._release_global_slot()  # no-op
 
     _asyncio.run(_drive())
+
+
+def test_env_concurrency_cap_none_means_no_env_semaphore():
+    from affine.src.executor.worker import ExecutorWorker
+
+    worker = ExecutorWorker(worker_id=0, env="MEMORY")
+    assert worker._env_sem is None
+
+
+def test_env_concurrency_cap_creates_asyncio_semaphore():
+    import asyncio as _asyncio
+    from affine.src.executor.worker import ExecutorWorker
+
+    worker = ExecutorWorker(
+        worker_id=0, env="LIVEWEB", env_concurrency_cap=100,
+    )
+    assert isinstance(worker._env_sem, _asyncio.Semaphore)
+    # Acquire 100 times; the 101st should not be immediately available.
+    async def _drive():
+        for _ in range(100):
+            await worker._env_sem.acquire()
+        assert worker._env_sem.locked()
+
+    _asyncio.run(_drive())
+
+
+def test_env_sem_caps_in_flight_evaluate_and_persist():
+    """Per-env cap must serialise concurrent evaluate calls inside one
+    worker. Without it, a flaky env's infra-retry storm can occupy the
+    entire global dispatch budget — exactly the LIVEWEB Stooq-lock
+    incident this knob exists to prevent."""
+    import asyncio as _asyncio
+    from affine.src.executor.worker import ExecutorWorker
+    from affine.src.scorer.window_state import MinerSnapshot
+
+    worker = ExecutorWorker(
+        worker_id=0, env="LIVEWEB", env_concurrency_cap=2,
+    )
+
+    observed_peak = {"value": 0}
+    in_flight = {"value": 0}
+
+    async def _fake_gated(**_kwargs):
+        in_flight["value"] += 1
+        observed_peak["value"] = max(observed_peak["value"], in_flight["value"])
+        try:
+            await _asyncio.sleep(0.05)
+        finally:
+            in_flight["value"] -= 1
+
+    worker._evaluate_and_persist_gated = _fake_gated
+
+    miner = MinerSnapshot(uid=1, hotkey="hk", model="m", revision="r")
+
+    async def _drive():
+        # Five concurrent calls; cap=2 should keep peak at 2.
+        await _asyncio.gather(*[
+            worker._evaluate_and_persist(
+                miner=miner, task_id=i, base_url="http://x",
+                refresh_block=0,
+            )
+            for i in range(5)
+        ])
+        assert observed_peak["value"] == 2
+
+    _asyncio.run(_drive())
+
+
+def test_env_sem_unset_does_not_serialise_calls():
+    """Without a cap, the outer wrapper must be a no-op — concurrent
+    evaluate calls all proceed in parallel up to the global semaphore."""
+    import asyncio as _asyncio
+    from affine.src.executor.worker import ExecutorWorker
+    from affine.src.scorer.window_state import MinerSnapshot
+
+    worker = ExecutorWorker(worker_id=0, env="MEMORY")  # no cap
+    observed_peak = {"value": 0}
+    in_flight = {"value": 0}
+
+    async def _fake_gated(**_kwargs):
+        in_flight["value"] += 1
+        observed_peak["value"] = max(observed_peak["value"], in_flight["value"])
+        try:
+            await _asyncio.sleep(0.05)
+        finally:
+            in_flight["value"] -= 1
+
+    worker._evaluate_and_persist_gated = _fake_gated
+
+    miner = MinerSnapshot(uid=1, hotkey="hk", model="m", revision="r")
+
+    async def _drive():
+        await _asyncio.gather(*[
+            worker._evaluate_and_persist(
+                miner=miner, task_id=i, base_url="http://x",
+                refresh_block=0,
+            )
+            for i in range(5)
+        ])
+        assert observed_peak["value"] == 5
+
+    _asyncio.run(_drive())
+
+
+def test_env_from_payload_parses_max_concurrent():
+    from affine.src.scorer.window_state import _env_from_payload
+
+    cfg = _env_from_payload({
+        "display_name": "LIVEWEB",
+        "enabled_for_sampling": True,
+        "sampling": {
+            "sampling_count": 400,
+            "dataset_range": [[0, 100]],
+            "sampling_mode": "random",
+            "max_concurrent": 100,
+        },
+    })
+    assert cfg.max_concurrent == 100
+
+
+def test_env_from_payload_max_concurrent_defaults_to_none():
+    from affine.src.scorer.window_state import _env_from_payload
+
+    cfg = _env_from_payload({
+        "display_name": "MEMORY",
+        "enabled_for_sampling": True,
+        "sampling": {"sampling_count": 200, "dataset_range": [[0, 10]]},
+    })
+    assert cfg.max_concurrent is None
+
+
+def test_env_from_payload_rejects_nonpositive_max_concurrent():
+    from affine.src.scorer.window_state import _env_from_payload
+
+    # Negative / zero / non-numeric all fall back to None to avoid
+    # silently uncapping or deadlocking an env with cap=0.
+    for bad in (-1, 0, "abc", None, "0"):
+        cfg = _env_from_payload({
+            "display_name": "x",
+            "enabled_for_sampling": True,
+            "sampling": {"max_concurrent": bad},
+        })
+        assert cfg.max_concurrent is None, f"bad input {bad!r} leaked through"

--- a/tests/test_miner_rank.py
+++ b/tests/test_miner_rank.py
@@ -119,6 +119,7 @@ def test_rank_table_renders_old_single_table_shape_with_sampling_marks():
     assert "70.00[79.00,81.00]/9" in out
     assert out.count("⚡| org/") == 2
     assert "Sampling: ⚡ marks miners in the current live sampling set" in out
+    assert "Queue: #1 UID 3" not in out
 
 
 def test_rank_table_renders_empty_scores_safely():

--- a/tests/test_miner_rank.py
+++ b/tests/test_miner_rank.py
@@ -10,10 +10,10 @@ import affine.src.miner.rank as rank
 from affine.src.miner.rank import _print_rank_table
 
 
-def _render_rank(window, queue, scores):
+def _render_rank(window, queue, scores, *, show_reason=False):
     buf = io.StringIO()
     with redirect_stdout(buf):
-        _print_rank_table(window, queue, scores)
+        _print_rank_table(window, queue, scores, show_reason=show_reason)
     return buf.getvalue()
 
 
@@ -111,7 +111,7 @@ def test_rank_table_renders_old_single_table_shape_with_sampling_marks():
     assert "Battle:     UID 2" in out
     assert "Hotkey" in out
     assert "⚡| Model" in out
-    assert "Reason" in out
+    assert "Reason" not in out
     assert " Valid " not in out
     assert "CHAMPION" in out
     assert "BATTLING" in out
@@ -158,7 +158,7 @@ def test_rank_table_groups_invalid_miners_below_valid_rows():
 
     assert out.index("good") < out.index("bad")
     assert "model_misma" in out
-    assert "model_mismatch:de" in out
+    assert "model_mismatch:de" not in out
 
 
 def test_rank_table_sorts_miners_by_status_then_uid_not_score():
@@ -212,7 +212,42 @@ def test_rank_table_sorts_miners_by_status_then_uid_not_score():
     assert out.index("uid9") < out.index("terminated")
     assert out.index("terminated") < out.index("invalid")
     assert "TERMINATED" in out
+    assert "lost_to_champion:" not in out
+
+
+def test_rank_table_can_show_reason_column_when_requested():
+    scores = {
+        "block_number": 100,
+        "calculated_at": 0,
+        "scores": [
+            {
+                "uid": 4,
+                "miner_hotkey": "terminated",
+                "model": "org/terminated",
+                "overall_score": 1.0,
+                "is_valid": False,
+                "invalid_reason": "hf_model_fetch_failed",
+                "challenge_status": "terminated",
+                "termination_reason": "lost_to_champion:abc",
+                "scores_by_env": {},
+            },
+            {
+                "uid": 2,
+                "miner_hotkey": "invalid",
+                "model": "org/invalid",
+                "overall_score": 1.0,
+                "is_valid": False,
+                "invalid_reason": "model_mismatch:detail",
+                "scores_by_env": {},
+            },
+        ],
+    }
+
+    out = _render_rank(None, None, scores, show_reason=True)
+
+    assert "Reason" in out
     assert "lost_to_champion:" in out
+    assert "model_mismatch:de" in out
 
 
 def test_rank_table_shows_terminated_for_terminated_status():

--- a/tests/test_miner_rank.py
+++ b/tests/test_miner_rank.py
@@ -119,6 +119,7 @@ def test_rank_table_renders_old_single_table_shape_with_sampling_marks():
     assert "80.00/300" in out
     assert "70.00[79.00,81.00]/9" in out
     assert out.count("⚡| org/") == 2
+    assert "  | org/q" in out
     assert "Sampling: ⚡ marks miners in the current live sampling set" in out
     assert "Queue: #1 UID 3" not in out
 

--- a/tests/test_miner_rank.py
+++ b/tests/test_miner_rank.py
@@ -204,6 +204,7 @@ def test_rank_table_sorts_miners_by_status_then_uid_not_score():
     assert out.index("uid3") < out.index("uid9")
     assert out.index("uid9") < out.index("invalid")
     assert out.index("uid9") < out.index("terminated")
+    assert out.index("terminated") < out.index("invalid")
 
 
 def test_rank_table_shows_terminated_for_terminated_status():

--- a/tests/test_miner_rank.py
+++ b/tests/test_miner_rank.py
@@ -184,7 +184,8 @@ def test_rank_table_sorts_miners_by_status_then_uid_not_score():
                 "miner_hotkey": "terminated",
                 "model": "org/terminated",
                 "overall_score": 1.0,
-                "is_valid": True,
+                "is_valid": False,
+                "invalid_reason": "hf_model_fetch_failed",
                 "challenge_status": "terminated",
                 "scores_by_env": {},
             },
@@ -206,6 +207,8 @@ def test_rank_table_sorts_miners_by_status_then_uid_not_score():
     assert out.index("uid9") < out.index("invalid")
     assert out.index("uid9") < out.index("terminated")
     assert out.index("terminated") < out.index("invalid")
+    assert "TERMINATED" in out
+    assert "hf_model_fe" not in out
 
 
 def test_rank_table_shows_terminated_for_terminated_status():

--- a/tests/test_miner_rank.py
+++ b/tests/test_miner_rank.py
@@ -111,6 +111,7 @@ def test_rank_table_renders_old_single_table_shape_with_sampling_marks():
     assert "Battle:     UID 2" in out
     assert "Hotkey" in out
     assert "⚡| Model" in out
+    assert "Reason" in out
     assert " Valid " not in out
     assert "CHAMPION" in out
     assert "BATTLING" in out
@@ -156,6 +157,7 @@ def test_rank_table_groups_invalid_miners_below_valid_rows():
 
     assert out.index("good") < out.index("bad")
     assert "model_misma" in out
+    assert "model_mismatch:de" in out
 
 
 def test_rank_table_sorts_miners_by_status_then_uid_not_score():
@@ -187,6 +189,7 @@ def test_rank_table_sorts_miners_by_status_then_uid_not_score():
                 "is_valid": False,
                 "invalid_reason": "hf_model_fetch_failed",
                 "challenge_status": "terminated",
+                "termination_reason": "lost_to_champion:abc",
                 "scores_by_env": {},
             },
             {
@@ -208,7 +211,7 @@ def test_rank_table_sorts_miners_by_status_then_uid_not_score():
     assert out.index("uid9") < out.index("terminated")
     assert out.index("terminated") < out.index("invalid")
     assert "TERMINATED" in out
-    assert "hf_model_fe" not in out
+    assert "lost_to_champion:" in out
 
 
 def test_rank_table_shows_terminated_for_terminated_status():

--- a/tests/test_miner_rank.py
+++ b/tests/test_miner_rank.py
@@ -157,6 +157,55 @@ def test_rank_table_groups_invalid_miners_below_valid_rows():
     assert "model_misma" in out
 
 
+def test_rank_table_sorts_miners_by_status_then_uid_not_score():
+    scores = {
+        "block_number": 100,
+        "calculated_at": 0,
+        "scores": [
+            {
+                "uid": 9,
+                "miner_hotkey": "uid9",
+                "model": "org/uid9",
+                "overall_score": 0.99,
+                "is_valid": True,
+                "scores_by_env": {},
+            },
+            {
+                "uid": 3,
+                "miner_hotkey": "uid3",
+                "model": "org/uid3",
+                "overall_score": 0.01,
+                "is_valid": True,
+                "scores_by_env": {},
+            },
+            {
+                "uid": 4,
+                "miner_hotkey": "terminated",
+                "model": "org/terminated",
+                "overall_score": 1.0,
+                "is_valid": True,
+                "challenge_status": "terminated",
+                "scores_by_env": {},
+            },
+            {
+                "uid": 2,
+                "miner_hotkey": "invalid",
+                "model": "org/invalid",
+                "overall_score": 1.0,
+                "is_valid": False,
+                "invalid_reason": "model_check:bad",
+                "scores_by_env": {},
+            },
+        ],
+    }
+
+    out = _render_rank(None, None, scores)
+
+    assert out.index("uid3") < out.index("uid9")
+    assert out.index("uid9") < out.index("invalid")
+    assert out.index("uid9") < out.index("terminated")
+
+
 def test_rank_table_shows_terminated_for_terminated_status():
     """miner_stats challenge_status='terminated' renders TERMINATED."""
     scores = {

--- a/tests/test_scheduler_flow.py
+++ b/tests/test_scheduler_flow.py
@@ -160,13 +160,13 @@ def _seed_state(*, sampling_count=4, with_champion=True) -> InMemoryConfigStore:
     kv = InMemoryConfigStore()
     kv.data["environments"] = {
         "ENV_A": {
-            "display_name": "A", "enabled": True,
+            "display_name": "A", "enabled_for_sampling": True,
             "sampling": {"sampling_count": sampling_count,
                          "dataset_range": [[0, 1000]],
                          "sampling_mode": "random"},
         },
         "ENV_B": {
-            "display_name": "B", "enabled": True,
+            "display_name": "B", "enabled_for_sampling": True,
             "sampling": {"sampling_count": sampling_count,
                          "dataset_range": [[0, 1000]],
                          "sampling_mode": "random"},

--- a/tests/test_state_store.py
+++ b/tests/test_state_store.py
@@ -78,9 +78,9 @@ async def test_task_state_roundtrip():
 async def test_environments_filter_disabled():
     kv = InMemoryConfigStore()
     kv.data["environments"] = {
-        "A": {"display_name": "A", "enabled": True,
+        "A": {"display_name": "A", "enabled_for_sampling": True,
               "sampling": {"sampling_count": 10, "dataset_range": [[0, 100]], "sampling_mode": "random"}},
-        "B": {"display_name": "B", "enabled": False,
+        "B": {"display_name": "B", "enabled_for_sampling": False,
               "sampling": {"sampling_count": 10, "dataset_range": [[0, 100]], "sampling_mode": "random"}},
     }
     store = StateStore(kv)
@@ -123,21 +123,24 @@ async def test_get_scoring_environments_filters_independently_from_sampling():
 
 
 @pytest.mark.asyncio
-async def test_legacy_enabled_key_maps_to_enabled_for_sampling():
-    """Older system_config rows used a single ``enabled`` flag. The
-    parser should accept it and treat it as ``enabled_for_sampling``
-    so we don't drop active envs during the schema transition."""
+async def test_missing_sampling_gate_is_disabled():
+    """Environment rows must explicitly opt into sampling."""
     kv = InMemoryConfigStore()
     kv.data["environments"] = {
-        "LEGACY": {"display_name": "Legacy", "enabled": True,
-                   "sampling": {"sampling_count": 5, "dataset_range": [[0, 50]], "sampling_mode": "random"}},
+        "MISSING_GATE": {
+            "display_name": "Missing",
+            "sampling": {
+                "sampling_count": 5,
+                "dataset_range": [[0, 50]],
+                "sampling_mode": "random",
+            },
+        },
     }
     store = StateStore(kv)
     envs = await store.get_environments()
-    assert "LEGACY" in envs
-    # Default scoring flag is True so legacy envs behave as before.
+    assert "MISSING_GATE" not in envs
     scoring = await store.get_scoring_environments()
-    assert "LEGACY" in scoring
+    assert "MISSING_GATE" not in scoring
 
 
 @pytest.mark.asyncio
@@ -146,7 +149,7 @@ async def test_environments_accepts_legacy_window_config_shape():
     ``.sampling``. Coercion should accept both."""
     kv = InMemoryConfigStore()
     kv.data["environments"] = {
-        "OLD": {"display_name": "Old", "enabled": True,
+        "OLD": {"display_name": "Old", "enabled_for_sampling": True,
                 "window_config": {"sampling_count": 50, "dataset_range": [[0, 1000]], "sampling_mode": "latest"}},
     }
     store = StateStore(kv)


### PR DESCRIPTION
Limit any single env's in-flight evaluate calls when an operator sets `EnvConfig.max_concurrent`, so a flaky env can't starve the rest. Bump `GLOBAL_DISPATCH_BUDGET` 480 → 600 (LIVEWEB doesn't go through b300, so b300-saturation is no longer the only constraint). Slow `[STATUS]` log cadence to 60s.

Pre-set `LIVEWEB.sampling.max_concurrent=100` in prod system_config; takes effect on next executor restart.