### PR TITLE
ceac: strip tqdm progress from remote snapshot_download stdout parse

### DIFF
--- a/affine/src/anticopy/worker.py
+++ b/affine/src/anticopy/worker.py
@@ -151,12 +151,23 @@ class _SglangError(RuntimeError):
     pass
 
 
-def _ssh_run(host: str, key_path: str, cmd: str, *, timeout: int = 600) -> tuple:
+def _ssh_run(
+    host: str, key_path: str, cmd: str,
+    *,
+    timeout: int = 600,
+    env: Optional[Dict[str, str]] = None,
+) -> tuple:
     """Run ``cmd`` over SSH; returns ``(rc, stdout, stderr)``.
 
     Used only when ``REMOTE_SSH_HOST`` is configured. The wrapper
     keeps stderr separate so we don't conflate sglang/HF banner output
     with the python helper's stdout, which we parse.
+
+    ``env`` (optional) is prefixed onto the remote command as
+    ``KEY=VAL python …`` — needed because SSH doesn't forward env
+    vars without server-side ``AcceptEnv`` (Targon's sshd doesn't
+    accept HF_TOKEN). Values are shell-quoted; an empty/missing
+    value is skipped so we don't poison the remote env with ``=``.
     """
     argv = [
         "ssh", "-i", key_path,
@@ -166,6 +177,13 @@ def _ssh_run(host: str, key_path: str, cmd: str, *, timeout: int = 600) -> tuple
     ]
     if REMOTE_SSH_PORT:
         argv += ["-p", REMOTE_SSH_PORT]
+    if env:
+        prefix = " ".join(
+            f"{k}={shlex.quote(str(v))}"
+            for k, v in env.items() if v
+        )
+        if prefix:
+            cmd = f"{prefix} {cmd}"
     argv += [host, cmd]
     proc = subprocess.run(
         argv,
@@ -1032,8 +1050,15 @@ def _remote_snapshot_download(
         "        ok = False; break\n"
         "print(p if ok else 'MISS')"
     )
+    # HF_TOKEN has to be smuggled across the SSH boundary explicitly
+    # — sshd on Targon doesn't AcceptEnv HF_TOKEN, so without this
+    # prefix the python helper sees os.getenv('HF_TOKEN') == None and
+    # falls back to anonymous downloads, which HuggingFace rate-limits
+    # severely (we've seen multi-hour stalls at 2.6 GB/model).
+    hf_env = {"HF_TOKEN": os.environ.get("HF_TOKEN", "")}
+
     cmd = f"{shlex.quote(py_path)} -c {shlex.quote(probe)}"
-    rc, out, err = _ssh_run(host, key_path, cmd, timeout=60)
+    rc, out, err = _ssh_run(host, key_path, cmd, timeout=60, env=hf_env)
     if rc == 0:
         line = (out.strip().splitlines() or [""])[-1].strip()
         if line and line != "MISS":
@@ -1049,7 +1074,7 @@ def _remote_snapshot_download(
         "print(p)"
     )
     cmd = f"{shlex.quote(py_path)} -c {shlex.quote(body)}"
-    rc, out, err = _ssh_run(host, key_path, cmd, timeout=3600)
+    rc, out, err = _ssh_run(host, key_path, cmd, timeout=3600, env=hf_env)
     if rc != 0:
         raise RuntimeError(
             f"remote snapshot_download rc={rc}: {err[-200:].strip()}"

--- a/affine/src/anticopy/worker.py
+++ b/affine/src/anticopy/worker.py
@@ -1055,7 +1055,15 @@ def _remote_snapshot_download(
     # prefix the python helper sees os.getenv('HF_TOKEN') == None and
     # falls back to anonymous downloads, which HuggingFace rate-limits
     # severely (we've seen multi-hour stalls at 2.6 GB/model).
-    hf_env = {"HF_TOKEN": os.environ.get("HF_TOKEN", "")}
+    # HF_HUB_DISABLE_PROGRESS_BARS suppresses tqdm; otherwise the
+    # progress bar's final line (``Fetching N files: 100%|…``) lands
+    # on stdout as the trailing line and gets parsed as if it were
+    # the snapshot path below — sglang's /update_weights_from_disk
+    # then polls forever for the bogus path.
+    hf_env = {
+        "HF_TOKEN": os.environ.get("HF_TOKEN", ""),
+        "HF_HUB_DISABLE_PROGRESS_BARS": "1",
+    }
 
     cmd = f"{shlex.quote(py_path)} -c {shlex.quote(probe)}"
     rc, out, err = _ssh_run(host, key_path, cmd, timeout=60, env=hf_env)
@@ -1079,10 +1087,19 @@ def _remote_snapshot_download(
         raise RuntimeError(
             f"remote snapshot_download rc={rc}: {err[-200:].strip()}"
         )
-    lines = [ln for ln in out.strip().splitlines() if ln.strip()]
+    # Belt-and-suspenders: even with HF_HUB_DISABLE_PROGRESS_BARS=1
+    # we filter to lines that look like absolute paths, so a stray
+    # banner or warning never wins out as "the snapshot directory".
+    # This is the value handed to sglang's /update_weights_from_disk
+    # — a bad string here silently burns the 30-min polling timeout.
+    lines = [
+        ln.strip() for ln in out.splitlines()
+        if ln.strip().startswith("/")
+    ]
     if not lines:
         raise RuntimeError(
-            f"remote snapshot_download produced no path; stderr={err[-200:].strip()}"
+            f"remote snapshot_download produced no path; "
+            f"stdout={out[-200:].strip()!r} stderr={err[-200:].strip()!r}"
         )
     return lines[-1]
 


### PR DESCRIPTION
## Summary
When ``huggingface_hub`` leaks its tqdm progress bar to stdout, the worker's per-job ``_remote_snapshot_download`` parses the final stdout line as the snapshot path. With the bar enabled that line is e.g. ``Fetching 25 files: 100%|██████████| 25/25 [03:08<00:00,  7.53s/it]``, and sglang's ``/update_weights_from_disk`` then polls for that bogus ``model_path`` until the 30 min watchdog burns the job. Caught in prod once the HF_TOKEN smuggle (#489) made the actual download fast enough to expose this race.

Two-layer fix:
1. ``HF_HUB_DISABLE_PROGRESS_BARS=1`` in the env smuggled to the remote (alongside HF_TOKEN) — suppresses tqdm at the source.
2. Filter stdout to lines starting with ``/`` before picking the trailing one — defends against any future stderr-vs-stdout reshuffle from ``huggingface_hub``.

## Test plan
- [x] Anticopy unit tests pass locally (63 passed)
- [ ] After deploy, watch a worker job complete past ``update_weights`` (the path that hung in prod)