### PR TITLE
ceac: wrap anti-copy ssh tunnel in autossh for auto-reconnect

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ FROM rust:1.88-slim-bookworm AS base
 RUN apt-get update \
  && apt-get install -y --no-install-recommends \
     python3 python3-venv python3-pip python3-dev \
-    build-essential curl pkg-config libssl-dev protobuf-compiler libprotobuf-dev docker.io git openssh-client \
+    build-essential curl pkg-config libssl-dev protobuf-compiler libprotobuf-dev docker.io git openssh-client autossh \
  && rm -rf /var/lib/apt/lists/*
 
 # 2) Install the 'uv' CLI

--- a/affine/src/anticopy/main.py
+++ b/affine/src/anticopy/main.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import asyncio
 import os
 import shlex
+import shutil
 import signal
 import subprocess
 import time
@@ -120,23 +121,46 @@ def _maybe_start_ssh_tunnel() -> "subprocess.Popen | None":
     remote_port = int(os.getenv("ANTICOPY_REMOTE_SGLANG_PORT", "30000"))
 
     ssh_port = os.getenv("ANTICOPY_REMOTE_SSH_PORT", "")
-    cmd = [
-        "ssh", "-N", "-T",
+    # Use autossh so the tunnel reconnects when sglang stalls past
+    # ServerAlive grace and the ssh client tears down. Bare ssh leaves
+    # the worker hung on a dead localhost port until the container is
+    # restarted (observed: ~8.5h gap during a weight reload stall).
+    # ``-M 0`` disables autossh's own monitor port; we rely entirely on
+    # ssh keepalive (ServerAliveInterval × ServerAliveCountMax).
+    ssh_args = [
+        "-N", "-T",
         "-i", key_path,
         "-o", "StrictHostKeyChecking=no",
         "-o", "ConnectTimeout=30",
         "-o", "ServerAliveInterval=30",
+        "-o", "ServerAliveCountMax=3",
         "-o", "ExitOnForwardFailure=yes",
         "-L", f"{local_port}:127.0.0.1:{remote_port}",
     ]
     if ssh_port:
-        cmd += ["-p", ssh_port]
-    cmd.append(host)
+        ssh_args += ["-p", ssh_port]
+    ssh_args.append(host)
+
+    autossh_bin = shutil.which("autossh")
+    env = os.environ.copy()
+    if autossh_bin:
+        cmd = [autossh_bin, "-M", "0"] + ssh_args
+        # AUTOSSH_GATETIME=0 disables the 30s "first connect must
+        # succeed" gate so reconnect kicks in immediately after a
+        # mid-session drop too.
+        env["AUTOSSH_GATETIME"] = "0"
+        wrapper = "autossh"
+    else:
+        cmd = ["ssh"] + ssh_args
+        wrapper = "ssh (autossh not installed — tunnel will NOT auto-reconnect)"
+
     logger.info(
-        f"[anticopy.worker] starting ssh tunnel "
+        f"[anticopy.worker] starting {wrapper} tunnel "
         f"localhost:{local_port} → {host}:{remote_port}"
     )
-    proc = subprocess.Popen(cmd, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+    proc = subprocess.Popen(
+        cmd, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL, env=env,
+    )
     # Block until the port answers (or the tunnel dies).
     deadline = time.time() + 30
     while time.time() < deadline:


### PR DESCRIPTION
## Summary

The anti-copy worker's SSH tunnel to the GPU host (`localhost:33000 →
wrk-…@targon:30000`) is a bare `ssh` subprocess with no reconnect
logic. When sglang stalls past the SSH keepalive grace window
(`ServerAliveInterval=30 × ServerAliveCountMax=3 = 90s`) during a
weight reload, the ssh client tears the connection down and the
worker is left hung on a dead localhost port.

Observed on 2026-05-18: the tunnel died at 17:30 mid `update_weights`
and the worker spent 8.5h re-trying HTTP against the dead port,
falsely attributing the failure to whatever model happened to be in
its job claim. Recovery only came when watchtower restarted the
container at 01:42.

## Fix

- Wrap the tunnel in `autossh -M 0` (relying on ssh keepalive for
  liveness, no monitor port) with `AUTOSSH_GATETIME=0` so a
  mid-session drop reconnects immediately instead of waiting out the
  30s first-connect gate.
- Add the `autossh` package to the Dockerfile.
- Fall back to bare ssh with a loud warning if `autossh` is missing,
  so non-Docker dev setups still work.
- Make `ServerAliveCountMax=3` explicit (it was the implicit default).

## Test plan

- [ ] Build the image and confirm `autossh` is on `$PATH` inside
  `affine-anticopy-worker`.
- [ ] Deploy on the validator; verify the start-up log shows
  `starting autossh tunnel …` (not `starting ssh tunnel …`).
- [ ] Force a tunnel break (`ssh -O exit` against the inner ssh, or
  briefly drop the GPU host's port 22) and confirm a new ssh child
  appears within ~10s with the same `-L 33000:…` forward.
- [ ] Run a normal `update_weights_from_disk` cycle (5+ min) and
  confirm the tunnel survives.