### PR TITLE
ceac: exit worker if ssh tunnel fails to come up at startup

### DIFF
--- a/affine/src/anticopy/main.py
+++ b/affine/src/anticopy/main.py
@@ -13,6 +13,7 @@ import shlex
 import shutil
 import signal
 import subprocess
+import sys
 import time
 from urllib.parse import urlparse
 
@@ -193,10 +194,17 @@ def worker_main(verbose: int):
     try:
         tunnel = _maybe_start_ssh_tunnel()
     except Exception as e:
-        logger.error(f"[anticopy.worker] ssh tunnel failed: {e}")
-        # don't crash — worker may be co-located with sglang
-        # (no tunnel needed) and will still operate; otherwise the
-        # /model_info poll will surface the connection failure.
+        # Configured for remote SSH but the tunnel never came up
+        # (typically a transient targon outage at startup). Exit so
+        # the container's restart policy retries — keeping the
+        # worker alive without a tunnel produces a half-zombie that
+        # fails every job against a phantom localhost port and
+        # never reconnects on its own.
+        logger.error(
+            f"[anticopy.worker] ssh tunnel failed: {e} — exiting to "
+            f"trigger container restart"
+        )
+        sys.exit(1)
 
     def _factory():
         return ForwardWorker()


### PR DESCRIPTION
Continuing without a tunnel produces a half-zombie worker that fails every job against a dead localhost port with no reconnect path. Exit on tunnel failure so the container restart policy retries once targon SSH is back.

Observed 2026-05-21 14:57: watchtower auto-recreated the worker during a transient targon SSH blip, tunnel startup hit the 30s timeout, worker continued tunnel-less, every candidate looked like a permanent sglang launch failure. ~30 min of zombie worker time before a manual restart fixed it.