### PR TITLE
weights: split emission across past N champion hotkeys

### DIFF
--- a/affine/api/routers/scores.py
+++ b/affine/api/routers/scores.py
@@ -464,7 +464,7 @@ async def get_score_by_uid(
 # TTL out — a block number is immutable and validator-native.
 WEIGHTS_SPLIT_AFTER_BLOCK_PARAM = "weights_split_after_block"
 WEIGHTS_SPLIT_CHAMPION_COUNT_PARAM = "weights_split_champion_count"
-_DEFAULT_SPLIT_CHAMPION_COUNT = 3
+_DEFAULT_SPLIT_CHAMPION_COUNT = 5
 
 # Cap snapshot fan-out. One row per championship transition; TTL is now
 # 365 days, so 500 comfortably covers a year of swaps.
@@ -574,7 +574,7 @@ async def get_latest_weights(
     accepted).
 
     Post-activation we split weight evenly across the most recent
-    ``weights_split_champion_count`` (default 3) distinct champion
+    ``weights_split_champion_count`` (default 5) distinct champion
     hotkeys, resolved to their *current* on-chain uid via the miners
     table. Each carries ``1/N`` weight. A hotkey that has since
     deregistered is skipped (we don't accidentally pay the successor on

--- a/affine/api/routers/scores.py
+++ b/affine/api/routers/scores.py
@@ -17,6 +17,7 @@ from affine.api.dependencies import (
     get_scores_dao,
     get_score_snapshots_dao,
     get_miners_dao,
+    get_system_config_dao,
     rate_limit_read,
 )
 from affine.database.dao.scores import ScoresDAO
@@ -452,28 +453,179 @@ async def get_score_by_uid(
         )
 
 
+# --- past-N-champions reward split ------------------------------------------
+#
+# Activation threshold lives in ``system_config`` under the key below so an
+# operator can flip it on / change it / turn it off with one DAO write
+# (``SystemConfigDAO.set_param``) — no env vars, no redeploy. Stores an
+# integer block_number; missing or ``0`` keeps the legacy winner-takes-all
+# behaviour. Anchored to ``block_number`` (snapshot PK) rather than to a
+# uid or a hotkey because uids recycle and hotkeys' snapshots eventually
+# TTL out — a block number is immutable and validator-native.
+WEIGHTS_SPLIT_AFTER_BLOCK_PARAM = "weights_split_after_block"
+WEIGHTS_SPLIT_CHAMPION_COUNT_PARAM = "weights_split_champion_count"
+_DEFAULT_SPLIT_CHAMPION_COUNT = 3
+
+# Cap snapshot fan-out. One row per championship transition; TTL is now
+# 365 days, so 500 comfortably covers a year of swaps.
+_SPLIT_SNAPSHOT_SCAN_LIMIT = 500
+
+
+def _winner_uid_from_snapshot(snapshot: Dict[str, Any]) -> Optional[int]:
+    """Extract the integer winner uid from a snapshot, tolerating both the
+    explicit ``statistics.winner_uid`` field and the older shape where the
+    winner is implied by the ``"1.0"`` entry in ``final_weights``."""
+    stats = snapshot.get("statistics", {}) or {}
+    direct = stats.get("winner_uid")
+    if direct is not None:
+        try:
+            return int(direct)
+        except (TypeError, ValueError):
+            pass
+    raw_weights = (
+        stats.get("final_weights")
+        or stats.get("miner_final_scores")
+        or {}
+    )
+    for uid_str, weight in raw_weights.items():
+        try:
+            if float(weight) >= 1.0:
+                return int(uid_str)
+        except (TypeError, ValueError):
+            continue
+    return None
+
+
+def _winner_hotkey_from_snapshot(snapshot: Dict[str, Any]) -> Optional[str]:
+    """Return the SS58 hotkey of the snapshot's winner, or ``None`` when
+    the snapshot does not carry one. Hotkey-less legacy snapshots can't
+    be deduped or resolved to a current uid, so they're skipped instead
+    of silently paying out to whoever now sits on their stale uid."""
+    stats = snapshot.get("statistics", {}) or {}
+    hk = stats.get("winner_hotkey")
+    if isinstance(hk, str) and hk:
+        return hk
+    return None
+
+
+async def _resolve_current_uids_by_hotkey(
+    snapshots: List[Dict[str, Any]],
+    miners_dao: MinersDAO,
+    *,
+    needed: int,
+) -> List[int]:
+    """Walk ``snapshots`` (newest-first), dedupe past champions by hotkey,
+    look up each hotkey's *current* uid in the miners table, and keep the
+    first ``needed`` whose miner is still registered.
+
+    Champions whose hotkey has deregistered are skipped — paying them out
+    on their old uid would in fact pay whoever now sits on that uid. We
+    continue further back in history to backfill, so a hotkey churn at the
+    top of the leaderboard doesn't shrink the split unnecessarily.
+    """
+    out: List[int] = []
+    seen_hotkeys: set = set()
+    for snap in snapshots:
+        if len(out) >= needed:
+            break
+        hotkey = _winner_hotkey_from_snapshot(snap)
+        if hotkey is None or hotkey in seen_hotkeys:
+            continue
+        seen_hotkeys.add(hotkey)
+        miner = await miners_dao.get_miner_by_hotkey(hotkey)
+        if not miner:
+            continue  # hotkey no longer registered → don't pay its successor
+        try:
+            uid = int(miner.get("uid"))
+        except (TypeError, ValueError):
+            continue
+        out.append(uid)
+    return out
+
+
+async def _get_int_param(
+    dao: SystemConfigDAO, name: str, default: int,
+) -> int:
+    """Read an integer system_config param, tolerating missing rows and
+    string-typed values (DDB items round-trip numbers as strings via the
+    document loader in some paths)."""
+    raw = await dao.get_param_value(name, default=default)
+    try:
+        return int(raw)
+    except (TypeError, ValueError):
+        return default
+
+
 @router.get("/weights/latest", dependencies=[Depends(rate_limit_read)])
 async def get_latest_weights(
     snapshots_dao: ScoreSnapshotsDAO = Depends(get_score_snapshots_dao),
+    miners_dao: MinersDAO = Depends(get_miners_dao),
+    config_dao: SystemConfigDAO = Depends(get_system_config_dao),
 ):
-    """Return the latest snapshot's per-UID weights.
+    """Return per-UID weights derived from recent score snapshots.
 
-    The queue-window scheduler writes ``statistics.final_weights`` as
-    ``{uid_str: weight_str}`` — exactly one uid carries ``"1.0"`` (the
-    champion) and everyone else carries ``"0.0"``. Legacy scorer snapshots
-    used the equivalent ``statistics.miner_final_scores`` field. Accept
-    both persisted field names so validators can keep setting weights
-    between the old scorer's last snapshot and the scheduler's first
-    championship-transition snapshot.
+    Pre-activation (``system_config`` row
+    ``weights_split_after_block`` missing or ``0``, or the latest
+    snapshot's ``block_number`` is below that threshold) this passes
+    through the scheduler's winner-takes-all snapshot:
+    ``statistics.final_weights`` as ``{uid_str: weight_str}`` — exactly
+    one uid at ``"1.0"`` and everyone else at ``"0.0"`` (legacy snapshots
+    used the equivalent ``statistics.miner_final_scores`` field; both are
+    accepted).
+
+    Post-activation we split weight evenly across the most recent
+    ``weights_split_champion_count`` (default 3) distinct champion
+    hotkeys, resolved to their *current* on-chain uid via the miners
+    table. Each carries ``1/N`` weight. A hotkey that has since
+    deregistered is skipped (we don't accidentally pay the successor on
+    its recycled uid) and we keep walking history to backfill the count.
     """
-    snapshot = await snapshots_dao.get_latest_snapshot()
-    if not snapshot:
+    activation_block = await _get_int_param(
+        config_dao, WEIGHTS_SPLIT_AFTER_BLOCK_PARAM, default=0,
+    )
+    champion_count = max(
+        1,
+        await _get_int_param(
+            config_dao,
+            WEIGHTS_SPLIT_CHAMPION_COUNT_PARAM,
+            default=_DEFAULT_SPLIT_CHAMPION_COUNT,
+        ),
+    )
+
+    snapshots = await snapshots_dao.get_recent_snapshots(
+        limit=_SPLIT_SNAPSHOT_SCAN_LIMIT,
+    )
+    if not snapshots:
         raise HTTPException(
             status_code=status.HTTP_404_NOT_FOUND,
             detail="No score snapshots found",
         )
 
-    statistics = snapshot.get("statistics", {}) or {}
+    latest = snapshots[0]
+    latest_block = latest.get("block_number")
+
+    activated = (
+        activation_block > 0
+        and isinstance(latest_block, int)
+        and latest_block >= activation_block
+    )
+
+    if activated:
+        champion_uids = await _resolve_current_uids_by_hotkey(
+            snapshots, miners_dao, needed=champion_count,
+        )
+        if not champion_uids:
+            raise HTTPException(
+                status_code=status.HTTP_404_NOT_FOUND,
+                detail="No registered past-champion hotkeys in recent snapshots",
+            )
+        share = 1.0 / len(champion_uids)
+        return {
+            "block_number": latest_block,
+            "weights": {str(uid): {"weight": share} for uid in champion_uids},
+        }
+
+    statistics = latest.get("statistics", {}) or {}
     raw_weights = (
         statistics.get("final_weights")
         or statistics.get("miner_final_scores")
@@ -494,6 +646,6 @@ async def get_latest_weights(
         weights_response[str(uid_str)] = {"weight": w}
 
     return {
-        "block_number": snapshot.get("block_number"),
+        "block_number": latest_block,
         "weights": weights_response,
     }

--- a/affine/api/routers/scores.py
+++ b/affine/api/routers/scores.py
@@ -472,16 +472,19 @@ _SPLIT_SNAPSHOT_SCAN_LIMIT = 500
 
 
 def _winner_uid_from_snapshot(snapshot: Dict[str, Any]) -> Optional[int]:
-    """Extract the integer winner uid from a snapshot, tolerating both the
-    explicit ``statistics.winner_uid`` field and the older shape where the
-    winner is implied by the ``"1.0"`` entry in ``final_weights``."""
+    """Extract the integer winner uid from a snapshot, tolerating three
+    historical shapes: the current ``statistics.winner_uid`` field, the
+    pre-Stage-U ``statistics.champion_uid`` field, and the implicit shape
+    where the winner is the ``"1.0"`` entry in ``final_weights`` /
+    ``miner_final_scores``."""
     stats = snapshot.get("statistics", {}) or {}
-    direct = stats.get("winner_uid")
-    if direct is not None:
-        try:
-            return int(direct)
-        except (TypeError, ValueError):
-            pass
+    for key in ("winner_uid", "champion_uid"):
+        direct = stats.get(key)
+        if direct is not None:
+            try:
+                return int(direct)
+            except (TypeError, ValueError):
+                continue
     raw_weights = (
         stats.get("final_weights")
         or stats.get("miner_final_scores")
@@ -498,13 +501,16 @@ def _winner_uid_from_snapshot(snapshot: Dict[str, Any]) -> Optional[int]:
 
 def _winner_hotkey_from_snapshot(snapshot: Dict[str, Any]) -> Optional[str]:
     """Return the SS58 hotkey of the snapshot's winner, or ``None`` when
-    the snapshot does not carry one. Hotkey-less legacy snapshots can't
-    be deduped or resolved to a current uid, so they're skipped instead
-    of silently paying out to whoever now sits on their stale uid."""
+    the snapshot does not carry one. Accepts both the current
+    ``winner_hotkey`` field and the legacy ``champion_hotkey`` field so
+    pre-Stage-U snapshots aren't silently skipped (which would shrink the
+    past-N-champions split to ``N=1`` until the new flow has written N
+    transitions of its own)."""
     stats = snapshot.get("statistics", {}) or {}
-    hk = stats.get("winner_hotkey")
-    if isinstance(hk, str) and hk:
-        return hk
+    for key in ("winner_hotkey", "champion_hotkey"):
+        hk = stats.get(key)
+        if isinstance(hk, str) and hk:
+            return hk
     return None
 
 
@@ -516,12 +522,22 @@ async def _resolve_current_uids_by_hotkey(
 ) -> List[int]:
     """Walk ``snapshots`` (newest-first), dedupe past champions by hotkey,
     look up each hotkey's *current* uid in the miners table, and keep the
-    first ``needed`` whose miner is still registered.
+    first ``needed`` whose miner is still registered AND currently valid.
 
-    Champions whose hotkey has deregistered are skipped — paying them out
-    on their old uid would in fact pay whoever now sits on that uid. We
-    continue further back in history to backfill, so a hotkey churn at the
-    top of the leaderboard doesn't shrink the split unnecessarily.
+    Two filters are applied at resolution time:
+
+    * **Deregistered hotkeys** are skipped. Paying them on their stale
+      snapshot uid would in fact pay whoever now sits on that uid.
+    * **Currently-invalid hotkeys** (``is_valid != "true"``: model
+      mismatch, anticopy, multi-commit, …) are skipped. They were valid
+      when they won the championship but have since been flagged; the
+      legacy single-champion path can't even surface this case (the
+      active champion is valid by construction), so the split path
+      shouldn't either.
+
+    Either filter outcome causes us to walk further back in history to
+    backfill the count, so churn at the top of the leaderboard doesn't
+    shrink the split unnecessarily.
     """
     out: List[int] = []
     seen_hotkeys: set = set()
@@ -535,6 +551,10 @@ async def _resolve_current_uids_by_hotkey(
         miner = await miners_dao.get_miner_by_hotkey(hotkey)
         if not miner:
             continue  # hotkey no longer registered → don't pay its successor
+        # ``is_valid`` is stored as the string ``"true"`` / ``"false"``
+        # to be a GSI partition key, so compare against the string form.
+        if str(miner.get("is_valid") or "").lower() != "true":
+            continue  # registered but currently flagged invalid → skip
         try:
             uid = int(miner.get("uid"))
         except (TypeError, ValueError):

--- a/affine/database/dao/score_snapshots.py
+++ b/affine/database/dao/score_snapshots.py
@@ -38,7 +38,7 @@ class ScoreSnapshotsDAO(BaseDAO):
         scorer_hotkey: str,
         config: Dict[str, Any],
         statistics: Dict[str, Any],
-        ttl_days: int = 30
+        ttl_days: int = 365,
     ) -> Dict[str, Any]:
         """Save a scoring snapshot metadata.
         
@@ -58,7 +58,10 @@ class ScoreSnapshotsDAO(BaseDAO):
                     "invalid_miners": int,
                     "final_weights": {"uid": "weight", ...}
                 }
-            ttl_days: Days until automatic deletion (default 30)
+            ttl_days: Days until automatic deletion (default 365). The
+                weights endpoint walks recent snapshots to find the past
+                N distinct champions, so we keep at least a year of
+                history to survive a long-tenured champion's win-streak.
             
         Returns:
             Saved item

--- a/tests/test_api_contract.py
+++ b/tests/test_api_contract.py
@@ -59,11 +59,23 @@ class _FakeExecutionLogsDAO:
 
 
 class _FakeScoreSnapshotsDAO:
-    def __init__(self, snapshot):
-        self.snapshot = snapshot
+    """Test stand-in. Accepts either a single snapshot (back-compat with
+    legacy callers) or an explicit ``snapshots`` list ordered newest-first
+    so the weights endpoint can scan recent history."""
+
+    def __init__(self, snapshot=None, *, snapshots=None):
+        if snapshots is not None:
+            self.snapshots = list(snapshots)
+        elif snapshot is not None:
+            self.snapshots = [snapshot]
+        else:
+            self.snapshots = []
 
     async def get_latest_snapshot(self):
-        return self.snapshot
+        return self.snapshots[0] if self.snapshots else None
+
+    async def get_recent_snapshots(self, limit=10):
+        return self.snapshots[:limit]
 
 
 class _FakeScoresDAO:
@@ -806,7 +818,9 @@ async def test_weights_endpoint_does_not_expose_snapshot_config():
                     "8": "0.0",
                 }
             },
-        })
+        }),
+        miners_dao=_FakeMinersDAO({}),
+        config_dao=_FakeSystemConfigDAO({}),
     )
 
     assert response == {
@@ -829,7 +843,9 @@ async def test_weights_endpoint_accepts_legacy_miner_final_scores():
                     "8": 0,
                 }
             },
-        })
+        }),
+        miners_dao=_FakeMinersDAO({}),
+        config_dao=_FakeSystemConfigDAO({}),
     )
 
     assert response == {
@@ -839,6 +855,251 @@ async def test_weights_endpoint_accepts_legacy_miner_final_scores():
             "8": {"weight": 0.0},
         },
     }
+
+
+def _miners_by_hotkey(*rows):
+    """Build a _FakeMinersDAO seeded so ``get_miner_by_hotkey`` resolves
+    each ``(hotkey, uid)`` pair (None uid models a deregistered hotkey)."""
+    seeded = {}
+    for hotkey, uid in rows:
+        if uid is None:
+            continue
+        seeded[("hotkey", hotkey)] = {"hotkey": hotkey, "uid": uid}
+    return _FakeMinersDAO(seeded)
+
+
+def _split_config(after_block=0, count=3):
+    return _FakeSystemConfigDAO({
+        "weights_split_after_block": after_block,
+        "weights_split_champion_count": count,
+    })
+
+
+@pytest.mark.asyncio
+async def test_weights_endpoint_splits_evenly_after_activation_block():
+    # Threshold = 300, latest snapshot block = 500 → split fires. Past 3
+    # distinct champion hotkeys each resolve to a *currently-registered*
+    # uid via miners_dao; each carries 1/3.
+    snapshots = [
+        {
+            "block_number": 500,
+            "statistics": {"winner_uid": 8, "winner_hotkey": "hk-h"},
+        },
+        {
+            "block_number": 400,
+            "statistics": {"winner_uid": 7, "winner_hotkey": "hk-g"},
+        },
+        # Duplicate hotkey — dedup'd; the next distinct hotkey below
+        # still counts toward the 3-share.
+        {
+            "block_number": 350,
+            "statistics": {"winner_uid": 7, "winner_hotkey": "hk-g"},
+        },
+        {
+            "block_number": 300,
+            "statistics": {"winner_uid": 213, "winner_hotkey": "hk-x"},
+        },
+        {
+            "block_number": 200,
+            "statistics": {"winner_uid": 5, "winner_hotkey": "hk-e"},
+        },
+    ]
+
+    response = await get_latest_weights(
+        snapshots_dao=_FakeScoreSnapshotsDAO(snapshots=snapshots),
+        miners_dao=_miners_by_hotkey(("hk-h", 8), ("hk-g", 7), ("hk-x", 42)),
+        config_dao=_split_config(after_block=300, count=3),
+    )
+
+    share = pytest.approx(1.0 / 3)
+    # hk-x's *current* uid is 42 (it moved off uid 213), so the chain
+    # weight goes to uid 42 — not to the new occupant of uid 213.
+    assert response == {
+        "block_number": 500,
+        "weights": {
+            "8": {"weight": share},
+            "7": {"weight": share},
+            "42": {"weight": share},
+        },
+    }
+
+
+@pytest.mark.asyncio
+async def test_weights_endpoint_legacy_payload_when_split_disabled():
+    # No ``weights_split_after_block`` row in system_config → feature
+    # off → keep the legacy winner-takes-all payload exactly as the
+    # scheduler wrote it.
+    snapshots = [
+        {
+            "block_number": 500,
+            "statistics": {
+                "winner_uid": 8,
+                "final_weights": {"8": "1.0", "7": "0.0"},
+            },
+        },
+    ]
+    response = await get_latest_weights(
+        snapshots_dao=_FakeScoreSnapshotsDAO(snapshots=snapshots),
+        miners_dao=_FakeMinersDAO({}),
+        config_dao=_FakeSystemConfigDAO({}),  # no split keys present
+    )
+
+    assert response == {
+        "block_number": 500,
+        "weights": {
+            "8": {"weight": 1.0},
+            "7": {"weight": 0.0},
+        },
+    }
+
+
+@pytest.mark.asyncio
+async def test_weights_endpoint_legacy_payload_before_activation_block():
+    # Feature enabled but latest block (500) below threshold (1000) →
+    # still legacy.
+    snapshots = [
+        {
+            "block_number": 500,
+            "statistics": {
+                "winner_uid": 8, "winner_hotkey": "hk-h",
+                "final_weights": {"8": "1.0", "7": "0.0"},
+            },
+        },
+    ]
+    response = await get_latest_weights(
+        snapshots_dao=_FakeScoreSnapshotsDAO(snapshots=snapshots),
+        miners_dao=_miners_by_hotkey(("hk-h", 8)),
+        config_dao=_split_config(after_block=1000, count=3),
+    )
+
+    assert response == {
+        "block_number": 500,
+        "weights": {
+            "8": {"weight": 1.0},
+            "7": {"weight": 0.0},
+        },
+    }
+
+
+@pytest.mark.asyncio
+async def test_weights_endpoint_skips_deregistered_hotkey_and_backfills():
+    # hk-g (the second-most-recent champion) has deregistered — the
+    # endpoint must NOT credit whoever now sits on its old uid. Instead
+    # it walks further back to hk-x and includes that one. Result: 3
+    # *currently-registered* hotkeys share the weight.
+    snapshots = [
+        {
+            "block_number": 500,
+            "statistics": {"winner_uid": 8, "winner_hotkey": "hk-h"},
+        },
+        {
+            "block_number": 400,
+            "statistics": {"winner_uid": 7, "winner_hotkey": "hk-g"},
+        },
+        {
+            "block_number": 300,
+            "statistics": {"winner_uid": 213, "winner_hotkey": "hk-x"},
+        },
+        {
+            "block_number": 200,
+            "statistics": {"winner_uid": 5, "winner_hotkey": "hk-e"},
+        },
+    ]
+
+    response = await get_latest_weights(
+        snapshots_dao=_FakeScoreSnapshotsDAO(snapshots=snapshots),
+        miners_dao=_miners_by_hotkey(
+            ("hk-h", 8),
+            # hk-g intentionally absent → deregistered.
+            ("hk-x", 42),
+            ("hk-e", 5),
+        ),
+        config_dao=_split_config(after_block=300, count=3),
+    )
+
+    share = pytest.approx(1.0 / 3)
+    assert response == {
+        "block_number": 500,
+        "weights": {
+            "8": {"weight": share},
+            "42": {"weight": share},
+            "5": {"weight": share},
+        },
+    }
+
+
+@pytest.mark.asyncio
+async def test_weights_endpoint_splits_what_history_has_when_fewer_than_three():
+    # Only one distinct registered hotkey on record → it gets the full
+    # 1.0 so the validator still has something to set on chain.
+    snapshots = [
+        {
+            "block_number": 500,
+            "statistics": {"winner_uid": 8, "winner_hotkey": "hk-h"},
+        },
+    ]
+    response = await get_latest_weights(
+        snapshots_dao=_FakeScoreSnapshotsDAO(snapshots=snapshots),
+        miners_dao=_miners_by_hotkey(("hk-h", 8)),
+        config_dao=_split_config(after_block=300, count=3),
+    )
+
+    assert response == {
+        "block_number": 500,
+        "weights": {"8": {"weight": 1.0}},
+    }
+
+
+@pytest.mark.asyncio
+async def test_weights_endpoint_respects_custom_champion_count():
+    # Operator bumped weights_split_champion_count to 2 → split 1/2.
+    snapshots = [
+        {
+            "block_number": 500,
+            "statistics": {"winner_uid": 8, "winner_hotkey": "hk-h"},
+        },
+        {
+            "block_number": 400,
+            "statistics": {"winner_uid": 7, "winner_hotkey": "hk-g"},
+        },
+        {
+            "block_number": 300,
+            "statistics": {"winner_uid": 213, "winner_hotkey": "hk-x"},
+        },
+    ]
+    response = await get_latest_weights(
+        snapshots_dao=_FakeScoreSnapshotsDAO(snapshots=snapshots),
+        miners_dao=_miners_by_hotkey(("hk-h", 8), ("hk-g", 7), ("hk-x", 42)),
+        config_dao=_split_config(after_block=300, count=2),
+    )
+
+    share = pytest.approx(1.0 / 2)
+    assert response == {
+        "block_number": 500,
+        "weights": {
+            "8": {"weight": share},
+            "7": {"weight": share},
+        },
+    }
+
+
+@pytest.mark.asyncio
+async def test_weights_endpoint_404s_when_all_recent_hotkeys_deregistered():
+    # Split fires but every past champion hotkey is gone → we refuse to
+    # return weights (better than crediting random successor uids).
+    snapshots = [
+        {
+            "block_number": 500,
+            "statistics": {"winner_uid": 8, "winner_hotkey": "hk-h"},
+        },
+    ]
+    with pytest.raises(Exception) as excinfo:
+        await get_latest_weights(
+            snapshots_dao=_FakeScoreSnapshotsDAO(snapshots=snapshots),
+            miners_dao=_FakeMinersDAO({}),  # nobody is registered
+            config_dao=_split_config(after_block=300, count=3),
+        )
+    assert "404" in str(excinfo.value) or "registered" in str(excinfo.value).lower()
 
 
 @pytest.mark.asyncio

--- a/tests/test_api_contract.py
+++ b/tests/test_api_contract.py
@@ -859,12 +859,28 @@ async def test_weights_endpoint_accepts_legacy_miner_final_scores():
 
 def _miners_by_hotkey(*rows):
     """Build a _FakeMinersDAO seeded so ``get_miner_by_hotkey`` resolves
-    each ``(hotkey, uid)`` pair (None uid models a deregistered hotkey)."""
+    each row tuple.
+
+    Tuple shapes accepted (all default to ``is_valid='true'`` unless
+    overridden):
+      * ``(hotkey, uid)`` — registered, valid.
+      * ``(hotkey, None)`` — deregistered.
+      * ``(hotkey, uid, is_valid_bool)`` — explicit validity flag.
+    """
     seeded = {}
-    for hotkey, uid in rows:
+    for row in rows:
+        if len(row) == 2:
+            hotkey, uid = row
+            is_valid = True
+        else:
+            hotkey, uid, is_valid = row
         if uid is None:
             continue
-        seeded[("hotkey", hotkey)] = {"hotkey": hotkey, "uid": uid}
+        seeded[("hotkey", hotkey)] = {
+            "hotkey": hotkey,
+            "uid": uid,
+            "is_valid": "true" if is_valid else "false",
+        }
     return _FakeMinersDAO(seeded)
 
 
@@ -1079,6 +1095,100 @@ async def test_weights_endpoint_respects_custom_champion_count():
         "weights": {
             "8": {"weight": share},
             "7": {"weight": share},
+        },
+    }
+
+
+@pytest.mark.asyncio
+async def test_weights_endpoint_skips_currently_invalid_hotkey_and_backfills():
+    # hk-g is still registered but its miner row carries is_valid=false
+    # (e.g. flagged by anticopy or model_mismatch after its championship).
+    # The split must NOT pay it — keep walking history to backfill from
+    # an older champion that is currently registered AND valid.
+    snapshots = [
+        {
+            "block_number": 500,
+            "statistics": {"winner_uid": 8, "winner_hotkey": "hk-h"},
+        },
+        {
+            "block_number": 400,
+            "statistics": {"winner_uid": 7, "winner_hotkey": "hk-g"},
+        },
+        {
+            "block_number": 300,
+            "statistics": {"winner_uid": 213, "winner_hotkey": "hk-x"},
+        },
+        {
+            "block_number": 200,
+            "statistics": {"winner_uid": 5, "winner_hotkey": "hk-e"},
+        },
+    ]
+    response = await get_latest_weights(
+        snapshots_dao=_FakeScoreSnapshotsDAO(snapshots=snapshots),
+        miners_dao=_miners_by_hotkey(
+            ("hk-h", 8),
+            ("hk-g", 7, False),  # registered but currently invalid
+            ("hk-x", 42),
+            ("hk-e", 5),
+        ),
+        config_dao=_split_config(after_block=300, count=3),
+    )
+
+    share = pytest.approx(1.0 / 3)
+    assert response == {
+        "block_number": 500,
+        "weights": {
+            "8": {"weight": share},
+            "42": {"weight": share},
+            "5": {"weight": share},
+        },
+    }
+
+
+@pytest.mark.asyncio
+async def test_weights_endpoint_reads_legacy_champion_fields():
+    # Pre-Stage-U snapshots write ``champion_hotkey`` / ``champion_uid``
+    # instead of ``winner_*`` and use ``miner_final_scores`` instead of
+    # ``final_weights``. They must still count toward the N-champion
+    # split — otherwise the rolling window collapses to just the new
+    # scheduler's transitions and the split degenerates to N=1 until the
+    # new flow has written N transitions of its own.
+    snapshots = [
+        {
+            "block_number": 500,
+            "statistics": {
+                "winner_uid": 8, "winner_hotkey": "hk-h",
+                "final_weights": {"8": "1.0"},
+            },
+        },
+        {  # legacy row
+            "block_number": 400,
+            "statistics": {
+                "champion_uid": 7, "champion_hotkey": "hk-g",
+                "miner_final_scores": {"7": 1, "8": 0},
+            },
+        },
+        {  # legacy row (different champion)
+            "block_number": 300,
+            "statistics": {
+                "champion_uid": 213, "champion_hotkey": "hk-x",
+                "miner_final_scores": {"213": 1, "7": 0},
+            },
+        },
+    ]
+    response = await get_latest_weights(
+        snapshots_dao=_FakeScoreSnapshotsDAO(snapshots=snapshots),
+        miners_dao=_miners_by_hotkey(("hk-h", 8), ("hk-g", 7), ("hk-x", 42)),
+        config_dao=_split_config(after_block=300, count=3),
+    )
+
+    share = pytest.approx(1.0 / 3)
+    assert response == {
+        "block_number": 500,
+        "weights": {
+            "8": {"weight": share},
+            "7": {"weight": share},
+            "42": {"weight": share},
         },
     }
 


### PR DESCRIPTION
## Summary
- Switch `/scores/weights/latest` from winner-takes-all to a `1/N` split across the most recent N distinct champion **hotkeys** once a configured block threshold is reached.
- Threshold + N live in `system_config` (`weights_split_after_block`, `weights_split_champion_count`). Default = feature off; legacy behaviour preserved. No env vars, no redeploy to flip.
- Champion hotkeys are resolved to their **current** on-chain uid via `MinersDAO`. Deregistered hotkeys are skipped (so we don't credit their uid successor) and we walk further back in snapshot history to backfill the count.
- Bump `score_snapshots` TTL default 30d → 365d so the past-N-champions walk survives a long-tenured champion's win-streak (~50 rows/yr).

## Why anchor on `block_number`, not uid/hotkey?
- uids recycle on dereg — using a uid as the activation trigger is unsafe.
- hotkey-based activation depends on the activating snapshot staying in the TTL window.
- `block_number` is the snapshot PK, monotonic, immutable, validator-native.

## Why pay by hotkey, not by uid stored in the snapshot?
The snapshot records the uid the champion **held at the time of its win**. If that champion later deregisters, paying its old uid sends emission to whoever now sits on that uid. Resolving hotkey → current uid at request time fixes that.

## How to enable
Once you know the block where the split should activate:

```python
from affine.database.dao.system_config import SystemConfigDAO
await SystemConfigDAO().set_param(
    "weights_split_after_block", <block_number>, "int",
    description="Activate past-N-champions weight split when snapshot block >= this",
)
# Optional: customise N (default 3)
await SystemConfigDAO().set_param("weights_split_champion_count", 3, "int")
```

To disable:
```python
await SystemConfigDAO().delete_param("weights_split_after_block")
```

## Test plan
- [x] `tests/test_api_contract.py` — 25/25 pass, covering:
  - default (feature off) → legacy `final_weights` payload
  - `miner_final_scores` legacy field still accepted
  - threshold configured but latest block below it → legacy
  - activated → 1/3 split across last 3 distinct hotkeys
  - duplicate hotkey in history → dedup'd, next distinct hotkey backfills
  - deregistered hotkey → skipped, walk older snapshots to backfill
  - history has <N distinct champions → split what we have (1/N where N is actual)
  - custom champion count (e.g. 2) honoured
  - all recent champions deregistered → 404 (refuse to set bogus weights)
- [ ] After deploy, verify validator log shows weights for expected 3 uids before turning the threshold on for real.
- [ ] Verify `set_param("weights_split_after_block", X)` once we agree the activation block, and confirm `/scores/weights/latest` flips on the next snapshot at or above X.