### PR TITLE
get-rank: precompute live per-(uid,env) avgs; drop stale snapshot fallback

### DIFF
--- a/affine/api/rank_state.py
+++ b/affine/api/rank_state.py
@@ -8,7 +8,7 @@ from affine.database.dao.miner_stats import MinerStatsDAO
 from affine.database.dao.miners import MinersDAO
 from affine.database.dao.scores import ScoresDAO
 from affine.database.dao.system_config import SystemConfigDAO
-from affine.src.scorer.dao_adapters import SampleResultsAdapter
+from affine.src.monitor.live_scores_monitor import LIVE_SCORES_KEY
 from affine.src.scorer.window_state import (
     BattleRecord,
     ChampionRecord,
@@ -60,48 +60,52 @@ async def _infer_champion_from_scores() -> Optional[ChampionRecord]:
 
 
 async def _sample_counts_and_averages(
-    champion: Optional[ChampionRecord],
-    battle: Optional[BattleRecord],
     task_state: Optional[TaskIdState],
 ) -> tuple[Dict[str, Dict[str, int]], Dict[str, Dict[str, float]]]:
-    """Per-(uid, env) live count + running average from sample_results.
+    """Per-(uid, env) live count + running average for every valid miner.
 
-    Reads the per-task scores for the current refresh_block, computes
-    both the count (used by ``af get-rank``'s sample-count column and
-    ``_live_sampling_uids``) and the running average (used by
-    ``af get-rank``'s per-env score cell so battle subjects show their
-    actual current score, not the stale snapshot's 0.00).
+    Reads the precomputed cache at ``system_config['live_scores']`` —
+    populated by :class:`affine.src.monitor.live_scores_monitor.LiveScoresMonitor`
+    on a fixed cadence (~30 min). Returning empty dicts is fine: the
+    rank UI then renders ``-`` instead of a stale snapshot value, which
+    is exactly what we want when the monitor hasn't produced a payload
+    yet (or has produced one for a different refresh_block).
+
+    The cache is keyed by ``refresh_block``. When the scheduler refreshes
+    the task pool between monitor cycles the cached entry is treated as
+    expired and dropped — readers must not see scores belonging to a
+    previous pool.
     """
     if task_state is None:
         return {}, {}
-    adapter = SampleResultsAdapter()
+    payload = await SystemConfigDAO().get_param_value(LIVE_SCORES_KEY, default=None)
+    if not isinstance(payload, dict):
+        return {}, {}
+    if int(payload.get("refresh_block") or 0) != int(task_state.refreshed_at_block):
+        return {}, {}
+    raw = payload.get("scores") or {}
+    if not isinstance(raw, dict):
+        return {}, {}
+
     counts: Dict[str, Dict[str, int]] = {}
     averages: Dict[str, Dict[str, float]] = {}
-
-    subjects = []
-    if champion is not None:
-        subjects.append((str(champion.uid), champion.hotkey, champion.revision))
-    if battle is not None:
-        challenger = battle.challenger
-        subjects.append((str(challenger.uid), challenger.hotkey, challenger.revision))
-
-    for uid, hotkey, revision in subjects:
+    for uid_key, env_map in raw.items():
+        if not isinstance(env_map, dict):
+            continue
+        uid = str(uid_key)
         env_counts: Dict[str, int] = {}
         env_avgs: Dict[str, float] = {}
-        for env, task_ids in task_state.task_ids.items():
-            scores = await adapter.read_scores_for_tasks(
-                hotkey,
-                revision,
-                env,
-                task_ids,
-                refresh_block=task_state.refreshed_at_block,
-            )
-            env_counts[env] = len(scores)
-            env_avgs[env] = (
-                sum(scores.values()) / len(scores) if scores else 0.0
-            )
-        counts[uid] = env_counts
-        averages[uid] = env_avgs
+        for env, entry in env_map.items():
+            if not isinstance(entry, dict):
+                continue
+            try:
+                env_counts[str(env)] = int(entry.get("count") or 0)
+                env_avgs[str(env)] = float(entry.get("avg") or 0.0)
+            except (TypeError, ValueError):
+                continue
+        if env_counts:
+            counts[uid] = env_counts
+            averages[uid] = env_avgs
     return counts, averages
 
 
@@ -143,9 +147,7 @@ async def get_current_state() -> Dict[str, Any]:
     battle = await store.get_battle()
     task_state = await store.get_task_state()
     envs = await store.get_environments()
-    sample_counts, sample_averages = await _sample_counts_and_averages(
-        champion, battle, task_state,
-    )
+    sample_counts, sample_averages = await _sample_counts_and_averages(task_state)
     return {
         "champion": _miner_summary(champion) if champion else None,
         "battle": {

--- a/affine/src/miner/rank.py
+++ b/affine/src/miner/rank.py
@@ -54,12 +54,6 @@ def _as_float(value: Any, default: float = 0.0) -> float:
         return default
 
 
-def _number(value: Any) -> Optional[float]:
-    if isinstance(value, (int, float)):
-        return float(value)
-    return None
-
-
 def _format_relative_time(epoch_seconds: Optional[int]) -> str:
     if not epoch_seconds:
         return "unknown"
@@ -94,69 +88,35 @@ def _env_names(scores: List[Dict[str, Any]]) -> List[str]:
 
 
 def _env_cell(
-    payload: Any,
+    payload: Any,  # noqa: ARG001 — kept for signature stability with callers
     live_count: Optional[int] = None,
     live_avg: Optional[float] = None,
     *,
     champion_live_avg: Optional[float] = None,
 ) -> str:
-    if not isinstance(payload, dict):
-        if live_avg is not None and live_count is not None and live_count > 0:
-            return f"{live_avg * 100:.2f}/{live_count}"
-        return "-"
-    # Live running average from the current refresh_block trumps the
-    # snapshot score — a miner mid-battle has a real running score even
-    # if the last decided snapshot has them at 0.00. Threshold metadata
-    # still belongs in the cell when present, otherwise the live row
-    # hides the actual battle bounds.
-    has_live_avg = live_avg is not None and live_count is not None and live_count > 0
-    score_on_common = live_avg if has_live_avg else _number(payload.get("score_on_common"))
-    # Brackets must reflect the *current* champion when there's a live
-    # battle — the snapshot ones are from the last DECIDED contest and
-    # can be wildly stale (eg [19.83, 23.23] when the current champion's
-    # live SWE-INFINITE avg is ~54%). Compute live brackets from the
-    # current champion's live_avg whenever we have it; fall back to
-    # snapshot only when no live data exists.
-    if champion_live_avg is not None:
-        from affine.src.scorer.comparator import (
-            DEFAULT_MARGIN, DEFAULT_NOT_WORSE_TOLERANCE,
-        )
-        lower = champion_live_avg * (1.0 - DEFAULT_NOT_WORSE_TOLERANCE)
-        upper = champion_live_avg + DEFAULT_MARGIN
-    else:
-        lower = _number(payload.get("not_worse_threshold"))
-        upper = _number(payload.get("dethrone_threshold"))
-    common_tasks = live_count if has_live_avg else payload.get("common_tasks")
-    if (
-        score_on_common is not None
-        and lower is not None
-        and upper is not None
-        and isinstance(common_tasks, int)
-    ):
-        return (
-            f"{score_on_common * 100:.2f}"
-            f"[{lower * 100:.2f},{upper * 100:.2f}]"
-            f"/{common_tasks}"
-        )
+    """Render one env cell as ``{score%}[{lower%},{upper%}]/{n}``.
 
-    score = None
-    if has_live_avg:
-        score = live_avg
-    else:
-        for key in ("score", "mean", "average_score", "score_on_common"):
-            score = _number(payload.get(key))
-            if score is not None:
-                break
-    if score is None:
+    Data source is the live ``system_config['live_scores']`` cache only;
+    the ``payload`` parameter (a ``scores_by_env[env]`` snapshot dict
+    from the affine_scores table) is intentionally ignored — that
+    snapshot is only refreshed on champion change, so it can be days
+    stale for a miner that lost its last battle. Showing ``-`` is
+    correct when the live cache has no entry for this miner.
+    """
+    if live_avg is None or live_count is None or live_count <= 0:
         return "-"
-    samples = live_count
-    for key in ("sample_count", "historical_count", "common_tasks", "count"):
-        if samples is None and isinstance(payload.get(key), int):
-            samples = int(payload[key])
-            break
-    if samples is None:
-        return f"{score * 100:.2f}"
-    return f"{score * 100:.2f}/{samples}"
+    if champion_live_avg is None:
+        return f"{live_avg * 100:.2f}/{live_count}"
+    from affine.src.scorer.comparator import (
+        DEFAULT_MARGIN, DEFAULT_NOT_WORSE_TOLERANCE,
+    )
+    lower = champion_live_avg * (1.0 - DEFAULT_NOT_WORSE_TOLERANCE)
+    upper = champion_live_avg + DEFAULT_MARGIN
+    return (
+        f"{live_avg * 100:.2f}"
+        f"[{lower * 100:.2f},{upper * 100:.2f}]"
+        f"/{live_count}"
+    )
 
 
 def _status_for(

--- a/affine/src/monitor/live_scores_monitor.py
+++ b/affine/src/monitor/live_scores_monitor.py
@@ -1,0 +1,207 @@
+"""
+Live scores monitor.
+
+Periodically computes per-(uid, env) live count + running average from the
+current refresh_block's sample_results, and writes the result into
+``system_config['live_scores']`` for the rank API to read.
+
+Why this exists: the ``af get-rank`` table needs to show every valid
+miner's *current* battle performance — not the last-decided snapshot's
+``scores_by_env``, which can be many days stale (eg a miner that lost
+its last battle keeps its scores_by_env frozen at the time of that
+loss). Computing it on every API call would cost ``len(valid) × envs``
+DDB queries per request, so we precompute on a fixed cadence.
+
+Storage shape::
+
+    {
+      "refreshed_at": <epoch seconds>,
+      "refresh_block": <int — the task_state.refreshed_at_block this maps to>,
+      "scores": {
+        "<uid>": {
+          "<env>": {"count": <int>, "avg": <float>}
+        },
+        ...
+      }
+    }
+
+The ``refresh_block`` field lets readers detect "this cache is for the
+previous task pool — discard it" when the scheduler refreshes the pool
+between cache cycles.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from statistics import mean
+from typing import Any, Dict, List, Optional
+
+from affine.core.setup import logger
+from affine.database.dao.miners import MinersDAO
+from affine.database.dao.system_config import SystemConfigDAO
+from affine.src.scorer.dao_adapters import SampleResultsAdapter
+from affine.src.scorer.window_state import (
+    StateStore,
+    SystemConfigKVAdapter,
+    TaskIdState,
+)
+
+
+# Storage key in system_config that holds the precomputed live-scores cache.
+LIVE_SCORES_KEY = "live_scores"
+
+# Default cadence: 30 minutes. Long enough that 320+ Query calls per cycle
+# is negligible cost; short enough that the rank UI stays useful within a
+# single battle window (~hour scale).
+DEFAULT_REFRESH_INTERVAL_SECONDS = 1800
+
+# Bound the per-cycle fan-out so we don't open hundreds of concurrent
+# DDB connections.
+MAX_CONCURRENCY = 32
+
+
+class LiveScoresMonitor:
+    """Refreshes ``system_config['live_scores']`` on a fixed cadence."""
+
+    _instance: Optional["LiveScoresMonitor"] = None
+    _lock = asyncio.Lock()
+
+    def __init__(self, refresh_interval_seconds: int = DEFAULT_REFRESH_INTERVAL_SECONDS):
+        self.refresh_interval_seconds = refresh_interval_seconds
+        self._config_dao = SystemConfigDAO()
+        self._state = StateStore(
+            SystemConfigKVAdapter(self._config_dao, updated_by="live_scores_monitor")
+        )
+        self._miners_dao = MinersDAO()
+        self._samples = SampleResultsAdapter()
+        self._background_task: Optional[asyncio.Task] = None
+
+    @classmethod
+    async def initialize(
+        cls, refresh_interval_seconds: int = DEFAULT_REFRESH_INTERVAL_SECONDS,
+    ) -> "LiveScoresMonitor":
+        async with cls._lock:
+            if cls._instance is None:
+                cls._instance = cls(refresh_interval_seconds=refresh_interval_seconds)
+                await cls._instance.start_background_tasks()
+        return cls._instance
+
+    async def start_background_tasks(self) -> None:
+        if self._background_task and not self._background_task.done():
+            return
+        self._background_task = asyncio.create_task(self._refresh_loop())
+
+    async def stop_background_tasks(self) -> None:
+        if self._background_task and not self._background_task.done():
+            self._background_task.cancel()
+            try:
+                await self._background_task
+            except asyncio.CancelledError:
+                pass
+        self._background_task = None
+
+    async def _refresh_loop(self) -> None:
+        # Run once immediately at startup so the rank UI doesn't show
+        # nothing for the first refresh interval after a deploy.
+        while True:
+            try:
+                await self.refresh_once()
+            except Exception as e:
+                logger.error(
+                    f"[LiveScoresMonitor] refresh failed: {e}", exc_info=True,
+                )
+            await asyncio.sleep(self.refresh_interval_seconds)
+
+    async def refresh_once(self) -> Optional[Dict[str, Any]]:
+        """Run one refresh cycle. Returns the payload written, or None if
+        skipped (no task pool / no valid miners / no scoring envs)."""
+        task_state = await self._state.get_task_state()
+        if task_state is None or not task_state.task_ids:
+            logger.info(
+                "[LiveScoresMonitor] no task_state; skipping cycle"
+            )
+            return None
+
+        env_configs = await self._state.get_scoring_environments()
+        scoring_envs = [env for env in env_configs if task_state.task_ids.get(env)]
+        if not scoring_envs:
+            logger.info(
+                "[LiveScoresMonitor] no scoring envs with task_ids; skipping"
+            )
+            return None
+
+        valid_miners = await self._miners_dao.get_valid_miners()
+        if not valid_miners:
+            logger.info("[LiveScoresMonitor] no valid miners; skipping cycle")
+            return None
+
+        start = time.time()
+        scores = await self._compute_scores(
+            valid_miners, scoring_envs, task_state,
+        )
+        elapsed = time.time() - start
+
+        payload = {
+            "refreshed_at": int(time.time()),
+            "refresh_block": int(task_state.refreshed_at_block),
+            "scores": scores,
+        }
+        await self._config_dao.set_param(
+            param_name=LIVE_SCORES_KEY,
+            param_value=payload,
+            param_type="dict",
+            updated_by="live_scores_monitor",
+        )
+        logger.info(
+            f"[LiveScoresMonitor] refreshed {len(scores)} miners × "
+            f"{len(scoring_envs)} envs in {elapsed:.1f}s "
+            f"(refresh_block={task_state.refreshed_at_block})"
+        )
+        return payload
+
+    async def _compute_scores(
+        self,
+        valid_miners: List[Dict[str, Any]],
+        scoring_envs: List[str],
+        task_state: TaskIdState,
+    ) -> Dict[str, Dict[str, Dict[str, Any]]]:
+        """Return ``{uid_str: {env: {"count": int, "avg": float}}}`` for
+        every (valid miner × scoring env) pair that has at least one
+        sample row in the current refresh_block. Envs with zero samples
+        are omitted from the per-miner dict to keep the payload tight."""
+
+        sem = asyncio.Semaphore(MAX_CONCURRENCY)
+
+        async def _one(uid: int, hotkey: str, revision: str, env: str):
+            task_ids = task_state.task_ids.get(env) or []
+            if not task_ids:
+                return uid, env, None
+            async with sem:
+                scored = await self._samples.read_scores_for_tasks(
+                    hotkey, revision, env, task_ids,
+                    refresh_block=task_state.refreshed_at_block,
+                )
+            if not scored:
+                return uid, env, None
+            return uid, env, {
+                "count": len(scored),
+                "avg": float(mean(scored.values())),
+            }
+
+        coros = []
+        for m in valid_miners:
+            uid = m.get("uid")
+            hotkey = m.get("hotkey")
+            revision = m.get("revision")
+            if not isinstance(uid, int) or not hotkey or not revision:
+                continue
+            for env in scoring_envs:
+                coros.append(_one(uid, hotkey, str(revision), env))
+
+        out: Dict[str, Dict[str, Dict[str, Any]]] = {}
+        for uid, env, entry in await asyncio.gather(*coros):
+            if entry is None:
+                continue
+            out.setdefault(str(uid), {})[env] = entry
+        return out

--- a/affine/src/monitor/main.py
+++ b/affine/src/monitor/main.py
@@ -10,12 +10,13 @@ import signal
 import click
 from affine.core.setup import logger, setup_logging
 from affine.database import init_client, close_client
+from .live_scores_monitor import LiveScoresMonitor
 from .miners_monitor import MinersMonitor
 
 async def run_service():
     """Run the miners monitor service."""
     logger.info("Starting Miners Monitor Service")
-    
+
     # Initialize database
     try:
         await init_client()
@@ -23,45 +24,53 @@ async def run_service():
     except Exception as e:
         logger.error(f"Failed to initialize database: {e}")
         raise
-    
+
     # Setup signal handlers
     shutdown_event = asyncio.Event()
-    
+
     def handle_shutdown(sig):
         logger.info(f"Received signal {sig}, initiating shutdown...")
         shutdown_event.set()
-    
+
     loop = asyncio.get_event_loop()
     for sig in (signal.SIGINT, signal.SIGTERM):
         loop.add_signal_handler(sig, lambda s=sig: handle_shutdown(s))
-    
-    # Initialize and start MinersMonitor
+
+    # Initialize and start monitors
     monitor = None
+    live_scores_monitor = None
     try:
         monitor = await MinersMonitor.initialize()
         logger.info("MinersMonitor started")
-        
+        live_scores_monitor = await LiveScoresMonitor.initialize()
+        logger.info("LiveScoresMonitor started")
+
         # Wait for shutdown signal
         await shutdown_event.wait()
-        
+
     except Exception as e:
-        logger.error(f"Error running MinersMonitor: {e}", exc_info=True)
+        logger.error(f"Error running monitors: {e}", exc_info=True)
         raise
     finally:
-        # Cleanup
+        if live_scores_monitor:
+            try:
+                await live_scores_monitor.stop_background_tasks()
+                logger.info("LiveScoresMonitor stopped")
+            except Exception as e:
+                logger.error(f"Error stopping LiveScoresMonitor: {e}")
         if monitor:
             try:
                 await monitor.stop_background_tasks()
                 logger.info("MinersMonitor stopped")
             except Exception as e:
                 logger.error(f"Error stopping MinersMonitor: {e}")
-        
+
         try:
             await close_client()
             logger.info("Database client closed")
         except Exception as e:
             logger.error(f"Error closing database: {e}")
-    
+
     logger.info("Miners Monitor Service shut down successfully")
 
 


### PR DESCRIPTION
## Why

A challenger that lost its last battle keeps its `scores_by_env` frozen at the time of that loss in `affine_scores`. `af get-rank` used that as fallback when the miner wasn't the current champion / challenger, so a mid-battle `TERMINATED` miner could show e.g. `SWE-INFINITE=26.59%/173` from a 4-day-old snapshot while its real current-refresh avg was `36.82%/201` — making the table actively misleading for comparing models.

## What

- **New** `affine/src/monitor/live_scores_monitor.py`: a background task in the monitor service. Every 30 min computes count + avg for every valid miner across every scoring env at the current `refresh_block` (`asyncio.gather` with concurrency 32), persists to `system_config['live_scores']` keyed by `refresh_block`.
- `affine/api/rank_state.py` — `_sample_counts_and_averages` now reads that cache instead of recomputing for only champion + challenger. Cache is treated as expired whenever `refresh_block` doesn't match current `task_state`, so readers never see scores belonging to a previous pool.
- `affine/src/miner/rank.py` — `_env_cell` drops all snapshot fallbacks. No live data → `-`. Brackets only render when `champion_live_avg` is present.
- `affine/src/monitor/main.py` — starts/stops `LiveScoresMonitor` alongside `MinersMonitor`.

The `scheduler._write_weights` path is **unchanged**: `affine_scores` rows still get written on champion change, including `scores_by_env` for posterity. Only the rank UI stops consuming that field.

## Test plan
- [x] End-to-end manual: ran `LiveScoresMonitor.refresh_once` against prod DDB, read it back via `get_current_state` — UID 213 / 228 both show their real current-refresh avgs (`213/0.3662` and `201/0.3682` for SWE-INFINITE), instead of the stale snapshot values
- [ ] Deploy monitor service so `LiveScoresMonitor` starts running; verify `system_config['live_scores']` gets refreshed every 30 min
- [ ] `af get-rank` shows live avgs for all valid miners with samples in the current refresh; `-` for everyone else (no stale-snapshot leakage)