### PR TITLE
scheduler: strongly-consistent reads on contest decide path

### DIFF
--- a/affine/src/scorer/dao_adapters.py
+++ b/affine/src/scorer/dao_adapters.py
@@ -217,6 +217,16 @@ class SampleResultsAdapter:
         Single Query on the (pk = MINER#hk#REV#rev#ENV#env) partition,
         then filter in Python to the requested task_id subset AND to the
         current refresh.
+
+        Uses ``ConsistentRead=True``: the scheduler reads this just
+        before deciding a contest. With the default eventually-consistent
+        read a fresh sample row visible to ``_battle_overlap_ready`` can
+        be invisible to the follow-up read inside ``_decide`` (different
+        replica), shrinking a per-env mean enough to flip the challenger
+        from ``not_worse`` to ``worse`` on an env where the true mean is
+        comfortably above threshold. Strongly consistent reads on the
+        main table close that race; the cost is 2x RCU which is fine at
+        this query rate.
         """
         if not task_ids:
             return {}
@@ -235,6 +245,7 @@ class SampleResultsAdapter:
                     ":sk": {"S": "TASK#"},
                 },
                 "ProjectionExpression": "task_id, score, refresh_block",
+                "ConsistentRead": True,
             }
             if exclusive_start:
                 params["ExclusiveStartKey"] = exclusive_start

--- a/tests/test_miner_rank.py
+++ b/tests/test_miner_rank.py
@@ -60,6 +60,7 @@ def test_rank_table_renders_old_single_table_shape_with_sampling_marks():
         },
         "task_refresh_block": 40,
         "sample_counts": {"1": {"SWE": 300}, "2": {"SWE": 77}},
+        "sample_averages": {"1": {"SWE": 0.80}, "2": {"SWE": 0.70}},
         "live_sampling_uids": [1, 2],
     }
     queue = [
@@ -117,8 +118,14 @@ def test_rank_table_renders_old_single_table_shape_with_sampling_marks():
     assert "CHAMPION" in out
     assert "BATTLING" in out
     assert "QUEUE #1" in out
+    # Champion row: live count + live avg, no brackets (champion never
+    # shows thresholds against itself).
     assert "80.00/300" in out
-    assert "70.00[79.00,81.00]/9" in out
+    # Challenger row: brackets computed from champion's live_avg (0.80)
+    # via DEFAULT_NOT_WORSE_TOLERANCE=0.02 and DEFAULT_MARGIN=0.03 →
+    # [0.784, 0.830], score is challenger's live_avg, count is its
+    # live_count from sample_counts.
+    assert "70.00[78.40,83.00]/77" in out
     assert out.count("⚡| org/") == 2
     assert "  | org/q" in out
     assert "Sampling: ⚡ marks miners in the current live sampling set" in out
@@ -357,6 +364,7 @@ def test_rank_table_uses_live_count_only_for_non_threshold_cells():
         "champion": {"uid": 1, "hotkey": "champ", "model": "org/champ"},
         "battle": None,
         "sample_counts": {"1": {"SWE": 321}},
+        "sample_averages": {"1": {"SWE": 0.80}},
     }
     scores = {
         "block_number": 100,
@@ -384,19 +392,28 @@ def test_rank_table_uses_live_count_only_for_non_threshold_cells():
 
     out = _render_rank(window, [], scores)
 
-    assert "80.00[70.00,90.00]/10" in out
-    assert "80.00[70.00,90.00]/321" not in out
+    # Champion row: live_avg + live_count from window; no brackets
+    # (champion never shows thresholds against itself).
+    assert "80.00/321" in out
+    # Snapshot's own threshold metadata (not_worse_threshold,
+    # dethrone_threshold) is never used for bracket rendering — only
+    # the *champion's* live_avg drives brackets, and a champion row has
+    # no brackets at all.
+    assert "[70.00,90.00]" not in out
 
 
 def test_rank_table_keeps_thresholds_when_using_live_running_average():
+    # Champion live_avg drives the bracket math:
+    #   lower = champ * (1 - DEFAULT_NOT_WORSE_TOLERANCE=0.02) = 0.4851
+    #   upper = champ + DEFAULT_MARGIN=0.03                   = 0.5249
     window = {
         "champion": {"uid": 1, "hotkey": "champ", "model": "org/champ"},
         "battle": {
             "challenger": {"uid": 2, "hotkey": "chal", "model": "org/chal"},
             "started_at_block": 42,
         },
-        "sample_counts": {"2": {"SWE": 178}},
-        "sample_averages": {"2": {"SWE": 0.4816}},
+        "sample_counts": {"1": {"SWE": 213}, "2": {"SWE": 178}},
+        "sample_averages": {"1": {"SWE": 0.4950}, "2": {"SWE": 0.4816}},
     }
     scores = {
         "block_number": 100,
@@ -408,22 +425,14 @@ def test_rank_table_keeps_thresholds_when_using_live_running_average():
                 "model": "org/chal",
                 "overall_score": 0.0,
                 "is_valid": True,
-                "scores_by_env": {
-                    "SWE": {
-                        "score": 0.0,
-                        "score_on_common": 0.0,
-                        "common_tasks": 0,
-                        "not_worse_threshold": 0.4849,
-                        "dethrone_threshold": 0.5248,
-                    },
-                },
+                "scores_by_env": {"SWE": {}},
             },
         ],
     }
 
     out = _render_rank(window, [], scores)
 
-    assert "48.16[48.49,52.48]/178" in out
+    assert "48.16[48.51,52.50]/178" in out
 
 
 def test_rank_table_uses_color_on_tty(monkeypatch):
@@ -582,11 +591,14 @@ def test_rank_table_uses_live_brackets_from_current_champion_average():
     )
 
 
-def test_rank_table_falls_back_to_snapshot_brackets_when_no_live_champion_avg():
-    """Backward-compat: when the champion has no live_avg for this env
-    (eg between battles, or championship was just inferred from
-    weights), keep using the snapshot ``not_worse_threshold`` /
-    ``dethrone_threshold`` rather than dropping them silently."""
+def test_rank_table_omits_brackets_when_no_live_champion_avg():
+    """When the champion has no ``live_avg`` for this env (eg between
+    battles, championship was just inferred from weights, or the
+    live_scores cache hasn't been populated yet), the cell shows
+    just ``score/count`` with no brackets. The snapshot's
+    ``not_worse_threshold`` / ``dethrone_threshold`` fields are
+    intentionally NOT consumed — they go stale across champion
+    changes and would mislead readers."""
     window = {
         "champion": {"uid": 1, "hotkey": "champ", "model": "org/champ"},
         "battle": {
@@ -617,7 +629,9 @@ def test_rank_table_falls_back_to_snapshot_brackets_when_no_live_champion_avg():
     }
 
     out = _render_rank(window, [], scores)
-    assert "48.16[48.49,52.48]/178" in out
+    assert "48.16/178" in out
+    # Snapshot brackets are NOT fallback-rendered.
+    assert "[48.49,52.48]" not in out
 
 
 def test_rank_table_champion_row_never_displays_live_brackets():

--- a/tests/test_rank_state.py
+++ b/tests/test_rank_state.py
@@ -20,7 +20,7 @@ from affine.src.scorer.window_state import (
 )
 
 
-async def _empty_counts(champion, battle, task_state):
+async def _empty_counts(task_state):
     return {}, {}
 
 
@@ -92,7 +92,7 @@ async def test_current_state_with_battle_in_flight(monkeypatch):
 
 @pytest.mark.asyncio
 async def test_current_state_marks_only_incomplete_subjects_as_live_sampling(monkeypatch):
-    async def _counts(champion, battle, task_state):
+    async def _counts(task_state):
         return (
             {"1": {"ENV_A": 5}, "2": {"ENV_A": 2}},
             {"1": {"ENV_A": 0.42}, "2": {"ENV_A": 0.10}},


### PR DESCRIPTION
## Why

Every DDB query in this codebase uses the default eventually-consistent read. The scheduler's contest path issues *two* separate queries against \`sample_results\` seconds apart — \`_battle_overlap_ready\` and the read inside \`_decide\` — so replica propagation can leave a fresh sample row visible to the first read but invisible to the second.

For envs with bimodal score distributions (eg SWE-INFINITE's \`score ∈ {0,1}\`), missing 2–3 late-arriving 1.0 samples shrinks the challenger mean by ~0.01 — enough to flip an env from \`not_worse\` to \`regressed_beyond_tolerance\` even though the true mean is comfortably above the threshold.

We saw exactly that on uid 228 vs 213 on 2026-05-14: table data showed \`SWE-INFINITE\` delta = **+0.0020** (well inside the 2 % tolerance band), but the scheduler logged \`regressed_in_env:SWE-INFINITE:regressed_beyond_tolerance\` and dethroned the challenger.

## What

- \`read_scores_for_tasks\` in \`affine/src/scorer/dao_adapters.py\` now sets \`ConsistentRead=True\` on its DDB Query.
- \`count_samples_for_tasks\` already delegates to \`read_scores_for_tasks\`, so both gates now see the same authoritative view.
- 2× RCU cost is negligible at this rate (one partition Query per (miner, env) per contest tick).
- GSI queries would not support \`ConsistentRead\` — this Query is on the main partition key so we're fine.

Tests updated for #469's renderer rewrite (this branch is based on post-#469 \`main\`):
- \`_sample_counts_and_averages\` now takes only \`task_state\`
- \`_env_cell\` no longer falls back to snapshot \`scores_by_env\` / brackets
- brackets are rendered only when a \`champion_live_avg\` is present

## Test plan
- [x] \`pytest -q\` (253 passed, including \`test_scheduler_flow\`, \`test_window_comparator\`, \`test_miner_rank\`, \`test_rank_state\`)
- [x] Smoke-tested \`read_scores_for_tasks\` against prod DDB — 213 SWE-INFINITE \`n=213 avg=0.3662\`, 228 SWE-INFINITE \`n=201 avg=0.3682\` (same as the eventually-consistent reads currently see; the win is repeatability, not the data itself)
- [ ] Watch \`FlowScheduler: champion uid ... held against ...\` log lines for spurious \`regressed_beyond_tolerance\` once deployed