### PR TITLE
Fix post-sampling battle flow: single-instance dispatch + recovery completeness

### DIFF
--- a/affine/database/cli.py
+++ b/affine/database/cli.py
@@ -129,11 +129,48 @@ async def _cmd_load_config(json_file: str) -> None:
                 description=f"Loaded from {os.path.basename(json_file)}",
                 updated_by="cli:load-config",
             )
-            preview = _preview(value)
-            print(f"  {key:<24} → {preview}")
+            if key == "environments" and isinstance(value, dict):
+                print(f"  {key} ({len(value)} envs):")
+                _print_env_summary(value)
+            else:
+                preview = _preview(value)
+                print(f"  {key:<24} → {preview}")
         print(f"✓ Loaded {len(payload)} keys")
     finally:
         await close_client()
+
+
+def _print_env_summary(environments: dict) -> None:
+    """One line per env with the fields operators actually need to verify."""
+    for env_name in sorted(environments):
+        cfg = environments.get(env_name) or {}
+        sampling = cfg.get("sampling") or {}
+        sampling_on = cfg.get("enabled_for_sampling", False)
+        scoring_on = cfg.get("enabled_for_scoring", True)
+        count = sampling.get("sampling_count", "?")
+        mode = sampling.get("sampling_mode", "?")
+        cap = sampling.get("max_concurrent")
+        cap_str = str(cap) if cap else "—"
+        rng = sampling.get("dataset_range")
+        if sampling.get("dataset_range_source"):
+            rng_str = "resolved-at-refresh"
+        elif isinstance(rng, list) and rng:
+            try:
+                lo, hi = rng[0][0], rng[-1][1]
+                rng_str = f"[{lo},{hi}]" if len(rng) == 1 else f"{len(rng)} ranges"
+            except (IndexError, TypeError):
+                rng_str = "?"
+        else:
+            rng_str = "—"
+        print(
+            f"      {env_name:<14} "
+            f"sampling={'Y' if sampling_on else 'N'} "
+            f"scoring={'Y' if scoring_on else 'N'} "
+            f"count={count:<5} "
+            f"mode={mode:<7} "
+            f"cap={cap_str:<5} "
+            f"range={rng_str}"
+        )
 
 
 async def _resolve_env_dataset_ranges(environments: dict) -> dict:

--- a/affine/database/cli.py
+++ b/affine/database/cli.py
@@ -149,8 +149,6 @@ def _print_env_summary(environments: dict) -> None:
         scoring_on = cfg.get("enabled_for_scoring", True)
         count = sampling.get("sampling_count", "?")
         mode = sampling.get("sampling_mode", "?")
-        cap = sampling.get("max_concurrent")
-        cap_str = str(cap) if cap else "—"
         rng = sampling.get("dataset_range")
         if sampling.get("dataset_range_source"):
             rng_str = "resolved-at-refresh"
@@ -168,7 +166,6 @@ def _print_env_summary(environments: dict) -> None:
             f"scoring={'Y' if scoring_on else 'N'} "
             f"count={count:<5} "
             f"mode={mode:<7} "
-            f"cap={cap_str:<5} "
             f"range={rng_str}"
         )
 

--- a/affine/database/system_config.json
+++ b/affine/database/system_config.json
@@ -38,7 +38,8 @@
       "sampling": {
         "sampling_count": 400,
         "dataset_range": [[0, 78060000]],
-        "sampling_mode": "random"
+        "sampling_mode": "random",
+        "max_concurrent": 100
       }
     },
     "LOGPROBS": {

--- a/affine/database/system_config.json
+++ b/affine/database/system_config.json
@@ -38,8 +38,7 @@
       "sampling": {
         "sampling_count": 400,
         "dataset_range": [[0, 78060000]],
-        "sampling_mode": "random",
-        "max_concurrent": 100
+        "sampling_mode": "random"
       }
     },
     "LOGPROBS": {

--- a/affine/src/executor/config.py
+++ b/affine/src/executor/config.py
@@ -6,11 +6,10 @@ It's sized to the inference backend's saturation point (b300: 8 GPUs ×
 60 in-flight per card) — the goal is to keep that semaphore exhausted
 so the inference cluster stays fully utilized while we sample.
 
-Cross-env priority emerges naturally from the shared sem: a worker with
-more remaining task_ids spawns more coroutines, makes more acquire
-attempts per unit time, and so wins a proportionally larger share of
-slots than envs with little remaining work. No explicit priority queue
-is needed.
+Cross-env priority is adjusted by the manager from live progress:
+backlogged envs that are using their share receive more slots, while
+envs that cannot consume their current cap release capacity but keep a
+small probe floor so they cannot starve.
 
 Per-worker ``max_concurrent`` is a defensive floor — large enough not
 to gate anything, just so a runaway pending list can't schedule tens of
@@ -22,9 +21,8 @@ thousands of coroutines into asyncio at once.
 # that hit it (SWE-INFINITE, MEMORY, NAVWORLD, TERMINAL). 600 adds
 # headroom for envs that don't go through b300 — LIVEWEB runs against
 # its own SSH hosts for web scraping, so its in-flight share doesn't
-# consume GPU capacity. Pair with per-env ``max_concurrent`` caps
-# (EnvConfig.max_concurrent) to keep any single env from monopolising
-# the shared pool.
+# consume GPU capacity. The executor manager dynamically assigns per-env
+# caps inside this global budget from observed throughput and backlog.
 GLOBAL_DISPATCH_BUDGET = 600
 
 # Per-worker asyncio-side safety floor. Never the real gate — the

--- a/affine/src/executor/main.py
+++ b/affine/src/executor/main.py
@@ -16,6 +16,7 @@ connection pools don't have to be shared.
 from __future__ import annotations
 
 import asyncio
+import math
 import multiprocessing
 import signal
 from typing import Any, Dict, List, Optional
@@ -45,18 +46,16 @@ class ExecutorManager:
     ):
         self.envs = envs
         self.verbosity = verbosity
-        # Optional per-env evaluate-concurrency caps. Sourced from
-        # ``EnvConfig.max_concurrent`` (system_config). Envs absent
-        # from this dict only contend on the global semaphore.
+        # Per-env evaluate-concurrency caps. Sourced from a fair-share
+        # default plus optional ``EnvConfig.max_concurrent`` overrides.
         self.env_concurrency_caps = env_concurrency_caps or {}
         self.mp_ctx = multiprocessing.get_context("spawn")
         # Single cross-process bounded semaphore = the real concurrency
         # gate. Sized to the b300 saturation point so the inference
-        # backend is the bottleneck (where we want it). Workers
-        # contend on this sem before every evaluate(); envs with more
-        # remaining work submit more concurrent acquire() attempts and
-        # naturally win a proportional share of slots — that's the
-        # cross-env priority, no explicit queue needed.
+        # backend is the bottleneck (where we want it). Workers first pass
+        # their per-env cap, then contend on this shared sem before every
+        # evaluate. The per-env caps prevent fast-cycling envs from starving
+        # slower env workers.
         self.global_sem = self.mp_ctx.BoundedSemaphore(GLOBAL_DISPATCH_BUDGET)
         # Per-env in-flight counter; worker writes (single writer), manager
         # reads. ``lock=False`` is safe: only one process writes each
@@ -222,21 +221,52 @@ async def _enabled_envs() -> List[str]:
     return out
 
 
-async def _env_concurrency_caps(envs: List[str]) -> Dict[str, int]:
-    """Read ``EnvConfig.max_concurrent`` for the named envs via the
-    shared ``_env_from_payload`` parser. Returns a dict of only the
-    envs that have a positive cap configured — sharing the parser
-    keeps the int/bool/str validation in one place."""
+def _compute_env_caps(
+    envs: List[str],
+    raw_envs: Dict[str, Any],
+    *,
+    global_budget: int,
+) -> Dict[str, int]:
+    """Return one evaluate-in-flight cap per sampling env.
+
+    A single global semaphore alone is not fair: workers with many fast
+    retries or short tasks win more acquire races and can crowd out slow
+    envs. Envs without an explicit cap split the remaining global budget
+    evenly, so every env has a bounded share. An explicit
+    ``system_config.environments.<env>.sampling.max_concurrent`` overrides
+    the default for that env.
+    """
     from affine.src.scorer.window_state import _env_from_payload
 
-    config_dao = SystemConfigDAO()
-    envs_raw = await config_dao.get_param_value("environments", default={}) or {}
+    if not envs:
+        return {}
+    parsed = {name: _env_from_payload(raw_envs.get(name)) for name in envs}
+    explicit = {
+        name: cfg.max_concurrent
+        for name, cfg in parsed.items()
+        if cfg.max_concurrent
+    }
+    uncapped = [name for name in envs if name not in explicit]
+    explicit_total = sum(explicit.values())
+    default_cap = 1
+    if uncapped:
+        remaining = max(1, global_budget - explicit_total)
+        default_cap = max(1, math.ceil(remaining / len(uncapped)))
     out: Dict[str, int] = {}
     for name in envs:
-        cfg = _env_from_payload(envs_raw.get(name))
-        if cfg.max_concurrent:
-            out[name] = cfg.max_concurrent
+        out[name] = explicit.get(name) or default_cap
     return out
+
+
+async def _env_concurrency_caps(envs: List[str]) -> Dict[str, int]:
+    """Compute per-env caps from live ``system_config.environments``."""
+    config_dao = SystemConfigDAO()
+    envs_raw = await config_dao.get_param_value("environments", default={}) or {}
+    return _compute_env_caps(
+        envs,
+        envs_raw if isinstance(envs_raw, dict) else {},
+        global_budget=GLOBAL_DISPATCH_BUDGET,
+    )
 
 
 async def _run() -> None:

--- a/affine/src/executor/main.py
+++ b/affine/src/executor/main.py
@@ -19,7 +19,7 @@ import asyncio
 import math
 import multiprocessing
 import signal
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List
 
 import click
 
@@ -42,26 +42,26 @@ class ExecutorManager:
         envs: List[str],
         *,
         verbosity: int = 1,
-        env_concurrency_caps: Optional[Dict[str, int]] = None,
     ):
         self.envs = envs
         self.verbosity = verbosity
-        # Per-env evaluate-concurrency caps. Sourced from a fair-share
-        # default plus optional ``EnvConfig.max_concurrent`` overrides.
-        self.env_concurrency_caps = env_concurrency_caps or {}
         self.mp_ctx = multiprocessing.get_context("spawn")
         # Single cross-process bounded semaphore = the real concurrency
         # gate. Sized to the b300 saturation point so the inference
         # backend is the bottleneck (where we want it). Workers first pass
-        # their per-env cap, then contend on this shared sem before every
-        # evaluate. The per-env caps prevent fast-cycling envs from starving
-        # slower env workers.
+        # their dynamic per-env cap, then contend on this shared sem before
+        # every evaluate. The manager adjusts per-env caps from live
+        # progress instead of hardcoding env-specific limits.
         self.global_sem = self.mp_ctx.BoundedSemaphore(GLOBAL_DISPATCH_BUDGET)
         # Per-env in-flight counter; worker writes (single writer), manager
         # reads. ``lock=False`` is safe: only one process writes each
         # Value, and aligned c_int reads are atomic on CPython.
         self.in_flight_values: Dict[str, Any] = {
             env: self.mp_ctx.Value("i", 0, lock=False) for env in envs
+        }
+        initial_cap = _initial_env_cap(envs, GLOBAL_DISPATCH_BUDGET)
+        self.env_cap_values: Dict[str, Any] = {
+            env: self.mp_ctx.Value("i", initial_cap, lock=False) for env in envs
         }
         self.workers: List[WorkerProcess] = []
         # Per-env running totals from the prior status print, used to
@@ -82,9 +82,9 @@ class ExecutorManager:
                 worker_id=idx, env=env,
                 global_sem=self.global_sem,
                 in_flight_value=self.in_flight_values[env],
+                env_cap_value=self.env_cap_values[env],
                 max_concurrent=get_max_concurrent(env),
                 verbosity=self.verbosity,
-                env_concurrency_cap=self.env_concurrency_caps.get(env),
             )
             wp.start()
             self.workers.append(wp)
@@ -147,46 +147,90 @@ class ExecutorManager:
         import time as _t
         tids = await sc.get_param_value("current_task_ids") or {}
         champion = await sc.get_param_value("champion") or {}
+        battle = await sc.get_param_value("current_battle") or {}
         task_ids_by_env: Dict[str, List[int]] = tids.get("task_ids", {}) or {}
         refresh_block = int(tids.get("refreshed_at_block", 0) or 0)
-        hk = champion.get("hotkey")
-        rev = champion.get("revision")
+        subjects: List[tuple[str, str]] = []
+        if champion.get("hotkey") and champion.get("revision"):
+            subjects.append((str(champion["hotkey"]), str(champion["revision"])))
+        challenger = battle.get("challenger") if isinstance(battle, dict) else None
+        if (
+            isinstance(challenger, dict)
+            and challenger.get("hotkey")
+            and challenger.get("revision")
+        ):
+            pair = (str(challenger["hotkey"]), str(challenger["revision"]))
+            if pair not in subjects:
+                subjects.append(pair)
 
         now = _t.time()
         elapsed_s = max(1, int(now - self._last_status_at)) if self._last_status_at else 0
         in_flight_total = 0
-        per_env_parts: List[str] = []
         total_done = 0
         total_target = 0
         total_delta = 0
+        env_stats: Dict[str, Dict[str, int]] = {}
+        rows: Dict[str, Dict[str, Any]] = {}
 
         for env in sorted(self.envs):
             ids = task_ids_by_env.get(env, []) or []
-            target = len(ids)
+            target = len(ids) * max(1, len(subjects))
             done = 0
-            if ids and hk and rev and refresh_block:
-                try:
-                    done = await samples.count_samples_for_tasks(
-                        hk, rev, env, ids, refresh_block=refresh_block,
-                    )
-                except Exception as e:
-                    logger.debug(f"status count failed for {env}: {e}")
+            if ids and subjects and refresh_block:
+                for hk, rev in subjects:
+                    try:
+                        done += await samples.count_samples_for_tasks(
+                            hk, rev, env, ids, refresh_block=refresh_block,
+                        )
+                    except Exception as e:
+                        logger.debug(f"status count failed for {env}: {e}")
             running = int(self.in_flight_values[env].value)
             prev = self._last_done.get(env, 0)
             delta = max(0, done - prev) if self._last_status_at else 0
-            rate_per_h = (delta / elapsed_s * 3600) if (elapsed_s and delta) else 0
-            short = env.split(":")[-1].split("-")[0].lower()
-            if self._last_status_at:
-                per_env_parts.append(
-                    f"{short}@{done}/{target} +{delta} rate:{rate_per_h:.0f}/h run:{running}"
-                )
-            else:
-                per_env_parts.append(f"{short}@{done}/{target} run:{running}")
+            env_stats[env] = {
+                "target": target,
+                "done": done,
+                "running": running,
+                "delta": delta,
+            }
+            rows[env] = {
+                "target": target,
+                "done": done,
+                "running": running,
+                "delta": delta,
+            }
             self._last_done[env] = done
             in_flight_total += running
             total_done += done
             total_target += target
             total_delta += delta
+
+        new_caps = _compute_adaptive_env_caps(
+            self.envs,
+            env_stats,
+            {env: int(v.value) for env, v in self.env_cap_values.items()},
+            global_budget=GLOBAL_DISPATCH_BUDGET,
+        )
+        for env, cap in new_caps.items():
+            self.env_cap_values[env].value = cap
+
+        per_env_parts: List[str] = []
+        for env in sorted(self.envs):
+            row = rows[env]
+            done = int(row["done"])
+            target = int(row["target"])
+            running = int(row["running"])
+            delta = int(row["delta"])
+            rate_per_h = (delta / elapsed_s * 3600) if (elapsed_s and delta) else 0
+            short = env.split(":")[-1].split("-")[0].lower()
+            cap = int(self.env_cap_values[env].value)
+            if self._last_status_at:
+                per_env_parts.append(
+                    f"{short}@{done}/{target} +{delta} "
+                    f"rate:{rate_per_h:.0f}/h run:{running}/{cap}"
+                )
+            else:
+                per_env_parts.append(f"{short}@{done}/{target} run:{running}/{cap}")
 
         total_rate = (total_delta / elapsed_s * 3600) if (elapsed_s and total_delta) else 0
         if self._last_status_at:
@@ -221,52 +265,121 @@ async def _enabled_envs() -> List[str]:
     return out
 
 
-def _compute_env_caps(
+def _initial_env_cap(envs: List[str], global_budget: int) -> int:
+    if not envs:
+        return max(1, global_budget)
+    return max(1, math.ceil(global_budget / len(envs)))
+
+
+def _compute_adaptive_env_caps(
     envs: List[str],
-    raw_envs: Dict[str, Any],
+    stats: Dict[str, Dict[str, int]],
+    previous_caps: Dict[str, int],
     *,
     global_budget: int,
 ) -> Dict[str, int]:
-    """Return one evaluate-in-flight cap per sampling env.
+    """Adapt per-env in-flight caps from live progress.
 
-    A single global semaphore alone is not fair: workers with many fast
-    retries or short tasks win more acquire races and can crowd out slow
-    envs. Envs without an explicit cap split the remaining global budget
-    evenly, so every env has a bounded share. An explicit
-    ``system_config.environments.<env>.sampling.max_concurrent`` overrides
-    the default for that env.
+    The objective is shortest wall-clock completion, not static fairness:
+    every backlogged env keeps a probe floor so it cannot starve, envs
+    that cannot consume their current cap release capacity, and the
+    remaining budget goes to saturated envs weighted by estimated time
+    to finish (remaining work divided by recent completions). If no env
+    is actually able to consume more slots, the function intentionally
+    returns less than ``global_budget`` instead of refilling the pool
+    with caps that would only create waiting coroutines.
     """
-    from affine.src.scorer.window_state import _env_from_payload
+    active = [
+        env for env in envs
+        if (stats.get(env, {}).get("target", 0) - stats.get(env, {}).get("done", 0)) > 0
+        or stats.get(env, {}).get("running", 0) > 0
+    ]
+    if not active:
+        initial = _initial_env_cap(envs, global_budget)
+        return {env: initial for env in envs}
+    fair = _initial_env_cap(active, global_budget)
+    floor = max(1, fair // 8)
+    caps: Dict[str, int] = {env: floor for env in envs}
+    weights: Dict[str, float] = {}
+    for env in active:
+        row = stats.get(env, {})
+        target = int(row.get("target", 0) or 0)
+        done = int(row.get("done", 0) or 0)
+        running = max(0, int(row.get("running", 0) or 0))
+        delta = max(0, int(row.get("delta", 0) or 0))
+        remaining = max(0, target - done)
+        prev = max(1, int(previous_caps.get(env, fair) or fair))
+        if remaining <= 0:
+            # Let existing calls drain; do not launch a new wave for an
+            # env whose current subject set is complete. Keep the probe
+            # floor so a newly started battle is not stuck at one-at-a-time
+            # until the next status interval.
+            caps[env] = max(floor, min(prev, running or floor))
+            continue
 
-    if not envs:
-        return {}
-    parsed = {name: _env_from_payload(raw_envs.get(name)) for name in envs}
-    explicit = {
-        name: cfg.max_concurrent
-        for name, cfg in parsed.items()
-        if cfg.max_concurrent
-    }
-    uncapped = [name for name in envs if name not in explicit]
-    explicit_total = sum(explicit.values())
-    default_cap = 1
-    if uncapped:
-        remaining = max(1, global_budget - explicit_total)
-        default_cap = max(1, math.ceil(remaining / len(uncapped)))
-    out: Dict[str, int] = {}
-    for name in envs:
-        out[name] = explicit.get(name) or default_cap
+        saturated = running >= max(floor, int(prev * 0.75))
+        if saturated:
+            if delta <= 0:
+                # Saturated but no recent completions: preserve a bounded
+                # share so long-running calls can finish, but do not add
+                # more pressure to a possibly stuck env.
+                caps[env] = max(floor, min(prev, running or floor))
+                continue
+            # Saturated envs compete for the shared budget by pressure.
+            # Keep only the probe floor before allocation so a nearly done
+            # env can release future launch capacity to a lagging peer even
+            # while its existing calls are still draining.
+            caps[env] = floor
+            # Remaining / delta approximates intervals-to-finish. With no
+            # completions yet, the branch above keeps the env at its current
+            # share instead of amplifying a possible stall.
+            weights[env] = float(remaining) / float(delta)
+        else:
+            # Minimum non-starving probe. Even an env with zero in-flight gets
+            # enough slots to prove it can make progress after cold starts,
+            # container stalls, or transient DB gaps. Underused envs stay at
+            # this local-demand cap and do not receive extra budget.
+            caps[env] = max(floor, min(prev, running + floor))
+
+    total = sum(caps.values())
+    if total > global_budget:
+        return _trim_caps(caps, global_budget=global_budget, floor=1)
+
+    extra = global_budget - total
+    if extra <= 0 or not weights:
+        return caps
+
+    total_weight = sum(weights.values())
+    allocations: Dict[str, int] = {}
+    fractions: List[tuple[float, str]] = []
+    used = 0
+    for env, weight in weights.items():
+        raw = extra * (weight / total_weight)
+        whole = int(raw)
+        allocations[env] = whole
+        fractions.append((raw - whole, env))
+        used += whole
+    for _, env in sorted(fractions, reverse=True):
+        if used >= extra:
+            break
+        allocations[env] += 1
+        used += 1
+    for env, add in allocations.items():
+        caps[env] += add
+    return _trim_caps(caps, global_budget=global_budget, floor=1)
+
+
+def _trim_caps(caps: Dict[str, int], *, global_budget: int, floor: int) -> Dict[str, int]:
+    out = {env: max(floor, int(cap)) for env, cap in caps.items()}
+    total = sum(out.values())
+    while total > global_budget:
+        candidates = [env for env, cap in out.items() if cap > floor]
+        if not candidates:
+            break
+        env = max(candidates, key=lambda e: out[e])
+        out[env] -= 1
+        total -= 1
     return out
-
-
-async def _env_concurrency_caps(envs: List[str]) -> Dict[str, int]:
-    """Compute per-env caps from live ``system_config.environments``."""
-    config_dao = SystemConfigDAO()
-    envs_raw = await config_dao.get_param_value("environments", default={}) or {}
-    return _compute_env_caps(
-        envs,
-        envs_raw if isinstance(envs_raw, dict) else {},
-        global_budget=GLOBAL_DISPATCH_BUDGET,
-    )
 
 
 async def _run() -> None:
@@ -278,13 +391,7 @@ async def _run() -> None:
         )
         return
 
-    caps = await _env_concurrency_caps(envs)
-    if caps:
-        logger.info(f"executor: per-env concurrency caps = {caps}")
-
-    manager = ExecutorManager(
-        envs=envs, verbosity=1, env_concurrency_caps=caps,
-    )
+    manager = ExecutorManager(envs=envs, verbosity=1)
     await manager.start()
 
     stop_event = asyncio.Event()

--- a/affine/src/executor/main.py
+++ b/affine/src/executor/main.py
@@ -109,17 +109,35 @@ class ExecutorManager:
                 if not wp.is_alive():
                     logger.warning(f"[{wp.env}] subprocess died; restarting")
                     try:
+                        self._recover_dead_worker_slots(wp.env)
                         wp.start()
                     except Exception as e:
                         logger.error(f"[{wp.env}] restart raised: {e}")
 
+    def _recover_dead_worker_slots(self, env: str) -> None:
+        """Clear dispatch accounting left behind by a dead worker process."""
+        value = self.in_flight_values.get(env)
+        if value is None:
+            return
+        stale = max(0, int(value.value))
+        if stale:
+            logger.warning(
+                f"[{env}] recovering {stale} stale dispatch slot(s) "
+                "after subprocess death"
+            )
+        for _ in range(stale):
+            try:
+                self.global_sem.release()
+            except ValueError:
+                break
+        value.value = 0
+
     async def _status_printer(self) -> None:
         """Periodic ``[STATUS]`` line in the legacy executor's format.
 
-        Reads done counts from ``sample_results`` (champion-only — the
-        challenger row count rides on the same window so isn't reported
-        separately) and per-env in-flight from the shared
-        ``in_flight_values`` Values. Format:
+        Reads done counts from ``sample_results`` for the champion and,
+        during battles, the challenger. Per-env in-flight comes from the
+        shared ``in_flight_values`` Values. Format:
 
             [STATUS] running=N/GLOBAL_DISPATCH_BUDGET | env@done/target +delta in Xs rate:Y/h
                 run:R | env2@... | total +D in Xs rate:Y/h
@@ -148,18 +166,19 @@ class ExecutorManager:
         tids = await sc.get_param_value("current_task_ids") or {}
         champion = await sc.get_param_value("champion") or {}
         battle = await sc.get_param_value("current_battle") or {}
+        envs_raw = await sc.get_param_value("environments", default={}) or {}
         task_ids_by_env: Dict[str, List[int]] = tids.get("task_ids", {}) or {}
         refresh_block = int(tids.get("refreshed_at_block", 0) or 0)
-        subjects: List[tuple[str, str]] = []
+        subjects: List[tuple[str, str, str]] = []
         if champion.get("hotkey") and champion.get("revision"):
-            subjects.append((str(champion["hotkey"]), str(champion["revision"])))
+            subjects.append(("champion", str(champion["hotkey"]), str(champion["revision"])))
         challenger = battle.get("challenger") if isinstance(battle, dict) else None
         if (
             isinstance(challenger, dict)
             and challenger.get("hotkey")
             and challenger.get("revision")
         ):
-            pair = (str(challenger["hotkey"]), str(challenger["revision"]))
+            pair = ("challenger", str(challenger["hotkey"]), str(challenger["revision"]))
             if pair not in subjects:
                 subjects.append(pair)
 
@@ -174,14 +193,20 @@ class ExecutorManager:
 
         for env in sorted(self.envs):
             ids = task_ids_by_env.get(env, []) or []
-            target = len(ids) * max(1, len(subjects))
+            sampling_count = _sampling_count_for_env(envs_raw, env, len(ids))
+            subject_targets = {
+                "champion": len(ids),
+                "challenger": min(len(ids), sampling_count),
+            }
+            target = sum(subject_targets[kind] for kind, _, _ in subjects)
             done = 0
             if ids and subjects and refresh_block:
-                for hk, rev in subjects:
+                for kind, hk, rev in subjects:
                     try:
-                        done += await samples.count_samples_for_tasks(
+                        count = await samples.count_samples_for_tasks(
                             hk, rev, env, ids, refresh_block=refresh_block,
                         )
+                        done += min(count, subject_targets[kind])
                     except Exception as e:
                         logger.debug(f"status count failed for {env}: {e}")
             running = int(self.in_flight_values[env].value)
@@ -299,7 +324,13 @@ def _compute_adaptive_env_caps(
         return {env: initial for env in envs}
     fair = _initial_env_cap(active, global_budget)
     floor = max(1, fair // 8)
-    caps: Dict[str, int] = {env: floor for env in envs}
+    # Envs with no current work keep their previous cap so a new battle
+    # can ramp immediately between status ticks. They do not enter the
+    # active budget math below because they are not consuming slots.
+    caps: Dict[str, int] = {
+        env: max(floor, int(previous_caps.get(env, fair) or fair))
+        for env in envs
+    }
     weights: Dict[str, float] = {}
     for env in active:
         row = stats.get(env, {})
@@ -311,19 +342,19 @@ def _compute_adaptive_env_caps(
         prev = max(1, int(previous_caps.get(env, fair) or fair))
         if remaining <= 0:
             # Let existing calls drain; do not launch a new wave for an
-            # env whose current subject set is complete. Keep the probe
-            # floor so a newly started battle is not stuck at one-at-a-time
+            # env whose current subject set is complete. Keep fair share
+            # ready so a newly started battle is not stuck at one-at-a-time
             # until the next status interval.
-            caps[env] = max(floor, min(prev, running or floor))
+            caps[env] = max(fair, min(prev, running or fair))
             continue
 
         saturated = running >= max(floor, int(prev * 0.75))
         if saturated:
             if delta <= 0:
                 # Saturated but no recent completions: preserve a bounded
-                # share so long-running calls can finish, but do not add
-                # more pressure to a possibly stuck env.
-                caps[env] = max(floor, min(prev, running or floor))
+                # fair-share launch cap so long-running calls can finish,
+                # but do not keep a previously inflated cap forever.
+                caps[env] = max(floor, min(prev, fair))
                 continue
             # Saturated envs compete for the shared budget by pressure.
             # Keep only the probe floor before allocation so a nearly done
@@ -341,9 +372,16 @@ def _compute_adaptive_env_caps(
             # this local-demand cap and do not receive extra budget.
             caps[env] = max(floor, min(prev, running + floor))
 
-    total = sum(caps.values())
+    total = sum(caps[env] for env in active)
     if total > global_budget:
-        return _trim_caps(caps, global_budget=global_budget, floor=1)
+        caps.update(
+            _trim_caps(
+                {env: caps[env] for env in active},
+                global_budget=global_budget,
+                floor=1,
+            )
+        )
+        return caps
 
     extra = global_budget - total
     if extra <= 0 or not weights:
@@ -366,7 +404,33 @@ def _compute_adaptive_env_caps(
         used += 1
     for env, add in allocations.items():
         caps[env] += add
-    return _trim_caps(caps, global_budget=global_budget, floor=1)
+    caps.update(
+        _trim_caps(
+            {env: caps[env] for env in active},
+            global_budget=global_budget,
+            floor=1,
+        )
+    )
+    return caps
+
+
+def _sampling_count_for_env(envs_raw: Any, env: str, default: int) -> int:
+    if not isinstance(envs_raw, dict):
+        return default
+    cfg = envs_raw.get(env) or {}
+    if not isinstance(cfg, dict):
+        return default
+    sampling = cfg.get("sampling") or cfg.get("window_config") or {}
+    if not isinstance(sampling, dict):
+        return default
+    raw = sampling.get("sampling_count", default)
+    if raw is None:
+        return default
+    try:
+        count = int(raw)
+    except (TypeError, ValueError):
+        return default
+    return max(0, count)
 
 
 def _trim_caps(caps: Dict[str, int], *, global_budget: int, floor: int) -> Dict[str, int]:

--- a/affine/src/executor/worker.py
+++ b/affine/src/executor/worker.py
@@ -16,7 +16,6 @@ from __future__ import annotations
 import asyncio
 import random
 import time
-from contextlib import nullcontext
 from typing import Any, Dict, List, Optional
 
 from affine.core.setup import logger
@@ -47,28 +46,21 @@ class ExecutorWorker:
         warmup_sec: float = 240.0,
         global_sem: Any = None,
         in_flight_value: Any = None,
-        env_concurrency_cap: Optional[int] = None,
+        env_cap_value: Any = None,
     ):
         self.worker_id = worker_id
         self.env = env
         self.max_concurrent = max_concurrent
         # Cross-process ``BoundedSemaphore`` (or ``None`` in unit tests /
         # standalone runs). Real backpressure runs through this — see
-        # ``_acquire_global_slot`` below. The per-tick local semaphore
-        # is sized at ``max_concurrent`` and only exists as a defensive
-        # floor against scheduling tens of thousands of coroutines.
+        # ``_acquire_global_slot`` below. ``max_concurrent`` remains as a
+        # standalone fallback for tests/local runs; production workers read
+        # their live cap from ``_env_cap_value``.
         self._global_sem = global_sem
-        # Optional in-process asyncio semaphore that caps concurrent
-        # evaluate() calls for THIS env's worker. Set from
-        # ``EnvConfig.max_concurrent`` so a flaky env can't burn the
-        # whole global dispatch budget retrying — see LIVEWEB
-        # Stooq-lock incident, PR #459. None = no per-env cap.
-        self.env_concurrency_cap = env_concurrency_cap
-        self._env_sem: Optional[asyncio.Semaphore] = (
-            asyncio.Semaphore(env_concurrency_cap)
-            if env_concurrency_cap is not None and env_concurrency_cap > 0
-            else None
-        )
+        # Manager-updated dynamic cap for this env. The worker reads this
+        # before acquiring the global semaphore, so cap changes take effect
+        # without restarting the subprocess.
+        self._env_cap_value = env_cap_value
         # Per-env ``mp.Value(c_int, lock=False)`` for the manager's
         # ``[STATUS]`` printer to read live in-flight without IPC ping.
         # Single writer (this worker), single reader (manager); aligned
@@ -441,25 +433,41 @@ class ExecutorWorker:
             hotkey=miner.hotkey, model=miner.model, revision=miner.revision,
             base_url=base_url,
         )
-        # Per-env cap (if configured) is acquired BEFORE the global slot
-        # so a flaky env can't transiently hold global capacity while
-        # waiting on its own sem. ``nullcontext`` makes this a no-op for
-        # envs without a cap.
-        env_gate = self._env_sem if self._env_sem is not None else nullcontext()
-        async with env_gate:
-            await self._evaluate_and_persist_gated(
-                miner=miner, task_id=task_id, base_url=base_url,
-                refresh_block=refresh_block, miner_obj=miner_obj,
-            )
+        await self._evaluate_and_persist_gated(
+            miner=miner, task_id=task_id, base_url=base_url,
+            refresh_block=refresh_block, miner_obj=miner_obj,
+        )
+
+    def _current_env_cap(self) -> int:
+        if self._env_cap_value is None:
+            return max(1, int(self.max_concurrent))
+        return max(1, int(self._env_cap_value.value))
+
+    def _current_env_in_flight(self) -> int:
+        if self._in_flight_value is not None:
+            return max(0, int(self._in_flight_value.value))
+        return max(0, int(self.metrics.tasks_in_flight))
+
+    async def _acquire_dispatch_slot(self) -> None:
+        """Acquire this env's dynamic share, then one global slot.
+
+        The cap is rechecked after acquiring the global slot because the
+        manager can lower it while this coroutine is waiting.
+        """
+        while True:
+            while self._current_env_in_flight() >= self._current_env_cap():
+                await asyncio.sleep(0.05)
+            await self._acquire_global_slot()
+            if self._current_env_in_flight() < self._current_env_cap():
+                return
+            self._release_global_slot()
+            await asyncio.sleep(0.05)
 
     async def _evaluate_and_persist_gated(
         self, *, miner: MinerSnapshot, task_id: int, base_url: str,
         refresh_block: int, miner_obj: "_Miner",
     ) -> None:
-        # Wait until the cross-process global semaphore yields a slot.
-        # The per-env semaphore has already bounded this worker's share,
-        # so fast retry loops cannot crowd out slower envs here.
-        await self._acquire_global_slot()
+        await self._acquire_dispatch_slot()
         started = time.monotonic()
         # Track real in-flight concurrency. Two counters intentionally:
         # ``metrics.tasks_in_flight`` is in-process for ``af db worker-status``

--- a/affine/src/executor/worker.py
+++ b/affine/src/executor/worker.py
@@ -155,9 +155,8 @@ class ExecutorWorker:
 
         Net effect: a tick that contains 200 SWE-INFINITE tasks no
         longer waits for the slowest task to finish before dispatching
-        peer task_ids. The global ``BoundedSemaphore(480)`` remains the
-        only concurrency gate; per-env env-container capacity is the
-        downstream physical bottleneck (operator dial).
+        peer task_ids. The per-env cap is applied before the shared
+        global semaphore so fast-cycling envs cannot monopolize it.
         """
         assert self._state and self._samples, "call initialize() first"
         status_task = asyncio.create_task(self._publish_status_loop())
@@ -296,11 +295,10 @@ class ExecutorWorker:
             that, overlap is sufficient and continuing adds no
             comparator signal.
 
-        Concurrency: the cross-process ``self._global_sem`` (480 by
-        default = b300 saturation) is the only gate. No per-env local
-        semaphore — env-container capacity is the physical bottleneck
-        downstream, and we want every un-sampled task_id contending for
-        a global slot so slow peers can't hide free capacity.
+        Concurrency: candidates pass the optional per-env semaphore first,
+        then the shared cross-process global semaphore. This keeps all
+        envs streaming while bounding how much of the global budget one
+        env can occupy.
         """
         task_state = await self._state.get_task_state()
         if task_state is None:
@@ -459,9 +457,8 @@ class ExecutorWorker:
         refresh_block: int, miner_obj: "_Miner",
     ) -> None:
         # Wait until the cross-process global semaphore yields a slot.
-        # Envs with bigger pending lists submit more concurrent acquire
-        # attempts and so win a proportional share of the b300 budget —
-        # that's the cross-env priority, no explicit queue needed.
+        # The per-env semaphore has already bounded this worker's share,
+        # so fast retry loops cannot crowd out slower envs here.
         await self._acquire_global_slot()
         started = time.monotonic()
         # Track real in-flight concurrency. Two counters intentionally:

--- a/affine/src/executor/worker.py
+++ b/affine/src/executor/worker.py
@@ -315,12 +315,12 @@ class ExecutorWorker:
         sampling_count = env_cfg.sampling_count
 
         champion = await self._state.get_champion()
-        champion_urls = _base_urls(
-            champion.deployments if champion else [],
-            champion.base_url if champion else None,
-        )
-        if champion is None or not champion_urls:
+        if champion is None:
             return 0
+        champion_urls = _base_urls(
+            champion.deployments,
+            champion.base_url,
+        )
 
         battle = await self._state.get_battle()
         battle_urls = _base_urls(
@@ -328,24 +328,32 @@ class ExecutorWorker:
             battle.base_url if battle else None,
         )
 
+        # Single-instance providers deliberately clear champion.deployment_id
+        # at battle start (the host is now serving the challenger). In that
+        # state we still need to dispatch challenger samples — bail out
+        # only when nobody has a serving URL.
+        if not champion_urls and not battle_urls:
+            return 0
+
         # Build the candidate pool: champion drains everything; challenger
         # is capped by ``sampling_count``. We shuffle so persistently slow
         # task_ids don't always end up at the tail across worker restarts.
         candidates: List[tuple] = []
-        champ_snap = MinerSnapshot(
-            uid=champion.uid, hotkey=champion.hotkey,
-            revision=champion.revision, model=champion.model,
-        )
-        for idx, tid in enumerate(task_ids):
-            key = (champion.hotkey, champion.revision, int(tid))
-            if key in in_flight_keys:
-                continue
-            if await self._samples.has_sample(
-                champion.hotkey, champion.revision, self.env, tid,
-                refresh_block=refresh_block,
-            ):
-                continue
-            candidates.append((key, champ_snap, tid, _pick_url(champion_urls, tid, idx)))
+        if champion_urls:
+            champ_snap = MinerSnapshot(
+                uid=champion.uid, hotkey=champion.hotkey,
+                revision=champion.revision, model=champion.model,
+            )
+            for idx, tid in enumerate(task_ids):
+                key = (champion.hotkey, champion.revision, int(tid))
+                if key in in_flight_keys:
+                    continue
+                if await self._samples.has_sample(
+                    champion.hotkey, champion.revision, self.env, tid,
+                    refresh_block=refresh_block,
+                ):
+                    continue
+                candidates.append((key, champ_snap, tid, _pick_url(champion_urls, tid, idx)))
 
         if battle is not None and battle_urls:
             chal_have = await self._samples.count_samples_for_tasks(

--- a/affine/src/executor/worker_process.py
+++ b/affine/src/executor/worker_process.py
@@ -21,8 +21,8 @@ def run_worker_subprocess(
     max_concurrent: int,
     global_sem: Any,
     in_flight_value: Any,
+    env_cap_value: Any,
     verbosity: int = 1,
-    env_concurrency_cap: Optional[int] = None,
 ) -> None:
     """Subprocess entry point — runs one ExecutorWorker until killed.
 
@@ -30,9 +30,8 @@ def run_worker_subprocess(
     worker contends on before each evaluate. It's the real concurrency
     gate; the per-worker ``max_concurrent`` is a defensive floor.
 
-    ``env_concurrency_cap`` is the optional per-env in-flight evaluate
-    cap (an asyncio semaphore inside this process). ``None`` means no
-    extra cap — only the global semaphore gates dispatch.
+    ``env_cap_value`` is a manager-updated ``multiprocessing.Value`` holding
+    this env's current dynamic cap.
 
     ``in_flight_value`` is a ``multiprocessing.Value(c_int, lock=False)``
     the worker increments/decrements around each evaluate so the manager
@@ -50,7 +49,7 @@ def run_worker_subprocess(
         worker = ExecutorWorker(
             worker_id=worker_id, env=env, max_concurrent=max_concurrent,
             global_sem=global_sem, in_flight_value=in_flight_value,
-            env_concurrency_cap=env_concurrency_cap,
+            env_cap_value=env_cap_value,
         )
         loop.run_until_complete(worker.initialize())
         worker.start()
@@ -88,18 +87,18 @@ class WorkerProcess:
         env: str,
         global_sem: Any,
         in_flight_value: Any,
+        env_cap_value: Any,
         *,
         max_concurrent: int = 60,
         verbosity: int = 1,
-        env_concurrency_cap: Optional[int] = None,
     ):
         self.worker_id = worker_id
         self.env = env
         self.max_concurrent = max_concurrent
         self.global_sem = global_sem
         self.in_flight_value = in_flight_value
+        self.env_cap_value = env_cap_value
         self.verbosity = verbosity
-        self.env_concurrency_cap = env_concurrency_cap
         self._proc: Optional[multiprocessing.Process] = None
 
     def start(self) -> None:
@@ -108,15 +107,12 @@ class WorkerProcess:
             target=run_worker_subprocess,
             args=(self.worker_id, self.env, self.max_concurrent,
                   self.global_sem, self.in_flight_value,
-                  self.verbosity, self.env_concurrency_cap),
+                  self.env_cap_value, self.verbosity),
             name=f"executor-{self.env}",
             daemon=False,
         )
         self._proc.start()
-        cap_str = (
-            f", env_cap={self.env_concurrency_cap}"
-            if self.env_concurrency_cap is not None else ""
-        )
+        cap_str = f", env_cap={int(self.env_cap_value.value)}"
         logger.info(
             f"[{self.env}] subprocess started pid={self._proc.pid}{cap_str}"
         )

--- a/affine/src/scheduler/flow.py
+++ b/affine/src/scheduler/flow.py
@@ -455,6 +455,13 @@ class FlowScheduler:
             base_url=result.base_url,
             started_at_block=current_block,
             deployments=_deployments_from_result(result),
+            # Captured BEFORE ``set_champion(new)`` ever runs so the
+            # _decide recovery branch can still terminate the old
+            # champion and re-emit weights after a mid-flow crash.
+            previous_champion=MinerSnapshot(
+                uid=champion.uid, hotkey=champion.hotkey,
+                revision=champion.revision, model=champion.model,
+            ),
         )
         await self.state.set_battle(battle)
         logger.info(
@@ -504,6 +511,57 @@ class FlowScheduler:
                 revision=champion.revision,
                 model=champion.model,
             )
+            # Old champion must also be flipped to ``terminated`` and the
+            # on-chain weight tx re-emitted — both got skipped if the
+            # crash happened between ``set_champion(new)`` and those
+            # steps. ``previous_champion`` is captured at battle start so
+            # we can still identify them after the canonical champion
+            # record was overwritten. The reason string mirrors the
+            # normal-path one in spirit but names the path explicitly:
+            # if the crash hit after ``mark_terminated(LOST)`` already
+            # ran, this write will overwrite the (more detailed) original
+            # reason — acceptable since both leave the row terminated.
+            prev = battle.previous_champion
+            prev_ready = (
+                prev is not None
+                and prev.uid != champion.uid
+                and prev.hotkey
+                and prev.revision
+            )
+            if prev_ready:
+                await self.queue.mark_terminated(
+                    prev.uid,
+                    OUTCOME_LOST,
+                    reason=f"dethroned_by:{champion.hotkey[:10]}:recovery",
+                    hotkey=prev.hotkey,
+                    revision=prev.revision,
+                    model=prev.model,
+                )
+                # ``result=None`` is fine — the comparator-derived per-env
+                # metadata becomes empty dicts; the actual weight tx
+                # (1.0 for champion, 0 for the rest) still happens.
+                try:
+                    await self._write_weights(
+                        champion, current_block, None, previous_champion=prev,
+                    )
+                except Exception as e:
+                    logger.error(
+                        f"FlowScheduler: recovery weight write failed: "
+                        f"{type(e).__name__}: {e}"
+                    )
+            elif prev is None:
+                logger.warning(
+                    "FlowScheduler: recovery path lacked previous_champion "
+                    "(pre-fix battle record); old champion not terminated "
+                    "and weights not re-emitted — operator must verify."
+                )
+            else:
+                logger.warning(
+                    f"FlowScheduler: recovery saw malformed previous_champion "
+                    f"(uid={prev.uid}, hotkey={prev.hotkey!r}, "
+                    f"revision={prev.revision!r}); skipping termination + "
+                    f"weight re-emit, operator must verify."
+                )
             await self.state.clear_battle()
             return
 

--- a/affine/src/scorer/window_state.py
+++ b/affine/src/scorer/window_state.py
@@ -66,12 +66,23 @@ class ChampionRecord:
 @dataclass
 class BattleRecord:
     """An in-flight contest. The challenger's Targon workload only lives
-    as long as this record does."""
+    as long as this record does.
+
+    ``previous_champion`` captures the champion's identity at the moment
+    ``_start_battle`` ran. We need this for recovery: if the scheduler
+    crashes between ``set_champion(new)`` and ``clear_battle()``, the
+    canonical champion record has already been overwritten with the
+    challenger, so we'd lose the old champion's UID/hotkey — and miss
+    marking them ``terminated`` and re-emitting weights. Optional only
+    for backward compat with battle rows written before this field
+    existed.
+    """
     challenger: MinerSnapshot
     deployment_id: str
     base_url: str
     started_at_block: int
     deployments: List[DeploymentRecord] = field(default_factory=list)
+    previous_champion: Optional[MinerSnapshot] = None
 
 
 @dataclass
@@ -332,13 +343,16 @@ def _champion_from_dict(raw: Dict[str, Any]) -> ChampionRecord:
 
 
 def _battle_to_dict(b: BattleRecord) -> Dict[str, Any]:
-    return {
+    out: Dict[str, Any] = {
         "challenger": asdict(b.challenger),
         "deployment_id": b.deployment_id,
         "base_url": b.base_url,
         "started_at_block": b.started_at_block,
         "deployments": [asdict(d) for d in b.deployments],
     }
+    if b.previous_champion is not None:
+        out["previous_champion"] = asdict(b.previous_champion)
+    return out
 
 
 def _battle_from_dict(raw: Dict[str, Any]) -> BattleRecord:
@@ -350,6 +364,13 @@ def _battle_from_dict(raw: Dict[str, Any]) -> BattleRecord:
         primary_id, primary_url = _primary_deployment(deployments)
         deployment_id = primary_id or ""
         base_url = primary_url or ""
+    prev_raw = raw.get("previous_champion") or {}
+    previous_champion: Optional[MinerSnapshot] = None
+    if isinstance(prev_raw, dict) and prev_raw.get("hotkey"):
+        previous_champion = MinerSnapshot(**{
+            k: prev_raw[k] for k in ("uid", "hotkey", "revision", "model")
+            if k in prev_raw
+        })
     return BattleRecord(
         challenger=MinerSnapshot(**{
             k: chal_raw[k] for k in ("uid", "hotkey", "revision", "model")
@@ -359,6 +380,7 @@ def _battle_from_dict(raw: Dict[str, Any]) -> BattleRecord:
         base_url=base_url,
         started_at_block=int(raw.get("started_at_block", 0)),
         deployments=deployments,
+        previous_champion=previous_champion,
     )
 
 

--- a/affine/src/scorer/window_state.py
+++ b/affine/src/scorer/window_state.py
@@ -109,13 +109,6 @@ class EnvConfig:
     # task_ids (SWE-INFINITE, DISTILL) always sample the freshest tail.
     # Shape: ``{"url": str, "field": str, "range_type": "zero_to_value"}``.
     dataset_range_source: Optional[Dict[str, Any]] = None
-    # Optional per-env in-flight evaluate cap. When ``None`` the env
-    # only contends on the shared global semaphore. When set, an
-    # additional asyncio semaphore in the env's worker subprocess caps
-    # concurrent evaluate() calls to this many — used to isolate flaky
-    # envs (LIVEWEB infra-retry storm in PR #459) so their failure loops
-    # cannot starve other envs out of the global dispatch budget.
-    max_concurrent: Optional[int] = None
 
 
 # ---- store protocol -------------------------------------------------------
@@ -377,16 +370,6 @@ def _env_from_payload(payload: Any) -> EnvConfig:
         )
     sampling = payload.get("sampling") or payload.get("window_config") or {}
     src = sampling.get("dataset_range_source")
-    raw_cap = sampling.get("max_concurrent")
-    cap: Optional[int] = None
-    if isinstance(raw_cap, bool):
-        # bool is an int subclass; ignore stray True/False so we don't
-        # silently end up with cap=1 from ``max_concurrent: True``.
-        cap = None
-    elif isinstance(raw_cap, int) and raw_cap > 0:
-        cap = raw_cap
-    elif isinstance(raw_cap, str) and raw_cap.isdigit() and int(raw_cap) > 0:
-        cap = int(raw_cap)
     return EnvConfig(
         display_name=str(payload.get("display_name", "")),
         enabled_for_sampling=bool(payload.get("enabled_for_sampling", False)),
@@ -398,5 +381,4 @@ def _env_from_payload(payload: Any) -> EnvConfig:
         dataset_range=list(sampling.get("dataset_range", []) or []),
         sampling_mode=str(sampling.get("sampling_mode", "random")),
         dataset_range_source=src if isinstance(src, dict) else None,
-        max_concurrent=cap,
     )

--- a/tests/test_executor_worker.py
+++ b/tests/test_executor_worker.py
@@ -340,3 +340,146 @@ def test_adaptive_caps_release_completed_env_capacity():
 
     assert 1 < caps["MEMORY"] < caps["TERMINAL"]
     assert caps["TERMINAL"] > 150
+
+
+def test_dispatch_proceeds_when_only_battle_has_url():
+    """Regression: under SSH single-instance providers, ``_start_battle``
+    clears the champion's deployment so the host can serve the
+    challenger. Without this guard, ``_dispatch_new`` exits early
+    (no champion URL → return 0) and the challenger never gets sampled,
+    so ``_battle_overlap_ready`` never satisfies and the battle stalls.
+    """
+    import asyncio as _asyncio
+    from affine.src.executor.worker import ExecutorWorker
+    from affine.src.scorer.window_state import (
+        BattleRecord, ChampionRecord, DeploymentRecord, EnvConfig,
+        MinerSnapshot, TaskIdState,
+    )
+
+    worker = ExecutorWorker(worker_id=0, env="ENV_A")
+    worker.warmup_sec = 0  # skip — not testing run-loop
+
+    class _StateStub:
+        async def get_task_state(self):
+            return TaskIdState(
+                task_ids={"ENV_A": [1, 2, 3]}, refreshed_at_block=0,
+            )
+
+        async def get_environments(self):
+            return {
+                "ENV_A": EnvConfig(
+                    display_name="ENV_A", enabled_for_sampling=True,
+                    sampling_count=3, dataset_range=[[0, 100]],
+                ),
+            }
+
+        async def get_champion(self):
+            # Champion exists but has no live deployment — exactly the
+            # state after single-instance ``_start_battle`` clears it.
+            return ChampionRecord(
+                uid=1, hotkey="champ_hk", revision="champ_rev",
+                model="org/m1", deployment_id=None, base_url=None,
+                deployments=[], since_block=0,
+            )
+
+        async def get_battle(self):
+            return BattleRecord(
+                challenger=MinerSnapshot(
+                    uid=2, hotkey="chal_hk", revision="chal_rev",
+                    model="org/m2",
+                ),
+                deployment_id="wrk-bat",
+                base_url="https://t/wrk-bat",
+                started_at_block=0,
+                deployments=[
+                    DeploymentRecord(
+                        endpoint_name="b300",
+                        deployment_id="wrk-bat",
+                        base_url="https://t/wrk-bat",
+                    ),
+                ],
+            )
+
+    class _SamplesStub:
+        async def has_sample(self, *a, **kw):
+            return False
+
+        async def count_samples_for_tasks(self, *a, **kw):
+            return 0
+
+    dispatched: list = []
+
+    async def _capture_dispatch_one(*, miner, task_id, base_url, **_kwargs):
+        dispatched.append((miner.uid, task_id, base_url))
+
+    worker._state = _StateStub()
+    worker._samples = _SamplesStub()
+    worker._dispatch_one = _capture_dispatch_one
+
+    async def _drive():
+        in_flight_keys: set = set()
+        in_flight_tasks: set = set()
+        n = await worker._dispatch_new(in_flight_keys, in_flight_tasks)
+        # All pending in-flight task wrappers are fire-and-forget — give
+        # them a tick to record into ``dispatched``.
+        await _asyncio.sleep(0)
+        return n
+
+    n = _asyncio.run(_drive())
+
+    # No champion candidates (no URL), but challenger candidates fire.
+    assert n == 3, f"expected 3 challenger dispatches, got {n}"
+    assert all(uid == 2 for uid, _, _ in dispatched), dispatched
+    assert all(url == "https://t/wrk-bat" for _, _, url in dispatched), dispatched
+
+
+def test_dispatch_skips_when_neither_has_url():
+    """If neither champion nor battle has a serving URL there's
+    genuinely nothing to dispatch — bail out fast."""
+    import asyncio as _asyncio
+    from affine.src.executor.worker import ExecutorWorker
+    from affine.src.scorer.window_state import (
+        ChampionRecord, EnvConfig, TaskIdState,
+    )
+
+    worker = ExecutorWorker(worker_id=0, env="ENV_A")
+    worker.warmup_sec = 0
+
+    class _StateStub:
+        async def get_task_state(self):
+            return TaskIdState(
+                task_ids={"ENV_A": [1, 2, 3]}, refreshed_at_block=0,
+            )
+
+        async def get_environments(self):
+            return {
+                "ENV_A": EnvConfig(
+                    display_name="ENV_A", enabled_for_sampling=True,
+                    sampling_count=3, dataset_range=[[0, 100]],
+                ),
+            }
+
+        async def get_champion(self):
+            return ChampionRecord(
+                uid=1, hotkey="champ_hk", revision="champ_rev",
+                model="org/m1", deployment_id=None, base_url=None,
+                deployments=[], since_block=0,
+            )
+
+        async def get_battle(self):
+            return None
+
+    class _SamplesStub:
+        async def has_sample(self, *a, **kw):
+            return False
+
+        async def count_samples_for_tasks(self, *a, **kw):
+            return 0
+
+    worker._state = _StateStub()
+    worker._samples = _SamplesStub()
+
+    async def _drive():
+        return await worker._dispatch_new(set(), set())
+
+    assert _asyncio.run(_drive()) == 0

--- a/tests/test_executor_worker.py
+++ b/tests/test_executor_worker.py
@@ -300,3 +300,42 @@ def test_env_from_payload_rejects_nonpositive_max_concurrent():
             "sampling": {"max_concurrent": bad},
         })
         assert cfg.max_concurrent is None, f"bad input {bad!r} leaked through"
+
+
+def test_compute_env_caps_defaults_to_fair_share():
+    from affine.src.executor.main import _compute_env_caps
+
+    caps = _compute_env_caps(
+        ["LIVEWEB", "MEMORY", "NAVWORLD", "SWE-INFINITE", "TERMINAL"],
+        {},
+        global_budget=600,
+    )
+
+    assert caps == {
+        "LIVEWEB": 120,
+        "MEMORY": 120,
+        "NAVWORLD": 120,
+        "SWE-INFINITE": 120,
+        "TERMINAL": 120,
+    }
+
+
+def test_compute_env_caps_allows_explicit_override():
+    from affine.src.executor.main import _compute_env_caps
+
+    caps = _compute_env_caps(
+        ["LIVEWEB", "MEMORY", "NAVWORLD"],
+        {
+            "LIVEWEB": {
+                "enabled_for_sampling": True,
+                "sampling": {"max_concurrent": 80},
+            },
+        },
+        global_budget=300,
+    )
+
+    assert caps == {
+        "LIVEWEB": 80,
+        "MEMORY": 110,
+        "NAVWORLD": 110,
+    }

--- a/tests/test_executor_worker.py
+++ b/tests/test_executor_worker.py
@@ -159,183 +159,184 @@ def test_global_slot_helpers_noop_when_unwired():
     _asyncio.run(_drive())
 
 
-def test_env_concurrency_cap_none_means_no_env_semaphore():
+class _SharedInt:
+    def __init__(self, value: int):
+        self.value = value
+
+
+def test_dynamic_env_cap_defaults_to_max_concurrent_without_shared_value():
     from affine.src.executor.worker import ExecutorWorker
 
-    worker = ExecutorWorker(worker_id=0, env="MEMORY")
-    assert worker._env_sem is None
+    worker = ExecutorWorker(worker_id=0, env="MEMORY", max_concurrent=17)
+    assert worker._current_env_cap() == 17
 
 
-def test_env_concurrency_cap_creates_asyncio_semaphore():
-    import asyncio as _asyncio
+def test_dynamic_env_cap_reads_shared_value_live():
     from affine.src.executor.worker import ExecutorWorker
 
+    cap = _SharedInt(3)
     worker = ExecutorWorker(
-        worker_id=0, env="LIVEWEB", env_concurrency_cap=100,
-    )
-    assert isinstance(worker._env_sem, _asyncio.Semaphore)
-    # Acquire 100 times; the 101st should not be immediately available.
-    async def _drive():
-        for _ in range(100):
-            await worker._env_sem.acquire()
-        assert worker._env_sem.locked()
-
-    _asyncio.run(_drive())
-
-
-def test_env_sem_caps_in_flight_evaluate_and_persist():
-    """Per-env cap must serialise concurrent evaluate calls inside one
-    worker. Without it, a flaky env's infra-retry storm can occupy the
-    entire global dispatch budget — exactly the LIVEWEB Stooq-lock
-    incident this knob exists to prevent."""
-    import asyncio as _asyncio
-    from affine.src.executor.worker import ExecutorWorker
-    from affine.src.scorer.window_state import MinerSnapshot
-
-    worker = ExecutorWorker(
-        worker_id=0, env="LIVEWEB", env_concurrency_cap=2,
+        worker_id=0, env="LIVEWEB", max_concurrent=500, env_cap_value=cap,
     )
 
-    observed_peak = {"value": 0}
-    in_flight = {"value": 0}
-
-    async def _fake_gated(**_kwargs):
-        in_flight["value"] += 1
-        observed_peak["value"] = max(observed_peak["value"], in_flight["value"])
-        try:
-            await _asyncio.sleep(0.05)
-        finally:
-            in_flight["value"] -= 1
-
-    worker._evaluate_and_persist_gated = _fake_gated
-
-    miner = MinerSnapshot(uid=1, hotkey="hk", model="m", revision="r")
-
-    async def _drive():
-        # Five concurrent calls; cap=2 should keep peak at 2.
-        await _asyncio.gather(*[
-            worker._evaluate_and_persist(
-                miner=miner, task_id=i, base_url="http://x",
-                refresh_block=0,
-            )
-            for i in range(5)
-        ])
-        assert observed_peak["value"] == 2
-
-    _asyncio.run(_drive())
+    assert worker._current_env_cap() == 3
+    cap.value = 8
+    assert worker._current_env_cap() == 8
 
 
-def test_env_sem_unset_does_not_serialise_calls():
-    """Without a cap, the outer wrapper must be a no-op — concurrent
-    evaluate calls all proceed in parallel up to the global semaphore."""
+def test_dynamic_dispatch_slot_waits_for_env_cap_room():
     import asyncio as _asyncio
     from affine.src.executor.worker import ExecutorWorker
-    from affine.src.scorer.window_state import MinerSnapshot
 
-    worker = ExecutorWorker(worker_id=0, env="MEMORY")  # no cap
-    observed_peak = {"value": 0}
-    in_flight = {"value": 0}
+    cap = _SharedInt(2)
+    in_flight = _SharedInt(2)
+    worker = ExecutorWorker(
+        worker_id=0, env="LIVEWEB", env_cap_value=cap, in_flight_value=in_flight,
+    )
+    acquired = {"value": 0}
 
-    async def _fake_gated(**_kwargs):
-        in_flight["value"] += 1
-        observed_peak["value"] = max(observed_peak["value"], in_flight["value"])
-        try:
-            await _asyncio.sleep(0.05)
-        finally:
-            in_flight["value"] -= 1
+    async def _fake_global():
+        acquired["value"] += 1
 
-    worker._evaluate_and_persist_gated = _fake_gated
-
-    miner = MinerSnapshot(uid=1, hotkey="hk", model="m", revision="r")
+    worker._acquire_global_slot = _fake_global
 
     async def _drive():
-        await _asyncio.gather(*[
-            worker._evaluate_and_persist(
-                miner=miner, task_id=i, base_url="http://x",
-                refresh_block=0,
-            )
-            for i in range(5)
-        ])
-        assert observed_peak["value"] == 5
+        waiter = _asyncio.create_task(worker._acquire_dispatch_slot())
+        await _asyncio.sleep(0.12)
+        assert acquired["value"] == 0
+        assert not waiter.done()
+
+        in_flight.value = 1
+        await _asyncio.wait_for(waiter, timeout=1.0)
+        assert acquired["value"] == 1
 
     _asyncio.run(_drive())
 
 
-def test_env_from_payload_parses_max_concurrent():
+def test_dynamic_dispatch_slot_releases_global_if_cap_drops_after_acquire():
+    import asyncio as _asyncio
+    from affine.src.executor.worker import ExecutorWorker
+
+    cap = _SharedInt(2)
+    in_flight = _SharedInt(1)
+    worker = ExecutorWorker(
+        worker_id=0, env="LIVEWEB", env_cap_value=cap, in_flight_value=in_flight,
+    )
+    acquired = {"value": 0}
+    released = {"value": 0}
+
+    async def _fake_global():
+        acquired["value"] += 1
+        cap.value = 1
+
+    def _fake_release():
+        released["value"] += 1
+        in_flight.value = 0
+
+    worker._acquire_global_slot = _fake_global
+    worker._release_global_slot = _fake_release
+
+    async def _drive():
+        await _asyncio.wait_for(worker._acquire_dispatch_slot(), timeout=1.0)
+        assert acquired["value"] == 2
+        assert released["value"] == 1
+
+    _asyncio.run(_drive())
+
+
+def test_env_from_payload_ignores_static_max_concurrent():
     from affine.src.scorer.window_state import _env_from_payload
 
     cfg = _env_from_payload({
         "display_name": "LIVEWEB",
         "enabled_for_sampling": True,
-        "sampling": {
-            "sampling_count": 400,
-            "dataset_range": [[0, 100]],
-            "sampling_mode": "random",
-            "max_concurrent": 100,
+        "sampling": {"sampling_count": 400, "max_concurrent": 100},
+    })
+    assert not hasattr(cfg, "max_concurrent")
+
+
+def test_adaptive_caps_keep_probe_floor_for_backlogged_envs():
+    from affine.src.executor.main import _compute_adaptive_env_caps
+
+    caps = _compute_adaptive_env_caps(
+        ["LIVEWEB", "MEMORY", "NAVWORLD", "SWE-INFINITE"],
+        {
+            env: {"target": 100, "done": 0, "running": 0, "delta": 0}
+            for env in ["LIVEWEB", "MEMORY", "NAVWORLD", "SWE-INFINITE"]
         },
-    })
-    assert cfg.max_concurrent == 100
-
-
-def test_env_from_payload_max_concurrent_defaults_to_none():
-    from affine.src.scorer.window_state import _env_from_payload
-
-    cfg = _env_from_payload({
-        "display_name": "MEMORY",
-        "enabled_for_sampling": True,
-        "sampling": {"sampling_count": 200, "dataset_range": [[0, 10]]},
-    })
-    assert cfg.max_concurrent is None
-
-
-def test_env_from_payload_rejects_nonpositive_max_concurrent():
-    from affine.src.scorer.window_state import _env_from_payload
-
-    # Negative / zero / non-numeric all fall back to None to avoid
-    # silently uncapping or deadlocking an env with cap=0.
-    for bad in (-1, 0, "abc", None, "0"):
-        cfg = _env_from_payload({
-            "display_name": "x",
-            "enabled_for_sampling": True,
-            "sampling": {"max_concurrent": bad},
-        })
-        assert cfg.max_concurrent is None, f"bad input {bad!r} leaked through"
-
-
-def test_compute_env_caps_defaults_to_fair_share():
-    from affine.src.executor.main import _compute_env_caps
-
-    caps = _compute_env_caps(
-        ["LIVEWEB", "MEMORY", "NAVWORLD", "SWE-INFINITE", "TERMINAL"],
         {},
         global_budget=600,
     )
 
-    assert caps == {
-        "LIVEWEB": 120,
-        "MEMORY": 120,
-        "NAVWORLD": 120,
-        "SWE-INFINITE": 120,
-        "TERMINAL": 120,
-    }
+    assert all(caps[env] >= 1 for env in caps)
+    assert sum(caps.values()) < 600
 
 
-def test_compute_env_caps_allows_explicit_override():
-    from affine.src.executor.main import _compute_env_caps
+def test_adaptive_caps_shift_capacity_from_underused_to_saturated_backlog():
+    from affine.src.executor.main import _compute_adaptive_env_caps
 
-    caps = _compute_env_caps(
+    caps = _compute_adaptive_env_caps(
         ["LIVEWEB", "MEMORY", "NAVWORLD"],
         {
-            "LIVEWEB": {
-                "enabled_for_sampling": True,
-                "sampling": {"max_concurrent": 80},
-            },
+            "LIVEWEB": {"target": 400, "done": 20, "running": 5, "delta": 0},
+            "MEMORY": {"target": 200, "done": 60, "running": 120, "delta": 3},
+            "NAVWORLD": {"target": 400, "done": 100, "running": 120, "delta": 6},
         },
+        {"LIVEWEB": 120, "MEMORY": 120, "NAVWORLD": 120},
         global_budget=300,
     )
 
-    assert caps == {
-        "LIVEWEB": 80,
-        "MEMORY": 110,
-        "NAVWORLD": 110,
-    }
+    assert caps["LIVEWEB"] < caps["MEMORY"]
+    assert caps["LIVEWEB"] < caps["NAVWORLD"]
+    assert sum(caps.values()) <= 300
+
+
+def test_adaptive_caps_prioritize_lagging_saturated_env():
+    from affine.src.executor.main import _compute_adaptive_env_caps
+
+    caps = _compute_adaptive_env_caps(
+        ["MEMORY", "TERMINAL"],
+        {
+            "MEMORY": {"target": 500, "done": 100, "running": 150, "delta": 1},
+            "TERMINAL": {"target": 500, "done": 450, "running": 150, "delta": 10},
+        },
+        {"MEMORY": 150, "TERMINAL": 150},
+        global_budget=300,
+    )
+
+    assert caps["MEMORY"] > caps["TERMINAL"]
+    assert sum(caps.values()) <= 300
+
+
+def test_adaptive_caps_do_not_expand_zero_progress_saturated_env():
+    from affine.src.executor.main import _compute_adaptive_env_caps
+
+    caps = _compute_adaptive_env_caps(
+        ["LIVEWEB", "TERMINAL"],
+        {
+            "LIVEWEB": {"target": 500, "done": 50, "running": 180, "delta": 0},
+            "TERMINAL": {"target": 500, "done": 250, "running": 120, "delta": 5},
+        },
+        {"LIVEWEB": 120, "TERMINAL": 120},
+        global_budget=300,
+    )
+
+    assert caps["LIVEWEB"] == 120
+    assert caps["TERMINAL"] > caps["LIVEWEB"]
+
+
+def test_adaptive_caps_release_completed_env_capacity():
+    from affine.src.executor.main import _compute_adaptive_env_caps
+
+    caps = _compute_adaptive_env_caps(
+        ["MEMORY", "TERMINAL"],
+        {
+            "MEMORY": {"target": 200, "done": 200, "running": 0, "delta": 0},
+            "TERMINAL": {"target": 500, "done": 50, "running": 150, "delta": 5},
+        },
+        {"MEMORY": 150, "TERMINAL": 150},
+        global_budget=300,
+    )
+
+    assert 1 < caps["MEMORY"] < caps["TERMINAL"]
+    assert caps["TERMINAL"] > 150

--- a/tests/test_executor_worker.py
+++ b/tests/test_executor_worker.py
@@ -29,6 +29,26 @@ def test_executor_manager_ipc_handles_survive_spawn():
     manager.global_sem.release()
 
 
+def test_executor_manager_recovers_stale_slots_after_worker_death():
+    from affine.src.executor.config import GLOBAL_DISPATCH_BUDGET
+
+    manager = ExecutorManager(["ENV_A"])
+    # Simulate a worker dying while holding two dispatch slots.
+    assert manager.global_sem.acquire(block=False)
+    assert manager.global_sem.acquire(block=False)
+    manager.in_flight_values["ENV_A"].value = 2
+
+    manager._recover_dead_worker_slots("ENV_A")
+
+    assert manager.in_flight_values["ENV_A"].value == 0
+    acquired = 0
+    while manager.global_sem.acquire(block=False):
+        acquired += 1
+    assert acquired == GLOBAL_DISPATCH_BUDGET
+    for _ in range(acquired):
+        manager.global_sem.release()
+
+
 def test_base_urls_prefers_deployments_and_dedupes():
     deployments = [
         DeploymentRecord(endpoint_name="a", deployment_id="da", base_url="http://a/v1"),
@@ -325,6 +345,23 @@ def test_adaptive_caps_do_not_expand_zero_progress_saturated_env():
     assert caps["TERMINAL"] > caps["LIVEWEB"]
 
 
+def test_adaptive_caps_decay_inflated_zero_progress_saturated_env_to_fair_share():
+    from affine.src.executor.main import _compute_adaptive_env_caps
+
+    caps = _compute_adaptive_env_caps(
+        ["LIVEWEB", "TERMINAL"],
+        {
+            "LIVEWEB": {"target": 500, "done": 50, "running": 240, "delta": 0},
+            "TERMINAL": {"target": 500, "done": 250, "running": 120, "delta": 5},
+        },
+        {"LIVEWEB": 240, "TERMINAL": 120},
+        global_budget=300,
+    )
+
+    assert caps["LIVEWEB"] == 150
+    assert caps["TERMINAL"] >= caps["LIVEWEB"]
+
+
 def test_adaptive_caps_release_completed_env_capacity():
     from affine.src.executor.main import _compute_adaptive_env_caps
 
@@ -340,6 +377,65 @@ def test_adaptive_caps_release_completed_env_capacity():
 
     assert 1 < caps["MEMORY"] < caps["TERMINAL"]
     assert caps["TERMINAL"] > 150
+
+
+def test_sampling_count_for_env_reads_current_config():
+    from affine.src.executor.main import _sampling_count_for_env
+
+    envs = {
+        "ENV_A": {
+            "sampling": {
+                "sampling_count": 400,
+            },
+        },
+    }
+
+    assert _sampling_count_for_env(envs, "ENV_A", 441) == 400
+    assert _sampling_count_for_env(envs, "MISSING", 441) == 441
+    envs["ENV_A"]["sampling"]["sampling_count"] = 0
+    assert _sampling_count_for_env(envs, "ENV_A", 441) == 0
+
+
+def test_status_target_uses_challenger_sampling_count_not_buffered_pool():
+    import asyncio as _asyncio
+
+    manager = ExecutorManager(["ENV_A"])
+    ids = list(range(441))
+
+    class _SC:
+        async def get_param_value(self, name, default=None):
+            values = {
+                "current_task_ids": {
+                    "task_ids": {"ENV_A": ids},
+                    "refreshed_at_block": 123,
+                },
+                "champion": {"hotkey": "champ_hk", "revision": "champ_rev"},
+                "current_battle": {
+                    "challenger": {
+                        "hotkey": "chal_hk",
+                        "revision": "chal_rev",
+                    },
+                },
+                "environments": {
+                    "ENV_A": {"sampling": {"sampling_count": 400}},
+                },
+            }
+            return values.get(name, default)
+
+    class _Samples:
+        async def count_samples_for_tasks(
+            self, hotkey, revision, env, task_ids, *, refresh_block
+        ):
+            if hotkey == "champ_hk":
+                return 441
+            if hotkey == "chal_hk":
+                return 400
+            return 0
+
+    _asyncio.run(manager._emit_status_line(_SC(), _Samples()))
+
+    assert manager._last_done["ENV_A"] == 841
+    assert manager.env_cap_values["ENV_A"].value == 600
 
 
 def test_dispatch_proceeds_when_only_battle_has_url():

--- a/tests/test_scheduler_flow.py
+++ b/tests/test_scheduler_flow.py
@@ -564,6 +564,182 @@ async def test_post_promotion_crash_recovery_does_not_self_demote():
 
 
 @pytest.mark.asyncio
+async def test_recovery_terminates_old_champion_and_writes_weights():
+    """When the crash window is hit (set_champion(new) ran, clear_battle
+    didn't), the recovery branch must:
+      - mark the new champion's miner_stats row as ``champion``
+      - mark the OLD champion's miner_stats row as ``terminated``
+        (otherwise two miners stay at status='champion' indefinitely)
+      - re-emit on-chain weights using the new champion (otherwise the
+        chain still credits the deposed miner)
+
+    Identifying the old champion requires ``BattleRecord.previous_champion``
+    — by the time recovery fires, system_config.champion already points at
+    the new winner, so the loser's UID has to live on the battle row.
+    """
+    kv = _seed_state()
+    miner_store = _InMemoryMinerStore([
+        _make_miner(
+            1, "loser_hk", 100,
+            status=STATUS_CHAMPION, revision="loser_rev",
+        ),
+        _make_miner(
+            2, "winner_hk", 200,
+            status=STATUS_IN_PROGRESS, revision="winner_rev",
+        ),
+    ])
+    kv.data["champion"] = {
+        "uid": 2, "hotkey": "winner_hk", "revision": "winner_rev",
+        "model": "org/m2",
+        "deployment_id": "wrk-002", "base_url": "https://t/wrk-002",
+        "since_block": 50,
+    }
+    kv.data["current_battle"] = {
+        "challenger": {
+            "uid": 2, "hotkey": "winner_hk", "revision": "winner_rev",
+            "model": "org/m2",
+        },
+        "deployment_id": "wrk-002",
+        "base_url": "https://t/wrk-002",
+        "started_at_block": 40,
+        "previous_champion": {
+            "uid": 1, "hotkey": "loser_hk", "revision": "loser_rev",
+            "model": "org/m1",
+        },
+    }
+    kv.data["current_task_ids"] = {
+        "task_ids": {"ENV_A": [1, 2, 3, 4], "ENV_B": [5, 6, 7, 8]},
+        "refreshed_at_block": 0,
+    }
+    deployer = _DeployTracker()
+    samples = _SamplesFake()
+    for env, tids in [("ENV_A", [1, 2, 3, 4]), ("ENV_B", [5, 6, 7, 8])]:
+        samples.set_samples("winner_hk", "winner_rev", env, tids, score=0.5)
+    weight_writer = _WeightWriterFake()
+    scheduler, state, _ = _build_scheduler(
+        kv=kv, miner_store=miner_store,
+        deployer=deployer, samples=samples, weight_writer=weight_writer,
+    )
+
+    await scheduler.tick(current_block=51)
+
+    # New champion preserved.
+    champ = await state.get_champion()
+    assert champ is not None and champ.uid == 2
+
+    # New champion marked champion.
+    assert miner_store.rows[2]["challenge_status"] == STATUS_CHAMPION
+    # Old champion (uid 1) flipped to terminated with a recovery reason.
+    assert miner_store.rows[1]["challenge_status"] == STATUS_TERMINATED, (
+        "recovery must terminate the old champion's miner_stats row"
+    )
+    assert "recovery" in miner_store.rows[1]["termination_reason"]
+    # Weights re-emitted for the new champion (otherwise the on-chain
+    # weight tx still credits the deposed miner).
+    assert weight_writer.calls, "recovery must re-emit weights"
+    # Battle cleared.
+    assert await state.get_battle() is None
+
+
+@pytest.mark.asyncio
+async def test_recovery_without_previous_champion_still_safe():
+    """Backward-compat: battle records written before the
+    ``previous_champion`` field existed shouldn't crash recovery. We
+    can't terminate an unknown loser or re-emit weights without
+    knowing the previous champion, so the path logs and finalizes only
+    the bookkeeping it does have."""
+    kv = _seed_state()
+    miner_store = _InMemoryMinerStore([
+        _make_miner(
+            2, "winner_hk", 200,
+            status=STATUS_IN_PROGRESS, revision="winner_rev",
+        ),
+    ])
+    kv.data["champion"] = {
+        "uid": 2, "hotkey": "winner_hk", "revision": "winner_rev",
+        "model": "org/m2",
+        "deployment_id": "wrk-002", "base_url": "https://t/wrk-002",
+        "since_block": 50,
+    }
+    # No previous_champion key — simulates an in-flight battle from a
+    # scheduler version that hadn't shipped the field yet.
+    kv.data["current_battle"] = {
+        "challenger": {
+            "uid": 2, "hotkey": "winner_hk", "revision": "winner_rev",
+            "model": "org/m2",
+        },
+        "deployment_id": "wrk-002",
+        "base_url": "https://t/wrk-002",
+        "started_at_block": 40,
+    }
+    kv.data["current_task_ids"] = {
+        "task_ids": {"ENV_A": [1, 2, 3, 4], "ENV_B": [5, 6, 7, 8]},
+        "refreshed_at_block": 0,
+    }
+    samples = _SamplesFake()
+    for env, tids in [("ENV_A", [1, 2, 3, 4]), ("ENV_B", [5, 6, 7, 8])]:
+        samples.set_samples("winner_hk", "winner_rev", env, tids, score=0.5)
+    weight_writer = _WeightWriterFake()
+    scheduler, state, _ = _build_scheduler(
+        kv=kv, miner_store=miner_store,
+        deployer=_DeployTracker(), samples=samples,
+        weight_writer=weight_writer,
+    )
+
+    await scheduler.tick(current_block=51)
+
+    # Doesn't crash; new champion preserved; battle cleared.
+    champ = await state.get_champion()
+    assert champ is not None and champ.uid == 2
+    assert await state.get_battle() is None
+    assert miner_store.rows[2]["challenge_status"] == STATUS_CHAMPION
+
+
+@pytest.mark.asyncio
+async def test_start_battle_captures_previous_champion():
+    """``_start_battle`` must seed ``BattleRecord.previous_champion`` so
+    a later crash + recovery can still terminate the loser. This pins
+    the seed write down so the field isn't accidentally dropped."""
+    kv = _seed_state()
+    miner_store = _InMemoryMinerStore([
+        _make_miner(
+            1, "champ_hk", 100,
+            status=STATUS_CHAMPION, revision="champ_rev",
+        ),
+        _make_miner(2, "chal_hk", 200, revision="chal_rev"),
+    ])
+    deployer = _DeployTracker()
+    samples = _SamplesFake()
+    scheduler, state, _ = _build_scheduler(
+        kv=kv, miner_store=miner_store, deployer=deployer, samples=samples,
+    )
+
+    # Tick 0: refresh task_ids.
+    await scheduler.tick(current_block=50)
+    # Tick 1: deploy champion.
+    await scheduler.tick(current_block=51)
+    task_state = await state.get_task_state()
+    rb = task_state.refreshed_at_block
+    # Fill champion samples so step 7 (start_battle) actually fires.
+    for env in ("ENV_A", "ENV_B"):
+        samples.set_samples(
+            "champ_hk", "champ_rev", env,
+            task_state.task_ids[env], score=0.9, refresh_block=rb,
+        )
+    # Tick 2: start battle. Should write a battle record with
+    # previous_champion populated from the current champion.
+    await scheduler.tick(current_block=52)
+
+    battle = await state.get_battle()
+    assert battle is not None, "battle should have started"
+    assert battle.previous_champion is not None, (
+        "_start_battle must capture previous_champion before set_champion(new)"
+    )
+    assert battle.previous_champion.uid == 1
+    assert battle.previous_champion.hotkey == "champ_hk"
+
+
+@pytest.mark.asyncio
 async def test_cold_start_set_champion_writes_before_mark_terminated():
     """The order of cold-start writes matters for crash recovery. If
     ``mark_terminated(WON)`` ran first and crashed before ``set_champion``,


### PR DESCRIPTION
Two correctness bugs in the post-sampling flow, both unexercised in prod until the first real battle decides.

**BUG-1 (blocker)**: `_dispatch_new` exited early when champion had no serving URL, which is exactly the state SSH single-instance providers enter at battle start (the host is now serving the challenger). Challenger samples never get dispatched → `_battle_overlap_ready` never satisfies → battle stalls forever. Decouple the champion-URL check from the function-entry guard.

**BUG-2 (corner-case)**: `_decide`'s post-promotion crash recovery only marked the new champion. Old champion's `miner_stats` stayed at `status='champion'` and the on-chain weight tx was skipped. Capture old champion's identity on `BattleRecord.previous_champion` at battle start; recovery uses it to terminate + re-emit weights. Defensive guards for malformed / pre-fix battle records.

5 new tests cover both fixes plus backward-compat with pre-fix battle records.