### PR TITLE
rank: surface past-N champion split in af get-rank

### DIFF
--- a/affine/api/rank_state.py
+++ b/affine/api/rank_state.py
@@ -6,6 +6,7 @@ from typing import Any, Dict, List, Optional
 
 from affine.database.dao.miner_stats import MinerStatsDAO
 from affine.database.dao.miners import MinersDAO
+from affine.database.dao.score_snapshots import ScoreSnapshotsDAO
 from affine.database.dao.scores import ScoresDAO
 from affine.database.dao.system_config import SystemConfigDAO
 from affine.src.monitor.live_scores_monitor import LIVE_SCORES_KEY
@@ -138,6 +139,38 @@ def _live_sampling_uids(
     return out
 
 
+async def _past_champions_split() -> List[Dict[str, Any]]:
+    """Past-N champions currently sharing weight, for ``af get-rank``.
+
+    Returns an empty list when:
+
+      * the split feature is off (``system_config['weights_split_after_block']``
+        missing or ``0``), or
+      * no eligible past champion currently maps to a registered, valid
+        miner, or
+      * any DDB-level error occurs while resolving the split — rank
+        rendering is a read surface and should not fail just because
+        the split lookup transiently can't be served.
+
+    Shape per row: ``{"uid", "hotkey", "model", "revision", "share"}``.
+    ``share`` is the same value the validator sets on chain (``1/N``),
+    not the snapshot's stale ``overall_score``.
+    """
+    # Local import to avoid a circular ``routers.scores`` ↔ ``rank_state``
+    # cycle at module load (the scores router itself imports nothing from
+    # this module today, but keeping the import local insulates against
+    # future churn).
+    from affine.api.routers.scores import compute_split_payees
+
+    try:
+        payees = await compute_split_payees(
+            ScoreSnapshotsDAO(), MinersDAO(), SystemConfigDAO(),
+        )
+    except Exception:
+        return []
+    return payees or []
+
+
 async def get_current_state() -> Dict[str, Any]:
     """Build the live state section used by ``/rank/current``."""
     store = _state_store()
@@ -148,8 +181,16 @@ async def get_current_state() -> Dict[str, Any]:
     task_state = await store.get_task_state()
     envs = await store.get_environments()
     sample_counts, sample_averages = await _sample_counts_and_averages(task_state)
+    past_champions = await _past_champions_split()
     return {
         "champion": _miner_summary(champion) if champion else None,
+        # Past N champions currently sharing the on-chain weight. Empty
+        # list when the split feature is off; otherwise the most recent
+        # N distinct hotkeys, resolved to their current uid and each
+        # carrying ``share = 1/N``. ``af get-rank`` surfaces this in a
+        # dedicated table column / header line so operators can see who
+        # is being paid and at what proportion.
+        "past_champions": past_champions,
         "battle": {
             "challenger": _miner_summary(battle.challenger),
             "started_at_block": battle.started_at_block,

--- a/affine/api/routers/scores.py
+++ b/affine/api/routers/scores.py
@@ -514,15 +514,16 @@ def _winner_hotkey_from_snapshot(snapshot: Dict[str, Any]) -> Optional[str]:
     return None
 
 
-async def _resolve_current_uids_by_hotkey(
+async def _resolve_split_payees(
     snapshots: List[Dict[str, Any]],
     miners_dao: MinersDAO,
     *,
     needed: int,
-) -> List[int]:
+) -> List[Dict[str, Any]]:
     """Walk ``snapshots`` (newest-first), dedupe past champions by hotkey,
-    look up each hotkey's *current* uid in the miners table, and keep the
-    first ``needed`` whose miner is still registered AND currently valid.
+    look up each hotkey's *current* miner row in the miners table, and
+    keep the first ``needed`` whose miner is still registered AND
+    currently valid.
 
     Two filters are applied at resolution time:
 
@@ -538,8 +539,12 @@ async def _resolve_current_uids_by_hotkey(
     Either filter outcome causes us to walk further back in history to
     backfill the count, so churn at the top of the leaderboard doesn't
     shrink the split unnecessarily.
+
+    Returns rows ``{"uid", "hotkey", "model", "revision"}`` so callers
+    that need display metadata (e.g. ``af get-rank``) don't have to
+    re-query the miners table.
     """
-    out: List[int] = []
+    out: List[Dict[str, Any]] = []
     seen_hotkeys: set = set()
     for snap in snapshots:
         if len(out) >= needed:
@@ -559,8 +564,63 @@ async def _resolve_current_uids_by_hotkey(
             uid = int(miner.get("uid"))
         except (TypeError, ValueError):
             continue
-        out.append(uid)
+        out.append({
+            "uid": uid,
+            "hotkey": hotkey,
+            "model": miner.get("model") or "",
+            "revision": miner.get("revision") or "",
+        })
     return out
+
+
+async def compute_split_payees(
+    snapshots_dao: ScoreSnapshotsDAO,
+    miners_dao: MinersDAO,
+    config_dao: SystemConfigDAO,
+) -> Optional[List[Dict[str, Any]]]:
+    """Compute the active reward-split list, or ``None`` if the feature
+    is currently off.
+
+    Shared by ``/scores/weights/latest`` (chain weights) and
+    ``/rank/current`` (display) so both surfaces stay in lockstep.
+    Off → ``None``. On with no eligible payees → ``[]`` (caller decides
+    how to handle: weights endpoint 404s, rank surface just hides the
+    section). On with payees → list of
+    ``{"uid", "hotkey", "model", "revision", "share"}`` rows; ``share``
+    is ``1/len(payees)`` so the caller can render percentages directly.
+    """
+    activation_block = await _get_int_param(
+        config_dao, WEIGHTS_SPLIT_AFTER_BLOCK_PARAM, default=0,
+    )
+    if activation_block <= 0:
+        return None
+
+    snapshots = await snapshots_dao.get_recent_snapshots(
+        limit=_SPLIT_SNAPSHOT_SCAN_LIMIT,
+    )
+    if not snapshots:
+        return None
+    latest_block = snapshots[0].get("block_number")
+    if not (isinstance(latest_block, int) and latest_block >= activation_block):
+        return None
+
+    champion_count = max(
+        1,
+        await _get_int_param(
+            config_dao,
+            WEIGHTS_SPLIT_CHAMPION_COUNT_PARAM,
+            default=_DEFAULT_SPLIT_CHAMPION_COUNT,
+        ),
+    )
+    payees = await _resolve_split_payees(
+        snapshots, miners_dao, needed=champion_count,
+    )
+    if not payees:
+        return []
+    share = 1.0 / len(payees)
+    for p in payees:
+        p["share"] = share
+    return payees
 
 
 async def _get_int_param(
@@ -600,51 +660,34 @@ async def get_latest_weights(
     deregistered is skipped (we don't accidentally pay the successor on
     its recycled uid) and we keep walking history to backfill the count.
     """
-    activation_block = await _get_int_param(
-        config_dao, WEIGHTS_SPLIT_AFTER_BLOCK_PARAM, default=0,
-    )
-    champion_count = max(
-        1,
-        await _get_int_param(
-            config_dao,
-            WEIGHTS_SPLIT_CHAMPION_COUNT_PARAM,
-            default=_DEFAULT_SPLIT_CHAMPION_COUNT,
-        ),
-    )
+    payees = await compute_split_payees(snapshots_dao, miners_dao, config_dao)
 
-    snapshots = await snapshots_dao.get_recent_snapshots(
-        limit=_SPLIT_SNAPSHOT_SCAN_LIMIT,
-    )
-    if not snapshots:
-        raise HTTPException(
-            status_code=status.HTTP_404_NOT_FOUND,
-            detail="No score snapshots found",
-        )
-
-    latest = snapshots[0]
-    latest_block = latest.get("block_number")
-
-    activated = (
-        activation_block > 0
-        and isinstance(latest_block, int)
-        and latest_block >= activation_block
-    )
-
-    if activated:
-        champion_uids = await _resolve_current_uids_by_hotkey(
-            snapshots, miners_dao, needed=champion_count,
-        )
-        if not champion_uids:
+    if payees is not None:
+        # Feature on. Need at least one valid payee to set anything on
+        # chain; refuse rather than send a malformed weight vector.
+        if not payees:
             raise HTTPException(
                 status_code=status.HTTP_404_NOT_FOUND,
                 detail="No registered past-champion hotkeys in recent snapshots",
             )
-        share = 1.0 / len(champion_uids)
+        # Latest block lives on the freshest snapshot in the same scan
+        # the resolver walked — fetch one more time for the response
+        # envelope. (Cheap: GSI Limit=1.)
+        latest = await snapshots_dao.get_latest_snapshot()
         return {
-            "block_number": latest_block,
-            "weights": {str(uid): {"weight": share} for uid in champion_uids},
+            "block_number": (latest or {}).get("block_number"),
+            "weights": {
+                str(p["uid"]): {"weight": p["share"]} for p in payees
+            },
         }
 
+    # Feature off → legacy winner-takes-all pass-through.
+    latest = await snapshots_dao.get_latest_snapshot()
+    if not latest:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="No score snapshots found",
+        )
     statistics = latest.get("statistics", {}) or {}
     raw_weights = (
         statistics.get("final_weights")
@@ -666,6 +709,6 @@ async def get_latest_weights(
         weights_response[str(uid_str)] = {"weight": w}
 
     return {
-        "block_number": latest_block,
+        "block_number": latest.get("block_number"),
         "weights": weights_response,
     }

--- a/affine/src/miner/rank.py
+++ b/affine/src/miner/rank.py
@@ -125,10 +125,17 @@ def _status_for(
     champion_uid: Optional[int],
     battle_uid: Optional[int],
     queue_positions: Dict[int, int],
+    co_champion_shares: Optional[Dict[int, float]] = None,
 ) -> str:
     uid = row.get("uid")
     if uid == champion_uid:
         return "CHAMPION"
+    # Past champion still drawing a share of the on-chain weight. We
+    # render this above the BATTLING / VALID / TERMINATED branches so
+    # an active reward recipient is never hidden behind a queue marker.
+    if co_champion_shares and uid in co_champion_shares:
+        pct = int(round(co_champion_shares[uid] * 100))
+        return f"CO {pct:>2d}%"
     # Terminated lifecycle state lives in miner_stats, not the current
     # miners snapshot.
     chal_status = str(row.get("challenge_status") or "")
@@ -156,6 +163,8 @@ def _colored_status(status: str, *, is_invalid: bool) -> str:
     text = f"{status:>11}"
     if status == "CHAMPION":
         return _ansi(text, "1;93")
+    if status.startswith("CO "):  # past champion still drawing a share
+        return _ansi(text, "1;93")
     if status == "BATTLING":
         return _ansi(text, "1;96")
     if status.startswith("QUEUE #"):
@@ -181,26 +190,34 @@ def _sort_scores(
     champion_uid: Optional[int],
     battle_uid: Optional[int],  # noqa: ARG001 — kept for signature stability
     queue_positions: Dict[int, int],  # noqa: ARG001 — kept for signature stability
+    co_champion_uids: Optional[set] = None,
 ) -> List[Dict[str, Any]]:
-    """Champion at top, then active miners, then inactive miners.
+    """Champion at top, co-champions next, then active, then inactive.
 
-    Three buckets, each sorted by commit time (``first_block`` ASC):
+    Buckets (each sorted by commit time ``first_block`` ASC):
 
-      - **champion** (single row): pinned to the top
-      - **active**: ``is_valid=true`` AND ``challenge_status != 'terminated'`` —
-        the queue / battling / valid rows the user actually cares about
-      - **inactive**: terminated, invalid (model check failure, no commit,
-        blacklist, etc) — kept for visibility but pushed below the
-        active set
+      - **0 champion** (single row): the active title holder
+      - **1 co-champions**: past champions still drawing a share of the
+        on-chain weight via the reward-split feature — pinned high so
+        operators see at a glance who's being paid
+      - **2 active**: ``is_valid=true`` AND ``challenge_status != 'terminated'``
+      - **3 inactive**: terminated, invalid (model check failure, no
+        commit, blacklist, etc) — kept for visibility but pushed below
+        the active set
 
     Within each bucket: ``first_block`` ASC (earliest committer first),
     then uid as a final tiebreaker. Rows missing ``first_block`` sink
     to the end of their bucket so they don't displace real
     chronological entries.
     """
+    co_champion_uids = co_champion_uids or set()
+
     def key(row: Dict[str, Any]) -> tuple:
         uid = row.get("uid")
         is_champion = (uid == champion_uid) if champion_uid is not None else False
+        is_co_champion = (
+            (not is_champion) and uid in co_champion_uids
+        )
         chal_status = str(row.get("challenge_status") or "")
         is_terminated = (chal_status == "terminated")
         is_invalid = (row.get("is_valid") is False)
@@ -213,10 +230,12 @@ def _sort_scores(
 
         if is_champion:
             bucket = 0
-        elif is_terminated or is_invalid:
-            bucket = 2
-        else:
+        elif is_co_champion:
             bucket = 1
+        elif is_terminated or is_invalid:
+            bucket = 3
+        else:
+            bucket = 2
         return (
             bucket,
             (0, fb) if has_fb else (1, 0),
@@ -281,6 +300,23 @@ def _print_rank_table(
         for uid in ((window or {}).get("live_sampling_uids") or [])
         if isinstance(uid, int)
     }
+    # Past-N champions currently sharing the on-chain weight. Map uid →
+    # share (e.g. 0.20 for N=5) for fast lookup in row rendering and
+    # bucket sorting. The active champion is included in the API payload
+    # (it's one of the N) but we exclude it here so its row keeps the
+    # plain CHAMPION status / weight rather than the CO-share label.
+    co_champion_shares: Dict[int, float] = {}
+    for entry in (window or {}).get("past_champions") or []:
+        try:
+            uid = int(entry.get("uid"))
+            share = float(entry.get("share") or 0.0)
+        except (TypeError, ValueError):
+            continue
+        if champion_uid is not None and uid == champion_uid:
+            continue
+        if share <= 0:
+            continue
+        co_champion_shares[uid] = share
 
     header_parts = ["Hotkey  ", " UID", "⚡| Model                    "]
     header_parts.extend(f"{env[:24]:>24}" for env in envs)
@@ -308,6 +344,28 @@ def _print_rank_table(
         )
     else:
         print("Champion:   (none)")
+    # Reward-split: one summary line listing each past champion still
+    # drawing a share. We render even when the only payee is the active
+    # champion (so operators see the split is enabled) but format the
+    # split level so it's distinct from the plain Champion: line above.
+    past_champions = (window or {}).get("past_champions") or []
+    if past_champions:
+        total_share = sum(
+            _as_float(entry.get("share")) for entry in past_champions
+        )
+        share_pct = (
+            int(round((1.0 / len(past_champions)) * 100))
+            if past_champions else 0
+        )
+        parts = []
+        for entry in past_champions:
+            uid = entry.get("uid")
+            hk = _short(entry.get("hotkey"), 6)
+            parts.append(f"UID {uid} {hk}…")
+        print(
+            f"Reward:     {len(past_champions)}-way split ({share_pct}% each, "
+            f"total {total_share:.2f}) — {', '.join(parts)}"
+        )
     if battle:
         battle_hk = _short(battle.get("hotkey"), 8)
         started = ((window or {}).get("battle") or {}).get("started_at_block")
@@ -329,12 +387,14 @@ def _print_rank_table(
         champion_uid=champion_uid,
         battle_uid=battle_uid,
         queue_positions=queue_positions,
+        co_champion_uids=set(co_champion_shares.keys()),
     ):
         status = _status_for(
             row,
             champion_uid=champion_uid,
             battle_uid=battle_uid,
             queue_positions=queue_positions,
+            co_champion_shares=co_champion_shares,
         )
         row_parts = [
             f"{_short(row.get('miner_hotkey'), 8):8s}",
@@ -364,7 +424,31 @@ def _print_rank_table(
         )
         if show_reason:
             row_parts.append(f"{_reason_for(row, status):18s}")
-        row_parts.append(f"{_as_float(row.get('overall_score')):>7.4f}")
+        # ``overall_score`` is the snapshot's stale weight (1.0 for last
+        # write's single champion). Override with the live split share
+        # when this row is a current payee so the Weight column reflects
+        # what the validator actually sets on chain.
+        uid_int = row.get("uid")
+        weight_to_show = (
+            co_champion_shares[uid_int]
+            if isinstance(uid_int, int) and uid_int in co_champion_shares
+            else _as_float(row.get("overall_score"))
+        )
+        # Also override the active champion when a split is on (its
+        # share is 1/N, not 1.0). past_champions includes the active
+        # champion; look it up there.
+        if (
+            uid_int == champion_uid
+            and (window or {}).get("past_champions")
+        ):
+            for entry in (window or {}).get("past_champions") or []:
+                try:
+                    if int(entry.get("uid")) == champion_uid:
+                        weight_to_show = _as_float(entry.get("share"))
+                        break
+                except (TypeError, ValueError):
+                    continue
+        row_parts.append(f"{weight_to_show:>7.4f}")
         print(" | ".join(row_parts))
 
     print(_ansi("=" * width, "2"))

--- a/tests/test_miner_rank.py
+++ b/tests/test_miner_rank.py
@@ -246,6 +246,95 @@ def test_rank_table_sorts_champion_active_inactive_buckets_by_commit_time():
     assert "lost_to_champion:" not in out
 
 
+def test_rank_table_renders_past_champions_split():
+    """When the reward-split feature is on, ``af get-rank`` should:
+
+    * print a ``Reward:`` summary line listing each past-N champion +
+      their share %.
+    * mark each *non-active* past champion with status ``CO {pct}%``.
+    * show the share (1/N) in the Weight column instead of the
+      snapshot's stale 0.0 for past-champion rows AND for the active
+      champion row (its on-chain weight is also 1/N now, not 1.0).
+    * pin co-champions in bucket 2 (right after the active champion),
+      above the rest of the valid set.
+    """
+    window = {
+        "champion": {"uid": 9, "hotkey": "hkChamp", "model": "org/champ"},
+        "past_champions": [
+            # Active champion is always one of the N — included so the
+            # frontend can display the full split in one place.
+            {"uid": 9, "hotkey": "hkChamp",
+             "model": "org/champ", "share": 0.5},
+            {"uid": 3, "hotkey": "hkPast",
+             "model": "org/past", "share": 0.5},
+        ],
+    }
+    scores = {
+        "block_number": 100,
+        "calculated_at": 0,
+        "scores": [
+            {
+                "uid": 9, "miner_hotkey": "hkChamp", "model": "org/champ",
+                "overall_score": 1.0, "is_valid": True,
+                "first_block": 500, "scores_by_env": {},
+            },
+            # Past champion. Its scores-table overall_score is 0.0
+            # (snapshot was winner-takes-all) — we expect the Weight
+            # column to surface the live 0.5 share instead.
+            {
+                "uid": 3, "miner_hotkey": "hkPast", "model": "org/past",
+                "overall_score": 0.0, "is_valid": True,
+                "first_block": 300, "scores_by_env": {},
+            },
+            # Plain valid miner — should sort below the co-champion.
+            {
+                "uid": 7, "miner_hotkey": "hkValid", "model": "org/v",
+                "overall_score": 0.0, "is_valid": True,
+                "first_block": 100, "scores_by_env": {},
+            },
+        ],
+    }
+
+    out = _render_rank(window, None, scores)
+
+    # Summary header line.
+    assert "Reward:" in out
+    assert "2-way split (50% each" in out
+
+    # The hotkeys also appear in the "Champion:" / "Reward:" header
+    # block above the table. Pick the *table* row for each hotkey by
+    # scanning lines and taking the first one that starts with the
+    # hotkey (header lines start with "Champion:" / "Reward:" /
+    # column-padding spaces, so the row line is the first match).
+    def _row(out_text: str, hotkey: str) -> str:
+        for line in out_text.splitlines():
+            if line.startswith(hotkey + " "):
+                return line
+        raise AssertionError(f"row for {hotkey!r} not found in:\n{out_text}")
+
+    champ_row = _row(out, "hkChamp")
+    past_row = _row(out, "hkPast")
+    valid_row = _row(out, "hkValid")
+
+    # Champion's Weight column shows 0.5 (= split share), not the stale
+    # snapshot's 1.0.
+    assert "CHAMPION" in champ_row
+    assert "0.5000" in champ_row
+    # Past champion's status reads "CO 50%" and Weight is 0.5 (not 0).
+    assert "CO 50%" in past_row
+    assert "0.5000" in past_row
+    # Plain valid row keeps its 0.0 overall_score.
+    assert "0.0000" in valid_row
+
+    # Sort order in the table: champion → co-champion → plain valid
+    # (even though plain valid has the earlier first_block).
+    lines = out.splitlines()
+    champ_line_no = next(i for i, l in enumerate(lines) if l.startswith("hkChamp "))
+    past_line_no = next(i for i, l in enumerate(lines) if l.startswith("hkPast "))
+    valid_line_no = next(i for i, l in enumerate(lines) if l.startswith("hkValid "))
+    assert champ_line_no < past_line_no < valid_line_no
+
+
 def test_rank_table_can_show_reason_column_when_requested():
     scores = {
         "block_number": 100,

--- a/tests/test_rank_state.py
+++ b/tests/test_rank_state.py
@@ -50,6 +50,9 @@ async def test_current_state_on_empty_state(monkeypatch):
         "sample_counts": {},
         "sample_averages": {},
         "live_sampling_uids": [],
+        # Reward-split feature is off by default → field is always
+        # present but empty.
+        "past_champions": [],
     }
 
 


### PR DESCRIPTION
## Summary
Once #473 is turned on (``system_config['weights_split_after_block']`` is set), the validator pays N hotkeys at ``1/N`` each — but ``af get-rank`` still only highlighted the single active champion. Operators couldn't see the other payees without ``curl``'ing the weights endpoint. This PR surfaces the split directly in the rank table.

## Changes

**Server-side ([affine/api/routers/scores.py](affine-cortex/affine/api/routers/scores.py))**
- Factor the past-N-champion resolver out of ``/scores/weights/latest`` into a reusable ``compute_split_payees()`` helper that returns ``[{uid, hotkey, model, revision, share}, …]`` or ``None`` when the feature is off.
- Both ``/scores/weights/latest`` and ``/rank/current`` now share the same activation gating and miner-validity filtering — no risk of the two surfaces drifting.

**Server-side ([affine/api/rank_state.py](affine-cortex/affine/api/rank_state.py))**
- ``/rank/current`` grows a ``past_champions`` field (always present, empty when split is off).
- Fails soft to ``[]`` on any DDB error so a transient hiccup never breaks rank rendering.

**CLI-side ([affine/src/miner/rank.py](affine-cortex/affine/src/miner/rank.py))**
- New header line ``Reward: N-way split (X% each, total Y) — UID a hk…, UID b hk…``.
- New per-row status ``CO {pct}%`` for past champions still drawing a share. Pinned in a bucket immediately below the active champion so they're never hidden behind queue/valid rows.
- Weight column for both the active champion and co-champion rows now shows the live ``1/N`` share rather than the snapshot's stale ``1.0`` / ``0.0``.

## Live preview (prod data, split forced on)

```
Champion:   UID 228  5CqkEFMX...  prexpert/affine-138-...
Reward:     2-way split (50% each, total 1.00) — UID 228 5CqkEF…, UID 213 5Gepm8…
...
Hotkey   |  UID | …| Model                |   Status   | Weight 
5CqkEFMX |  228 |  | prexpert/affine-138- |   CHAMPION |  0.5000
5Gepm8sy |  213 |  | leary-denis/affine-… |     CO 50% |  0.5000
…
```

## Data flow note
``af get-rank`` only talks HTTP to ``/rank/current`` — never DDB directly. The server-side ``rank_state.get_current_state()`` does the DDB work and embeds the past-N list in the JSON response.

## Test plan
- [x] ``tests/test_api_contract.py``: 27 tests (existing + 1 new) — all green.
- [x] ``tests/test_miner_rank.py``: 19 tests (existing + 1 new) — covers Reward summary line, ``CO 50%`` status, Weight override, bucket sort.
- [x] ``tests/test_rank_state.py``: 6 tests — empty-state expectation updated for the new field.
- [x] Probed against prod DynamoDB with split forced on (threshold=1, N=5) — rendered table matches the preview above.