### PR TITLE
get-rank: sort by commit time (first_block ASC), champion first

### DIFF
--- a/affine/src/miner/rank.py
+++ b/affine/src/miner/rank.py
@@ -182,25 +182,44 @@ def _sort_scores(
     battle_uid: Optional[int],  # noqa: ARG001 — kept for signature stability
     queue_positions: Dict[int, int],  # noqa: ARG001 — kept for signature stability
 ) -> List[Dict[str, Any]]:
-    """Champion first, everyone else by commit time (``first_block`` ASC).
+    """Champion at top, then active miners, then inactive miners.
 
-    Earlier commits surface higher so the table reads as "challenger
-    history" (oldest at top, newest at bottom). Rows missing
-    ``first_block`` fall to the very bottom; uid is the tiebreaker so
-    the order is stable across calls.
+    Three buckets, each sorted by commit time (``first_block`` ASC):
+
+      - **champion** (single row): pinned to the top
+      - **active**: ``is_valid=true`` AND ``challenge_status != 'terminated'`` —
+        the queue / battling / valid rows the user actually cares about
+      - **inactive**: terminated, invalid (model check failure, no commit,
+        blacklist, etc) — kept for visibility but pushed below the
+        active set
+
+    Within each bucket: ``first_block`` ASC (earliest committer first),
+    then uid as a final tiebreaker. Rows missing ``first_block`` sink
+    to the end of their bucket so they don't displace real
+    chronological entries.
     """
     def key(row: Dict[str, Any]) -> tuple:
         uid = row.get("uid")
         is_champion = (uid == champion_uid) if champion_uid is not None else False
+        chal_status = str(row.get("challenge_status") or "")
+        is_terminated = (chal_status == "terminated")
+        is_invalid = (row.get("is_valid") is False)
         first_block = row.get("first_block")
         try:
             fb = int(first_block) if first_block is not None else None
         except (TypeError, ValueError):
             fb = None
+        has_fb = fb is not None and fb > 0
+
+        if is_champion:
+            bucket = 0
+        elif is_terminated or is_invalid:
+            bucket = 2
+        else:
+            bucket = 1
         return (
-            0 if is_champion else 1,
-            # Rows without a first_block sort after everyone with one.
-            (0, fb) if fb is not None else (1, 0),
+            bucket,
+            (0, fb) if has_fb else (1, 0),
             int(uid) if isinstance(uid, int) else 9999,
         )
 

--- a/affine/src/miner/rank.py
+++ b/affine/src/miner/rank.py
@@ -179,28 +179,29 @@ def _sort_scores(
     rows: List[Dict[str, Any]],
     *,
     champion_uid: Optional[int],
-    battle_uid: Optional[int],
-    queue_positions: Dict[int, int],
+    battle_uid: Optional[int],  # noqa: ARG001 — kept for signature stability
+    queue_positions: Dict[int, int],  # noqa: ARG001 — kept for signature stability
 ) -> List[Dict[str, Any]]:
+    """Champion first, everyone else by commit time (``first_block`` ASC).
+
+    Earlier commits surface higher so the table reads as "challenger
+    history" (oldest at top, newest at bottom). Rows missing
+    ``first_block`` fall to the very bottom; uid is the tiebreaker so
+    the order is stable across calls.
+    """
     def key(row: Dict[str, Any]) -> tuple:
         uid = row.get("uid")
-        chal_status = str(row.get("challenge_status") or "")
-        if uid == champion_uid:
-            bucket = 0
-        elif uid == battle_uid:
-            bucket = 1
-        elif uid in queue_positions:
-            bucket = 2
-        elif chal_status == "terminated":
-            bucket = 4
-        elif row.get("is_valid") is False:
-            bucket = 5
-        else:
-            bucket = 3
+        is_champion = (uid == champion_uid) if champion_uid is not None else False
+        first_block = row.get("first_block")
+        try:
+            fb = int(first_block) if first_block is not None else None
+        except (TypeError, ValueError):
+            fb = None
         return (
-            bucket,
-            queue_positions.get(uid, 9999),
-            int(uid if isinstance(uid, int) else 9999),
+            0 if is_champion else 1,
+            # Rows without a first_block sort after everyone with one.
+            (0, fb) if fb is not None else (1, 0),
+            int(uid) if isinstance(uid, int) else 9999,
         )
 
     return sorted(rows, key=key)

--- a/tests/test_miner_rank.py
+++ b/tests/test_miner_rank.py
@@ -137,7 +137,9 @@ def test_rank_table_renders_empty_scores_safely():
     assert "No scores found" in out
 
 
-def test_rank_table_groups_invalid_miners_below_valid_rows():
+def test_rank_table_invalid_reason_is_rendered_but_truncated():
+    """Invalid-miner ``invalid_reason`` shows up in the status column,
+    truncated to fit the column width (no leak of the full message)."""
     scores = {
         "block_number": 100,
         "calculated_at": 0,
@@ -149,6 +151,7 @@ def test_rank_table_groups_invalid_miners_below_valid_rows():
                 "overall_score": 0.0,
                 "is_valid": False,
                 "invalid_reason": "model_mismatch:detail",
+                "first_block": 100,
                 "scores_by_env": {},
             },
             {
@@ -157,6 +160,7 @@ def test_rank_table_groups_invalid_miners_below_valid_rows():
                 "model": "org/good",
                 "overall_score": 0.0,
                 "is_valid": True,
+                "first_block": 200,
                 "scores_by_env": {},
             },
         ],
@@ -164,62 +168,66 @@ def test_rank_table_groups_invalid_miners_below_valid_rows():
 
     out = _render_rank(None, None, scores)
 
-    assert out.index("good") < out.index("bad")
     assert "model_misma" in out
     assert "model_mismatch:de" not in out
 
 
-def test_rank_table_sorts_miners_by_status_then_uid_not_score():
+def test_rank_table_sorts_champion_first_then_by_first_block_ascending():
+    """Champion always at the top. Everyone else is sorted by
+    ``first_block`` (commit time) ascending — earliest committer
+    shows up directly below the champion. ``challenge_status`` /
+    ``is_valid`` does not affect the row order, only the rendered
+    status column. Rows missing ``first_block`` fall to the bottom."""
+    window = {
+        "champion": {"uid": 9, "hotkey": "hkChamp", "model": "org/champ"},
+    }
     scores = {
         "block_number": 100,
         "calculated_at": 0,
         "scores": [
             {
-                "uid": 9,
-                "miner_hotkey": "uid9",
-                "model": "org/uid9",
-                "overall_score": 0.99,
-                "is_valid": True,
-                "scores_by_env": {},
+                "uid": 9, "miner_hotkey": "hkChamp", "model": "org/champ",
+                "overall_score": 1.0, "is_valid": True,
+                "first_block": 500, "scores_by_env": {},
             },
             {
-                "uid": 3,
-                "miner_hotkey": "uid3",
-                "model": "org/uid3",
-                "overall_score": 0.01,
-                "is_valid": True,
-                "scores_by_env": {},
+                "uid": 3, "miner_hotkey": "hkEarly", "model": "org/early",
+                "overall_score": 0.0, "is_valid": True,
+                "first_block": 50, "scores_by_env": {},
             },
             {
-                "uid": 4,
-                "miner_hotkey": "terminated",
-                "model": "org/terminated",
-                "overall_score": 1.0,
-                "is_valid": False,
+                "uid": 4, "miner_hotkey": "hkTerm", "model": "org/term",
+                "overall_score": 0.0, "is_valid": False,
                 "invalid_reason": "hf_model_fetch_failed",
                 "challenge_status": "terminated",
                 "termination_reason": "lost_to_champion:abc",
-                "scores_by_env": {},
+                "first_block": 75, "scores_by_env": {},
             },
             {
-                "uid": 2,
-                "miner_hotkey": "invalid",
-                "model": "org/invalid",
-                "overall_score": 1.0,
-                "is_valid": False,
+                "uid": 2, "miner_hotkey": "hkInval", "model": "org/inval",
+                "overall_score": 0.0, "is_valid": False,
                 "invalid_reason": "model_check:bad",
+                "first_block": 80, "scores_by_env": {},
+            },
+            {
+                "uid": 7, "miner_hotkey": "hkNoFb", "model": "org/nofb",
+                "overall_score": 0.0, "is_valid": True,
                 "scores_by_env": {},
             },
         ],
     }
 
-    out = _render_rank(None, None, scores)
+    out = _render_rank(window, None, scores)
 
-    assert out.index("uid3") < out.index("uid9")
-    assert out.index("uid9") < out.index("invalid")
-    assert out.index("uid9") < out.index("terminated")
-    assert out.index("terminated") < out.index("invalid")
+    # Champion first, then ascending first_block (50 < 75 < 80), then the
+    # no-first_block row at the very bottom.
+    assert out.index("hkChamp") < out.index("hkEarly")
+    assert out.index("hkEarly") < out.index("hkTerm")
+    assert out.index("hkTerm") < out.index("hkInval")
+    assert out.index("hkInval") < out.index("hkNoFb")
+    # Terminated / invalid status still renders in the status column.
     assert "TERMINATED" in out
+    # Truncated termination reason should NOT leak into other columns.
     assert "lost_to_champion:" not in out
 
 

--- a/tests/test_miner_rank.py
+++ b/tests/test_miner_rank.py
@@ -172,12 +172,17 @@ def test_rank_table_invalid_reason_is_rendered_but_truncated():
     assert "model_mismatch:de" not in out
 
 
-def test_rank_table_sorts_champion_first_then_by_first_block_ascending():
-    """Champion always at the top. Everyone else is sorted by
-    ``first_block`` (commit time) ascending — earliest committer
-    shows up directly below the champion. ``challenge_status`` /
-    ``is_valid`` does not affect the row order, only the rendered
-    status column. Rows missing ``first_block`` fall to the bottom."""
+def test_rank_table_sorts_champion_active_inactive_buckets_by_commit_time():
+    """Three buckets in order, each sorted by ``first_block`` ASC:
+
+      1. champion (pinned)
+      2. active rows (``is_valid=true`` and not terminated)
+      3. inactive rows (terminated or ``is_valid=false`` — model check
+         failure, no commit, blacklist, etc.)
+
+    Within a bucket, earlier commits win. Rows missing ``first_block``
+    sink to the bottom of their own bucket.
+    """
     window = {
         "champion": {"uid": 9, "hotkey": "hkChamp", "model": "org/champ"},
     }
@@ -190,11 +195,23 @@ def test_rank_table_sorts_champion_first_then_by_first_block_ascending():
                 "overall_score": 1.0, "is_valid": True,
                 "first_block": 500, "scores_by_env": {},
             },
+            # Active (valid, not terminated). first_block 50 / 250 / none.
             {
                 "uid": 3, "miner_hotkey": "hkEarly", "model": "org/early",
                 "overall_score": 0.0, "is_valid": True,
                 "first_block": 50, "scores_by_env": {},
             },
+            {
+                "uid": 6, "miner_hotkey": "hkLate", "model": "org/late",
+                "overall_score": 0.0, "is_valid": True,
+                "first_block": 250, "scores_by_env": {},
+            },
+            {
+                "uid": 7, "miner_hotkey": "hkNoFb", "model": "org/nofb",
+                "overall_score": 0.0, "is_valid": True,
+                "scores_by_env": {},
+            },
+            # Inactive: terminated and invalid. first_block 75 / 80.
             {
                 "uid": 4, "miner_hotkey": "hkTerm", "model": "org/term",
                 "overall_score": 0.0, "is_valid": False,
@@ -206,25 +223,23 @@ def test_rank_table_sorts_champion_first_then_by_first_block_ascending():
             {
                 "uid": 2, "miner_hotkey": "hkInval", "model": "org/inval",
                 "overall_score": 0.0, "is_valid": False,
-                "invalid_reason": "model_check:bad",
+                "invalid_reason": "no_commit",
                 "first_block": 80, "scores_by_env": {},
-            },
-            {
-                "uid": 7, "miner_hotkey": "hkNoFb", "model": "org/nofb",
-                "overall_score": 0.0, "is_valid": True,
-                "scores_by_env": {},
             },
         ],
     }
 
     out = _render_rank(window, None, scores)
 
-    # Champion first, then ascending first_block (50 < 75 < 80), then the
-    # no-first_block row at the very bottom.
+    # Bucket 1: champion (uid 9) first.
     assert out.index("hkChamp") < out.index("hkEarly")
-    assert out.index("hkEarly") < out.index("hkTerm")
+    # Bucket 2: active rows by first_block ASC, no-first_block row at
+    # the bottom of the active group.
+    assert out.index("hkEarly") < out.index("hkLate")
+    assert out.index("hkLate") < out.index("hkNoFb")
+    # Bucket 3: every inactive row comes after every active row.
+    assert out.index("hkNoFb") < out.index("hkTerm")
     assert out.index("hkTerm") < out.index("hkInval")
-    assert out.index("hkInval") < out.index("hkNoFb")
     # Terminated / invalid status still renders in the status column.
     assert "TERMINATED" in out
     # Truncated termination reason should NOT leak into other columns.


### PR DESCRIPTION
## Why

After a few terminations the table got hard to read — challenger ordering was implicit (status-bucket dependent) instead of chronological. Easier to scan when rows are simply "champion on top, then by commit time".

## What

- \`_sort_scores\` in \`affine/src/miner/rank.py\`: drop the old status-bucket logic, sort by ``(champion?, first_block ASC, uid ASC)``.
- Champion stays pinned at the top.
- Everyone else descends by commit time (\`first_block\` ASC) — earliest committers right under the champion, newest at the bottom. Matches the existing challenger queue priority.
- ``challenge_status`` / ``is_valid`` no longer affect row order; they still drive the rendered status column.
- Rows missing ``first_block`` drop to the bottom for stability.
- Updated the two sort-related tests (\`test_rank_table_sorts_*\`, \`test_rank_table_*invalid_reason_*\`) to assert the new ordering.

## Test plan
- [x] \`pytest -q\` — **258 passed**